### PR TITLE
Add Bitcoin theme helper and dynamic switching

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4026,95 +4026,85 @@ $(document).ready(function () {
         }
     }
 
+    // Handle theme changes for chart and UI elements
+    function handleThemeChange(useDeepSea) {
+        if (useDeepSea) {
+            if (typeof applyDeepSeaTheme === 'function') {
+                applyDeepSeaTheme();
+            }
+        } else if (typeof applyBitcoinTheme === 'function') {
+            applyBitcoinTheme();
+        }
+
+        if (trendChart) {
+            // Save all font configurations
+            const fontConfig = {
+                xTicks: { ...trendChart.options.scales.x.ticks.font },
+                yTicks: { ...trendChart.options.scales.y.ticks.font },
+                yTitle: { ...trendChart.options.scales.y.title.font },
+                tooltip: {
+                    title: { ...trendChart.options.plugins.tooltip.titleFont },
+                    body: { ...trendChart.options.plugins.tooltip.bodyFont }
+                }
+            };
+
+            const isMobile = window.innerWidth < 768;
+
+            const xTicksFontSize = fontConfig.xTicks.size || 14;
+            const yTicksFontSize = fontConfig.yTicks.size || 14;
+            const yTitleFontSize = fontConfig.yTitle.size || 16;
+
+            trendChart.destroy();
+            trendChart = initializeChart();
+
+            if (isMobile) {
+                trendChart.options.scales.x.ticks.font = {
+                    ...fontConfig.xTicks,
+                    size: xTicksFontSize
+                };
+                trendChart.options.scales.y.ticks.font = {
+                    ...fontConfig.yTicks,
+                    size: yTicksFontSize
+                };
+                trendChart.options.scales.y.title.font = {
+                    ...fontConfig.yTitle,
+                    size: yTitleFontSize
+                };
+                trendChart.options.plugins.tooltip.titleFont = {
+                    ...fontConfig.tooltip.title,
+                    size: fontConfig.tooltip.title.size || 16
+                };
+                trendChart.options.plugins.tooltip.bodyFont = {
+                    ...fontConfig.tooltip.body,
+                    size: fontConfig.tooltip.body.size || 14
+                };
+            } else {
+                trendChart.options.scales.x.ticks.font = fontConfig.xTicks;
+                trendChart.options.scales.y.ticks.font = fontConfig.yTicks;
+                trendChart.options.scales.y.title.font = fontConfig.yTitle;
+                trendChart.options.plugins.tooltip.titleFont = fontConfig.tooltip.title;
+                trendChart.options.plugins.tooltip.bodyFont = fontConfig.tooltip.body;
+            }
+
+            updateChartWithNormalizedData(trendChart, latestMetrics);
+            updateBlockAnnotations(trendChart);
+            trendChart.update('none');
+        }
+
+        updateRefreshButtonColor();
+        $(document).trigger('themeChanged');
+    }
+
     // Add this function to the document ready section
     function setupThemeChangeListener() {
         window.addEventListener('storage', function (event) {
             if (event.key === 'useDeepSeaTheme') {
-                if (trendChart) {
-                    // Save all font configurations
-                    const fontConfig = {
-                        xTicks: { ...trendChart.options.scales.x.ticks.font },
-                        yTicks: { ...trendChart.options.scales.y.ticks.font },
-                        yTitle: { ...trendChart.options.scales.y.title.font },
-                        tooltip: {
-                            title: { ...trendChart.options.plugins.tooltip.titleFont },
-                            body: { ...trendChart.options.plugins.tooltip.bodyFont }
-                        }
-                    };
-
-                    // No need to create a copy of lowHashrateState here, 
-                    // as we'll load it from localStorage after chart recreation
-
-                    // Save the low hashrate indicator element if it exists
-                    const wasInLowHashrateMode = trendChart.lowHashrateState &&
-                        trendChart.lowHashrateState.isLowHashrateMode;
-
-                    // Check if we're on mobile (viewport width < 768px)
-                    const isMobile = window.innerWidth < 768;
-
-                    // Store the original sizes before destroying chart
-                    const xTicksFontSize = fontConfig.xTicks.size || 14;
-                    const yTicksFontSize = fontConfig.yTicks.size || 14;
-                    const yTitleFontSize = fontConfig.yTitle.size || 16;
-
-                    // Recreate the chart with new theme colors
-                    trendChart.destroy();
-                    trendChart = initializeChart();
-
-                    // The state will be automatically loaded from localStorage in updateChartWithNormalizedData
-
-                    // Ensure font sizes are explicitly set to original values
-                    // This is especially important for mobile
-                    if (isMobile) {
-                        // On mobile, set explicit font sizes (based on the originals)
-                        trendChart.options.scales.x.ticks.font = {
-                            ...fontConfig.xTicks,
-                            size: xTicksFontSize
-                        };
-
-                        trendChart.options.scales.y.ticks.font = {
-                            ...fontConfig.yTicks,
-                            size: yTicksFontSize
-                        };
-
-                        trendChart.options.scales.y.title.font = {
-                            ...fontConfig.yTitle,
-                            size: yTitleFontSize
-                        };
-
-                        // Also set tooltip font sizes explicitly
-                        trendChart.options.plugins.tooltip.titleFont = {
-                            ...fontConfig.tooltip.title,
-                            size: fontConfig.tooltip.title.size || 16
-                        };
-
-                        trendChart.options.plugins.tooltip.bodyFont = {
-                            ...fontConfig.tooltip.body,
-                            size: fontConfig.tooltip.body.size || 14
-                        };
-
-                        console.log('Mobile device detected: Setting explicit font sizes for chart labels');
-                    } else {
-                        // On desktop, use the full font config objects as before
-                        trendChart.options.scales.x.ticks.font = fontConfig.xTicks;
-                        trendChart.options.scales.y.ticks.font = fontConfig.yTicks;
-                        trendChart.options.scales.y.title.font = fontConfig.yTitle;
-                        trendChart.options.plugins.tooltip.titleFont = fontConfig.tooltip.title;
-                        trendChart.options.plugins.tooltip.bodyFont = fontConfig.tooltip.body;
-                    }
-
-                    // Update with data and force an immediate chart update
-                    updateChartWithNormalizedData(trendChart, latestMetrics);
-                    updateBlockAnnotations(trendChart);
-                    trendChart.update('none');
-                }
-
-                // Update refresh button color
-                updateRefreshButtonColor();
-
-                // Trigger custom event
-                $(document).trigger('themeChanged');
+                handleThemeChange(event.newValue === 'true');
             }
+        });
+
+        window.addEventListener('themePreferenceChanged', function (e) {
+            handleThemeChange(e.detail);
         });
     }
 

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -118,6 +118,9 @@ function applyDeepSeaTheme() {
 
         // Update the data-text attribute for DeepSea theme
         updateDashboardDataText(true);
+        // Switch HTML class
+        document.documentElement.classList.add('deepsea-theme');
+        document.documentElement.classList.remove('bitcoin-theme');
 
         // Create or update CSS variables for the DeepSea theme
         const styleElement = document.createElement('style');
@@ -392,22 +395,69 @@ function applyDeepSeaTheme() {
             themeToggle.style.color = '#0088cc';
         }
 
-        console.log("DeepSea theme applied with color adjustments");
+console.log("DeepSea theme applied with color adjustments");
     } finally {
         // Reset the guard flag when done, even if there's an error
         setTimeout(() => { isApplyingTheme = false; }, 100);
     }
 }
 
