### PR TITLE
Add block event annotations to trend chart

### DIFF
--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -13,7 +13,8 @@ const BITCOIN_THEME = {
     CHART: {
         GRADIENT_START: '#f2a900',
         GRADIENT_END: 'rgba(242, 169, 0, 0.2)',
-        ANNOTATION: '#ffd700'
+        ANNOTATION: '#ffd700',
+        BLOCK_EVENT: '#00ffff'
     }
 };
 
@@ -29,7 +30,8 @@ const DEEPSEA_THEME = {
     CHART: {
         GRADIENT_START: '#0088cc',
         GRADIENT_END: 'rgba(0, 136, 204, 0.2)',
-        ANNOTATION: '#00b3ff'
+        ANNOTATION: '#00b3ff',
+        BLOCK_EVENT: '#ff00ff'
     }
 };
 


### PR DESCRIPTION
## Summary
- track block events in `blockAnnotations`
- render vertical annotations for blocks using theme color
- add `BLOCK_EVENT` color to both themes
- reload stored block events on page load
- update annotations when theme changes

## Testing
- `python -m py_compile *.py`