### PR TITLE
Add exchange rate API key configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
     "wallet": "yourwallethere",
     "timezone": "America/Los_Angeles",
     "network_fee": 0.0,
-    "currency": "USD"
+    "currency": "USD",
+    "EXCHANGE_RATE_API_KEY": ""
 }

--- a/config.py
+++ b/config.py
@@ -19,7 +19,8 @@ def load_config():
         "wallet": "yourwallethere",
         "timezone": "America/Los_Angeles",
         "network_fee": 0.0,  # Add default network fee
-        "currency": "USD" # Default currency
+        "currency": "USD",  # Default currency
+        "EXCHANGE_RATE_API_KEY": ""
     }
     
     if os.path.exists(CONFIG_FILE):
@@ -32,6 +33,10 @@ def load_config():
             if "network_fee" not in config:
                 config["network_fee"] = default_config["network_fee"]
                 logging.info("Added missing network_fee to config with default value")
+
+            if "EXCHANGE_RATE_API_KEY" not in config:
+                config["EXCHANGE_RATE_API_KEY"] = default_config["EXCHANGE_RATE_API_KEY"]
+                logging.info("Added missing EXCHANGE_RATE_API_KEY to config with default value")
                 
             return config
         except Exception as e:
@@ -117,3 +122,12 @@ def get_currency():
     
     # Default to USD
     return "USD"
+
+def get_exchange_rate_api_key():
+    """Get the ExchangeRate API key from env or config."""
+    env_key = os.environ.get("EXCHANGE_RATE_API_KEY")
+    if env_key:
+        return env_key
+
+    config = load_config()
+    return config.get("EXCHANGE_RATE_API_KEY", "")

--- a/data_service.py
+++ b/data_service.py
@@ -528,17 +528,21 @@ class MiningDashboardService:
             dict: Exchange rates for supported currencies or empty dict if using USD
         """
         # Get the configured currency
-        from config import get_currency
+        from config import get_currency, get_exchange_rate_api_key
         selected_currency = get_currency()
+        api_key = get_exchange_rate_api_key()
     
         # Only fetch exchange rates if not using USD
         if selected_currency == "USD":
             logging.info("Using USD currency, skipping exchange rate fetch")
             return {}
+
+        if not api_key:
+            logging.error("Exchange rate API key not configured")
+            return {}
         
         try:
-            # Use the provided API key with the v6 exchangerate-api endpoint
-            api_key = "179cbeb07c900f20dde92d3b"
+            # Use the configured API key with the v6 exchangerate-api endpoint
             url = f"https://v6.exchangerate-api.com/v6/{api_key}/latest/{base_currency}"
             response = self.session.get(url, timeout=5)
         


### PR DESCRIPTION
## Summary
- add `EXCHANGE_RATE_API_KEY` entry to `config.json`
- support the API key in `config.py` with env var fallback
- load the key in `MiningDashboardService.fetch_exchange_rates`

## Testing
- `python -m py_compile config.py data_service.py`