### PR TITLE
Fix pytz stub logic in tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,8 +6,10 @@ import pytest
 
 @pytest.fixture
 def client(monkeypatch):
-    # Provide a lightweight pytz substitute if needed
-    if "pytz" not in sys.modules:
+    # Provide a lightweight pytz substitute if the real package is unavailable
+    try:
+        import pytz  # noqa: F401
+    except ImportError:
         spec = importlib.util.spec_from_file_location(
             "pytz", Path(__file__).resolve().parents[1] / "pytz.py"
         )


### PR DESCRIPTION
## Summary
- ensure test fixture only falls back to the lightweight pytz stub when the real package cannot be imported

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*