### PR TITLE
Compute metrics in USD and convert to user currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This open-source dashboard provides real-time monitoring for Ocean.xyz pool mine
 
 ### Earnings Page
 - **Detailed Earnings Breakdown**: View earnings by time period (daily, weekly, monthly)
-- **Currency Conversion**: Automatically convert earnings to your preferred fiat currency
+ - **Currency Conversion**: Automatically convert earnings to your preferred fiat currency. All profitability metrics are calculated in USD first and converted using live exchange rates.
 - **Historical Data**: Access past earnings data for analysis
 
 ### System Resilience

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,6 +2,8 @@
 
 The dashboard can be customized through a combination of a `config.json` file and environment variables. Environment variables always override values found in the configuration file.
 
+Profitability calculations are always performed in USD. When a non-USD currency is configured, values are converted using the latest exchange rates before being displayed.
+
 ## `config.json`
 
 The default configuration file contains the following keys:

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1203,17 +1203,16 @@ function displayPayoutSummary() {
             ? latestMetrics.exchange_rates[currency]
             : 1.0;
 
-        // Calculate fiat value using current BTC price and exchange rate
+        // Calculate fiat value using current BTC price
         const btcPrice = latestMetrics?.btc_price || 0;
         if (btcPrice > 0) {
-            const fiatValue = parseFloat(lastPayout.amountBTC) * btcPrice * exchangeRate;
+            const fiatValue = parseFloat(lastPayout.amountBTC) * btcPrice;
             const symbol = getCurrencySymbol(currency);
             fiatValueStr = `${symbol}${numberWithCommas(fiatValue.toFixed(2))}`;
         }
         // Fallback to stored fiat value if available
         else if (lastPayout.fiat_value !== undefined && lastPayout.rate !== undefined) {
-            // Apply current exchange rate to convert from USD to selected currency
-            const fiatValue = lastPayout.fiat_value * exchangeRate;
+            const fiatValue = lastPayout.fiat_value;
             const symbol = getCurrencySymbol(currency);
             fiatValueStr = `${symbol}${numberWithCommas(fiatValue.toFixed(2))}`;
         }
@@ -3271,7 +3270,7 @@ function updateUI() {
 
         // Update BTC price with currency conversion and symbol
         if (data.btc_price != null) {
-            const btcPriceValue = data.btc_price * exchangeRate;
+            const btcPriceValue = data.btc_price;
             const symbol = getCurrencySymbol(currency);
 
             updateElementText("btc_price", formatCurrencyValue(btcPriceValue, currency));
@@ -3301,7 +3300,7 @@ function updateUI() {
 
         // Daily revenue with currency conversion
         if (data.daily_revenue != null) {
-            const dailyRevenue = data.daily_revenue * exchangeRate;
+            const dailyRevenue = data.daily_revenue;
             updateElementText("daily_revenue", formatCurrencyValue(dailyRevenue, currency));
         } else {
             updateElementText("daily_revenue", formatCurrencyValue(0, currency));
@@ -3309,7 +3308,7 @@ function updateUI() {
 
         // Daily power cost with currency conversion
         if (data.daily_power_cost != null) {
-            const dailyPowerCost = data.daily_power_cost * exchangeRate;
+            const dailyPowerCost = data.daily_power_cost;
             updateElementText("daily_power_cost", formatCurrencyValue(dailyPowerCost, currency));
         } else {
             updateElementText("daily_power_cost", formatCurrencyValue(0, currency));
@@ -3317,7 +3316,7 @@ function updateUI() {
 
         // Daily profit with currency conversion and color
         if (data.daily_profit_usd != null) {
-            const dailyProfit = data.daily_profit_usd * exchangeRate;
+            const dailyProfit = data.daily_profit_usd;
             const dailyProfitElement = document.getElementById("daily_profit_usd");
             if (dailyProfitElement) {
                 dailyProfitElement.textContent = formatCurrencyValue(dailyProfit, currency);
@@ -3333,7 +3332,7 @@ function updateUI() {
 
         // Monthly profit with currency conversion and color
         if (data.monthly_profit_usd != null) {
-            const monthlyProfit = data.monthly_profit_usd * exchangeRate;
+            const monthlyProfit = data.monthly_profit_usd;
             const monthlyProfitElement = document.getElementById("monthly_profit_usd");
             if (monthlyProfitElement) {
                 monthlyProfitElement.textContent = formatCurrencyValue(monthlyProfit, currency);

--- a/tests/test_currency_conversion.py
+++ b/tests/test_currency_conversion.py
@@ -1,0 +1,74 @@
+import sys, types
+
+if "pytz" not in sys.modules:
+    tz_module = types.ModuleType("pytz")
+    class DummyTZInfo:
+        def utcoffset(self, dt): return None
+        def dst(self, dt): return None
+        def tzname(self, dt): return "UTC"
+        def localize(self, dt_obj): return dt_obj.replace(tzinfo=self)
+    tz_module.timezone = lambda name: DummyTZInfo()
+    sys.modules["pytz"] = tz_module
+if "requests" not in sys.modules:
+    req_module = types.ModuleType("requests")
+    class DummySession:
+        def get(self, *args, **kwargs): raise NotImplementedError
+    req_module.Session = DummySession
+    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
+    sys.modules["requests"] = req_module
+if "bs4" not in sys.modules:
+    bs4_module = types.ModuleType("bs4")
+    class DummySoup: pass
+    bs4_module.BeautifulSoup = DummySoup
+    sys.modules["bs4"] = bs4_module
+
+import unittest
+from unittest.mock import patch
+
+from data_service import MiningDashboardService
+from models import OceanData
+
+class MetricsConversionTest(unittest.TestCase):
+    @patch('config.get_currency', return_value='EUR')
+    def test_fetch_metrics_converts_currency(self, mock_cur):
+        svc = MiningDashboardService(0, 0, 'w')
+        with patch.object(svc, 'get_ocean_data') as go, \
+             patch.object(svc, 'get_bitcoin_stats') as gb, \
+             patch.object(svc, 'fetch_exchange_rates') as fer:
+            go.return_value = OceanData(hashrate_3hr=100, hashrate_3hr_unit='TH/s', pool_fees_percentage=0.0)
+            gb.return_value = (0, 100e18, 10000, 0)
+            fer.return_value = {'EUR': 0.5}
+            metrics = svc.fetch_metrics()
+        self.assertAlmostEqual(metrics['btc_price'], 5000)
+        self.assertAlmostEqual(metrics['daily_revenue'], 2.25)
+        self.assertAlmostEqual(metrics['daily_profit_usd'], 2.25)
+        self.assertEqual(metrics['currency'], 'EUR')
+
+class EarningsConversionTest(unittest.TestCase):
+    @patch('config.get_currency', return_value='EUR')
+    def test_get_earnings_data_converts_currency(self, mock_cur):
+        svc = MiningDashboardService(0,0,'w')
+        with patch.object(svc, 'get_payment_history') as gph, \
+             patch.object(svc, 'get_ocean_data') as go, \
+             patch.object(svc, 'get_bitcoin_stats') as gb, \
+             patch.object(svc, 'fetch_exchange_rates') as fer:
+            gph.return_value = [{
+                'date': '2023-01-01 00:00',
+                'amount_btc': 0.1,
+                'amount_sats': 10000000,
+                'date_iso': '2023-01-01T00:00:00',
+                'fiat_value': 1000
+            }]
+            go.return_value = OceanData(unpaid_earnings=0.2, est_time_to_payout='soon')
+            gb.return_value = (0,0,10000,0)
+            fer.return_value = {'EUR':0.5}
+            data = svc.get_earnings_data()
+        self.assertAlmostEqual(data['total_paid_usd'], 1000)
+        self.assertAlmostEqual(data['total_paid_fiat'], 500)
+        self.assertAlmostEqual(data['payments'][0]['fiat_value'], 500)
+        self.assertAlmostEqual(data['monthly_summaries'][0]['total_fiat'], 500)
+        self.assertEqual(data['btc_price'], 5000)
+        self.assertEqual(data['currency'], 'EUR')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- always fetch Bitcoin price in USD
- convert metrics in `fetch_metrics` when a non-USD currency is selected
- convert earnings data to the selected currency
- update front-end logic to show already converted values
- document USD calculation behavior
- add tests for currency conversion

## Testing
- `python3 -m unittest discover tests -v`