### PR TITLE
Fix notification currency conversions

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -524,23 +524,17 @@ class MiningDashboardService:
     def fetch_exchange_rates(self, base_currency="USD"):
         """
         Fetch currency exchange rates from ExchangeRate API using API key.
-        Only fetches when currency is not USD to avoid unnecessary API calls.
     
         Args:
             base_currency (str): Base currency for rates (default: USD)
     
         Returns:
-            dict: Exchange rates for supported currencies or empty dict if using USD
+            dict: Exchange rates for supported currencies
         """
-        # Get the configured currency
+        # Get the configured currency and API key
         from config import get_currency, get_exchange_rate_api_key
         selected_currency = get_currency()
         api_key = get_exchange_rate_api_key()
-    
-        # Only fetch exchange rates if not using USD
-        if selected_currency == "USD":
-            logging.info("Using USD currency, skipping exchange rate fetch")
-            return {}
 
         if not api_key:
             logging.error("Exchange rate API key not configured")

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -71,7 +71,29 @@ class NotificationCurrencyTest(unittest.TestCase):
         notif = self.service.notifications[0]
         self.assertEqual(notif['data']['currency'], 'EUR')
         self.assertAlmostEqual(notif['data']['daily_profit'], 5.0)
+        self.assertAlmostEqual(notif['data']['daily_profit_usd'], 10.0)
         self.assertIn('€', notif['message'])
+
+    def test_convert_back_to_usd(self):
+        # First convert to JPY
+        with patch('notification_service.get_exchange_rates', return_value={'JPY': 150, 'USD': 1}):
+            self.service.update_notification_currency('JPY')
+
+        notif = self.service.notifications[0]
+        self.assertEqual(notif['data']['currency'], 'JPY')
+        self.assertAlmostEqual(notif['data']['daily_profit'], 1500.0)
+        self.assertAlmostEqual(notif['data']['daily_profit_usd'], 10.0)
+
+        # Now convert back to USD
+        with patch('notification_service.get_exchange_rates', return_value={'JPY': 150, 'USD': 1}):
+            updated = self.service.update_notification_currency('USD')
+
+        self.assertEqual(updated, 1)
+        notif = self.service.notifications[0]
+        self.assertEqual(notif['data']['currency'], 'USD')
+        self.assertAlmostEqual(notif['data']['daily_profit'], 10.0)
+        self.assertAlmostEqual(notif['data']['daily_profit_usd'], 10.0)
+        self.assertIn('$', notif['message'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- persist USD profit value when generating daily stats notifications
- handle stored USD values when converting notification currency
- test converting between JPY and USD

## Testing
- `python -m tests.test_notification_service`
- `python -m tests.test_currency_conversion`
