### PR TITLE
Add notification currency updater

### DIFF
--- a/App.py
+++ b/App.py
@@ -864,7 +864,7 @@ def update_config():
             if currency_changed:
                 try:
                     logging.info(f"Currency changed from {current_config.get('currency', 'USD')} to {new_config['currency']}")
-                    updated_count = notification_service.update_notification_currency()
+                    updated_count = notification_service.update_notification_currency(new_config["currency"])
                     logging.info(f"Updated {updated_count} notifications to use {new_config['currency']} currency")
                 except Exception as e:
                     logging.error(f"Error updating notification currency: {e}")

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -1,0 +1,77 @@
+import unittest
+from unittest.mock import patch
+import sys
+import types
+
+# Provide a lightweight pytz substitute if pytz is unavailable
+if 'pytz' not in sys.modules:
+    tz_module = types.ModuleType('pytz')
+    class DummyTZInfo:
+        def utcoffset(self, dt):
+            return None
+        def dst(self, dt):
+            return None
+        def tzname(self, dt):
+            return 'UTC'
+        def localize(self, dt_obj):
+            return dt_obj.replace(tzinfo=self)
+    tz_module.timezone = lambda name: DummyTZInfo()
+    sys.modules['pytz'] = tz_module
+
+# Stub requests module if not available
+if 'requests' not in sys.modules:
+    req_module = types.ModuleType('requests')
+    class DummySession:
+        def get(self, *args, **kwargs):
+            raise NotImplementedError
+    req_module.Session = DummySession
+    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
+    sys.modules['requests'] = req_module
+
+# Stub bs4 module if not available
+if 'bs4' not in sys.modules:
+    bs4_module = types.ModuleType('bs4')
+    class DummySoup:
+        pass
+    bs4_module.BeautifulSoup = DummySoup
+    sys.modules['bs4'] = bs4_module
+
+from notification_service import NotificationService
+
+class DummyStateManager:
+    def __init__(self):
+        self.redis_client = None
+        self.saved = None
+    def get_notifications(self):
+        return []
+    def save_notifications(self, notifications):
+        self.saved = notifications
+        return True
+
+class NotificationCurrencyTest(unittest.TestCase):
+    def setUp(self):
+        self.state = DummyStateManager()
+        self.service = NotificationService(self.state)
+        self.service.notifications = [
+            {
+                "id": "1",
+                "timestamp": "2023-01-01T00:00:00",
+                "message": "Daily Mining Summary: 100 TH/s average hashrate, 100 SATS mined ($10.00)",
+                "level": "info",
+                "category": "hashrate",
+                "data": {"daily_profit": 10.0, "currency": "USD"}
+            }
+        ]
+
+    def test_update_notification_currency(self):
+        with patch('notification_service.get_exchange_rates', return_value={'EUR': 0.5}):
+            updated = self.service.update_notification_currency('EUR')
+
+        self.assertEqual(updated, 1)
+        notif = self.service.notifications[0]
+        self.assertEqual(notif['data']['currency'], 'EUR')
+        self.assertAlmostEqual(notif['data']['daily_profit'], 5.0)
+        self.assertIn('€', notif['message'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle updating stored notifications when currency changes
- call the updater in the configuration route
- add unit test for update_notification_currency

## Testing
- `python -m unittest discover tests`