### PR TITLE
Fix config tests reload order

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,8 +6,9 @@ import config as config_module
 
 def test_load_config_defaults(tmp_path, monkeypatch):
     temp_file = tmp_path / "cfg.json"
-    monkeypatch.setattr(config_module, "CONFIG_FILE", str(temp_file))
-    cfg = importlib.reload(config_module).load_config()
+    cfg_module = importlib.reload(config_module)
+    monkeypatch.setattr(cfg_module, "CONFIG_FILE", str(temp_file))
+    cfg = cfg_module.load_config()
     assert cfg["currency"] == "USD"
     assert "EXCHANGE_RATE_API_KEY" in cfg
 
@@ -16,8 +17,9 @@ def test_load_config_file(tmp_path, monkeypatch):
     temp_file = tmp_path / "cfg.json"
     with open(temp_file, "w") as fh:
         json.dump({"currency": "EUR"}, fh)
-    monkeypatch.setattr(config_module, "CONFIG_FILE", str(temp_file))
-    cfg = importlib.reload(config_module).load_config()
+    cfg_module = importlib.reload(config_module)
+    monkeypatch.setattr(cfg_module, "CONFIG_FILE", str(temp_file))
+    cfg = cfg_module.load_config()
     assert cfg["currency"] == "EUR"
     assert "network_fee" in cfg
     assert "EXCHANGE_RATE_API_KEY" in cfg


### PR DESCRIPTION
## Summary
- reload `config_module` before patching its CONFIG_FILE

## Testing
- `pip install -q -r requirements.txt` *(fails: cannot connect to proxy)*