+// Revert to Bitcoin theme defaults
+function applyBitcoinTheme() {
+    if (window.themeProcessing) {
+        console.log("Theme application already in progress, avoiding recursion");
+        return;
+    }
+
+    isApplyingTheme = true;
+
+    try {
+        console.log("Applying Bitcoin theme...");
+
+        updateDashboardDataText(false);
+        document.documentElement.classList.add('bitcoin-theme');
+        document.documentElement.classList.remove('deepsea-theme');
+
+        const existingStyle = document.getElementById('deepSeaThemeStyles');
+        if (existingStyle) {
+            existingStyle.parentNode.removeChild(existingStyle);
+        }
+
+        document.documentElement.style.setProperty('--primary-color', '#f2a900');
+        document.documentElement.style.setProperty('--primary-color-rgb', '242, 169, 0');
+        document.documentElement.style.setProperty('--accent-color', '#ffd700');
+        document.documentElement.style.setProperty('--bg-gradient', 'linear-gradient(135deg, #0a0a0a, #1a1a1a)');
+
+        document.title = document.title.replace('DeepSea', 'BTC-OS');
+
+        const headerElement = document.querySelector('h1');
+        if (headerElement) {
+            headerElement.innerHTML = headerElement.innerHTML.replace('DeepSea', 'BTC-OS');
+            headerElement.innerHTML = headerElement.innerHTML.replace('DEEPSEA', 'BTC-OS');
+        }
+
+        updateChartControlsLabel(false);
+
+        const themeToggle = document.getElementById('themeToggle');
+        if (themeToggle) {
+            themeToggle.style.borderColor = '#f2a900';
+            themeToggle.style.color = '#f2a900';
+        }
+
+        console.log("Bitcoin theme applied with color adjustments");
+    } finally {
+        setTimeout(() => { isApplyingTheme = false; }, 100);
+    }
+}
+
 // Make the function accessible globally
 window.applyDeepSeaTheme = applyDeepSeaTheme;
+window.applyBitcoinTheme = applyBitcoinTheme;
 
 // Toggle theme with hard page refresh
+
 function toggleTheme() {
     const useDeepSea = localStorage.getItem('useDeepSeaTheme') !== 'true';
-
-    // Update the data-text attribute based on the new theme
-    updateDashboardDataText(useDeepSea);
 
     // Save the new theme preference
     saveThemePreference(useDeepSea);
@@ -444,10 +494,18 @@ function toggleTheme() {
 
     document.body.appendChild(loadingMessage);
 
-    // Short delay before refreshing
+    if (useDeepSea) {
+        applyDeepSeaTheme();
+    } else {
+        applyBitcoinTheme();
+    }
+
+    window.dispatchEvent(new CustomEvent('themePreferenceChanged', { detail: useDeepSea }));
+
     setTimeout(() => {
-        // Hard reload the page
-        window.location.reload();
+        if (loadingMessage.parentNode) {
+            loadingMessage.parentNode.removeChild(loadingMessage);
+        }
     }, 500);
 }
 
@@ -503,13 +561,7 @@ function loadThemePreference() {
             applyDeepSeaTheme();
             updateChartControlsLabel(true);
         } else {
-            // Make sure the toggle button is styled correctly for Bitcoin theme
-            const themeToggle = document.getElementById('themeToggle');
-            if (themeToggle) {
-                themeToggle.style.borderColor = '#f2a900';
-                themeToggle.style.color = '#f2a900';
-                updateChartControlsLabel(false);
-            }
+            applyBitcoinTheme();
         }
     } catch (e) {
         console.error("Error loading theme preference:", e);


### PR DESCRIPTION
## Summary
- add `applyBitcoinTheme` to revert DeepSea customizations
- update theme loading and toggling to use the new function
- centralize chart theme updates in `handleThemeChange`
- trigger theme updates without page reloads

## Testing
- `node -e "require('./static/js/theme.js')"`
- `node -e "require('./static/js/main.js')"`
