### PR TITLE
Add PyTest suite and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest -q

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,42 @@
+import importlib
+from types import SimpleNamespace
+import pytest
+
+@pytest.fixture
+def client(monkeypatch):
+    # Prevent scheduler from starting
+    import apscheduler.schedulers.background as bg
+    monkeypatch.setattr(bg.BackgroundScheduler, "start", lambda self: None)
+
+    App = importlib.reload(importlib.import_module("App"))
+
+    # Patch functions that interact with external systems
+    monkeypatch.setattr(App, "update_metrics_job", lambda force=False: None)
+    monkeypatch.setattr(App, "MiningDashboardService", lambda *a, **k: object())
+    monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
+
+    sample_cfg = {"wallet": "w"}
+    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+
+    return App.app.test_client()
+
+def test_health_endpoint(client):
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "status" in data
+
+
+def test_get_config_endpoint(client):
+    resp = client.get("/api/config")
+    assert resp.status_code == 200
+    assert resp.get_json()["wallet"] == "w"
+
+
+def test_update_config_endpoint(client):
+    resp = client.post("/api/config", json={"wallet": "abc"})
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data["status"] == "success"
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+import json
+import importlib
+import types
+from pathlib import Path
+import config as config_module
+
+def test_load_config_defaults(tmp_path, monkeypatch):
+    temp_file = tmp_path / "cfg.json"
+    monkeypatch.setattr(config_module, "CONFIG_FILE", str(temp_file))
+    cfg = importlib.reload(config_module).load_config()
+    assert cfg["currency"] == "USD"
+    assert "EXCHANGE_RATE_API_KEY" in cfg
+
+
+def test_load_config_file(tmp_path, monkeypatch):
+    temp_file = tmp_path / "cfg.json"
+    with open(temp_file, "w") as fh:
+        json.dump({"currency": "EUR"}, fh)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", str(temp_file))
+    cfg = importlib.reload(config_module).load_config()
+    assert cfg["currency"] == "EUR"
+    assert "network_fee" in cfg
+    assert "EXCHANGE_RATE_API_KEY" in cfg

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+from worker_service import WorkerService
+from data_service import MiningDashboardService
+from notification_service import NotificationService
+
+
+def test_generate_default_workers_data(monkeypatch):
+    monkeypatch.setattr('worker_service.get_timezone', lambda: 'UTC')
+    svc = WorkerService()
+    data = svc.generate_default_workers_data()
+    assert data['workers_total'] == 0
+    assert data['hashrate_unit'] == 'TH/s'
+    assert data['workers'] == []
+
+
+def test_fetch_url_success(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+    resp = MagicMock()
+    monkeypatch.setattr(svc.session, 'get', lambda url, timeout=5: resp)
+    assert svc.fetch_url('http://x') is resp
+
+
+def test_fetch_url_error(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+    def fail(url, timeout=5):
+        raise Exception('fail')
+    monkeypatch.setattr(svc.session, 'get', fail)
+    assert svc.fetch_url('http://x') is None
+
+
+def test_notification_update_currency(monkeypatch):
+    class DummyState:
+        def get_notifications(self):
+            return []
+        def save_notifications(self, n):
+            self.saved = n
+            return True
+    state = DummyState()
+    svc = NotificationService(state)
+    svc.notifications = [{
+        'id': '1',
+        'timestamp': '2023-01-01T00:00:00',
+        'message': 'profit ($10.00)',
+        'level': 'info',
+        'category': 'hashrate',
+        'data': {'daily_profit': 10.0, 'currency': 'USD'}
+    }]
+    monkeypatch.setattr('notification_service.get_exchange_rates', lambda: {'EUR': 0.5, 'USD':1})
+    updated = svc.update_notification_currency('EUR')
+    assert updated == 1
+    notif = svc.notifications[0]
+    assert notif['data']['currency'] == 'EUR'
+    assert abs(notif['data']['daily_profit'] - 5.0) < 1e-6
+


### PR DESCRIPTION
## Summary
- create a GitHub Actions workflow to run tests
- add pytest tests covering config loading
- test a few Flask API endpoints
- add service method unit tests

## Testing
- `pytest -q` *(fails: command not found)*