### PR TITLE
Clean up CSS via Prettier formatting

### DIFF
--- a/static/css/blocks.css
+++ b/static/css/blocks.css
@@ -5,430 +5,448 @@
 
 /* ----- CONTROLS & INPUTS ----- */
 .block-controls {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 15px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 15px;
 }
 
 .block-control-item {
-    display: flex;
-    align-items: center;
-    gap: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .block-input {
-    background-color: var(--bg-color) !important;
-    border: 1px solid var(--primary-color) !important;
-    color: var(--text-color);
-    padding: 5px 10px;
-    font-family: var(--terminal-font);
-    width: 150px;
-    transition: box-shadow 0.2s ease;
+  background-color: var(--bg-color) !important;
+  border: 1px solid var(--primary-color) !important;
+  color: var(--text-color);
+  padding: 5px 10px;
+  font-family: var(--terminal-font);
+  width: 150px;
+  transition: box-shadow 0.2s ease;
 }
 
-    .block-input:focus {
-        outline: none;
-        box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.5);
-    }
+.block-input:focus {
+  outline: none;
+  box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.5);
+}
 
 .block-button {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    padding: 5px 15px;
-    font-family: var(--terminal-font);
-    cursor: pointer;
-    transition: all 0.2s ease;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  padding: 5px 15px;
+  font-family: var(--terminal-font);
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
-    .block-button:hover {
-        background-color: var(--primary-color);
-        color: var(--bg-color);
-        box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
-    }
+.block-button:hover {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
+}
 
 /* ----- LATEST BLOCK STATS ----- */
 .latest-block-stats {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-    gap: 15px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 15px;
 }
 
 .stat-item {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
-    .stat-item strong {
-        color: var(--primary-color);
-        margin-bottom: 5px;
-    }
+.stat-item strong {
+  color: var(--primary-color);
+  margin-bottom: 5px;
+}
 
 /* ----- BLOCKS GRID ----- */
 .blocks-container {
-    overflow-x: auto;
-    position: relative;
+  overflow-x: auto;
+  position: relative;
 }
 
 .blocks-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    gap: 15px;
-    margin-top: 15px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 15px;
+  margin-top: 15px;
 }
 
 /* ----- BLOCK CARD ----- */
 .block-card {
-    background-color: var(--bg-color);
-    box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
-    position: relative;
-    overflow: hidden;
-    padding: 12px;
-    cursor: pointer;
-    transition: all 0.2s ease;
+  background-color: var(--bg-color);
+  box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
+  position: relative;
+  overflow: hidden;
+  padding: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
-    .block-card:hover {
-        box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.5);
-        transform: translateY(-2px);
-    }
+.block-card:hover {
+  box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.5);
+  transform: translateY(-2px);
+}
 
-    .block-card::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+.block-card::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 .block-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 8px;
-    position: relative;
-    z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  position: relative;
+  z-index: 2;
 }
 
 .block-height {
-    font-size: 1.2rem;
-    font-weight: bold;
-    color: var(--primary-color);
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: var(--primary-color);
 }
 
 .block-time {
-    font-size: 0.9rem;
-    color: #00dfff;
+  font-size: 0.9rem;
+  color: #00dfff;
 }
 
 .block-info {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 8px 15px;
-    position: relative;
-    z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px 15px;
+  position: relative;
+  z-index: 2;
 }
 
 .block-info-item {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .block-info-label {
-    font-size: 0.8rem;
-    color: #aaa;
+  font-size: 0.8rem;
+  color: #aaa;
 }
 
 .block-info-value {
-    font-size: 0.9rem;
+  font-size: 0.9rem;
 }
 
-    /* Color-coded values */
-    .block-info-value.yellow {
-        color: #ffd700;
-    }
+/* Color-coded values */
+.block-info-value.yellow {
+  color: #ffd700;
+}
 
-    .block-info-value.green {
-        color: #32CD32;
-    }
+.block-info-value.green {
+  color: #32cd32;
+}
 
-    .block-info-value.blue {
-        color: #00dfff;
-    }
+.block-info-value.blue {
+  color: #00dfff;
+}
 
-    .block-info-value.white {
-        color: #ffffff;
-    }
+.block-info-value.white {
+  color: #ffffff;
+}
 
-    .block-info-value.red {
-        color: #ff5555;
-    }
+.block-info-value.red {
+  color: #ff5555;
+}
 
 /* ----- LOADER ----- */
 .loader {
-    text-align: center;
-    padding: 20px;
-    grid-column: 1 / -1;
+  text-align: center;
+  padding: 20px;
+  grid-column: 1 / -1;
 }
 
 .loader-text {
-    display: inline-block;
-    margin-right: 5px;
+  display: inline-block;
+  margin-right: 5px;
 }
 
 /* ----- BLOCK MODAL ----- */
 .block-modal {
-    display: none;
-    position: fixed;
-    z-index: 1000;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgba(0, 0, 0, 0.8);
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.8);
 }
 
 .block-modal-content {
-    background-color: var(--bg-color);
-    margin: 5% auto;
-    border: 1px solid var(--primary-color);
-    box-shadow: 0 0 20px rgba(var(--primary-color-rgb), 0.5);
-    width: 90%;
-    max-width: 800px;
-    max-height: 80vh;
-    overflow-y: auto;
-    position: relative;
+  background-color: var(--bg-color);
+  margin: 5% auto;
+  border: 1px solid var(--primary-color);
+  box-shadow: 0 0 20px rgba(var(--primary-color-rgb), 0.5);
+  width: 90%;
+  max-width: 800px;
+  max-height: 80vh;
+  overflow-y: auto;
+  position: relative;
 }
 
-    .block-modal-content::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 0;
-    }
+.block-modal-content::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 0;
+}
 
 .block-modal-header {
-    background-color: #000;
-    color: var(--primary-color);
-    font-weight: bold;
-    padding: 0.5rem 1rem;
-    font-size: 1.1rem;
-    border-bottom: 1px solid var(--primary-color);
-    animation: flicker 4s infinite;
-    font-family: var(--header-font);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    position: relative;
-    z-index: 1;
+  background-color: #000;
+  color: var(--primary-color);
+  font-weight: bold;
+  padding: 0.5rem 1rem;
+  font-size: 1.1rem;
+  border-bottom: 1px solid var(--primary-color);
+  animation: flicker 4s infinite;
+  font-family: var(--header-font);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+  z-index: 1;
 }
 
 .block-modal-close {
-    color: var(--primary-color);
-    float: right;
-    font-size: 28px;
-    font-weight: bold;
-    cursor: pointer;
-    transition: color 0.3s ease;
+  color: var(--primary-color);
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: color 0.3s ease;
 }
 
-    .block-modal-close:hover,
-    .block-modal-close:focus {
-        color: #ffa500;
-    }
+.block-modal-close:hover,
+.block-modal-close:focus {
+  color: #ffa500;
+}
 
 .block-modal-body {
-    padding: 1rem;
-    position: relative;
-    z-index: 1;
+  padding: 1rem;
+  position: relative;
+  z-index: 1;
 }
 
 /* ----- BLOCK DETAILS ----- */
 #block-details {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 15px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 15px;
 }
 
 .block-detail-section {
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 }
 
 .block-detail-title {
-    font-size: 1.1rem;
-    color: var(--primary-color);
-    margin-bottom: 10px;
-    font-weight: bold;
+  font-size: 1.1rem;
+  color: var(--primary-color);
+  margin-bottom: 10px;
+  font-weight: bold;
 }
 
 .block-detail-item {
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 }
 
 .block-detail-label {
-    font-size: 0.9rem;
-    color: #aaa;
+  font-size: 0.9rem;
+  color: #aaa;
 }
 
 .block-detail-value {
-    font-size: 0.9rem;
-    word-break: break-all;
+  font-size: 0.9rem;
+  word-break: break-all;
 }
 
 .block-hash {
-    font-family: monospace;
-    font-size: 0.8rem;
-    color: #00dfff;
-    word-break: break-all;
+  font-family: monospace;
+  font-size: 0.8rem;
+  color: #00dfff;
+  word-break: break-all;
 }
 
 /* ----- FEE VISUALIZATION ----- */
 .transaction-data {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 }
 
 .fee-bar-container {
-    height: 5px;
-    width: 100%;
-    background-color: rgba(255, 255, 255, 0.1);
-    margin-top: 5px;
-    position: relative;
-    overflow: hidden;
+  height: 5px;
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.1);
+  margin-top: 5px;
+  position: relative;
+  overflow: hidden;
 }
 
 .fee-bar {
-    height: 100%;
-    width: 0;
-    background: linear-gradient(90deg, #32CD32, #ffd700);
-    transition: width 0.5s ease;
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #32cd32, #ffd700);
+  transition: width 0.5s ease;
 }
 
 /* ----- MINING ANIMATION ----- */
 .mining-animation-container {
-    padding: 0;
-    background-color: #0a0a0a;
-    overflow: hidden;
-    position: relative;
-    width: 100%;
+  padding: 0;
+  background-color: #0a0a0a;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
 }
 
-    .mining-animation-container::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+.mining-animation-container::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 #svg-container {
-    width: 100%;
-    height: 300px;
-    overflow: hidden;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  width: 100%;
+  height: 300px;
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 svg {
-    max-width: 100%;
-    height: auto;
-    display: block;
+  max-width: 100%;
+  height: auto;
+  display: block;
 }
 
 #block-mining-animation {
-    width: 100%;
-    height: 300px;
+  width: 100%;
+  height: 300px;
 }
 
 /* ----- BLOCK NAVIGATION ----- */
 .block-navigation {
-    display: flex;
-    justify-content: space-between;
-    gap: 10px;
-    margin-top: 15px;
-    grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 15px;
+  grid-column: 1 / -1;
 }
 
 /* ----- RESPONSIVE STYLES ----- */
 @media (max-width: 768px) {
-    .latest-block-stats {
-        grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    }
+  .latest-block-stats {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
 
-    .blocks-grid {
-        grid-template-columns: 1fr;
-    }
+  .blocks-grid {
+    grid-template-columns: 1fr;
+  }
 
-    .block-modal-content {
-        width: 95%;
-        margin: 10% auto;
-    }
+  .block-modal-content {
+    width: 95%;
+    margin: 10% auto;
+  }
 
-    #block-details {
-        grid-template-columns: 1fr;
-    }
+  #block-details {
+    grid-template-columns: 1fr;
+  }
 
-    #svg-container {
-        height: 250px;
-    }
+  #svg-container {
+    height: 250px;
+  }
 
-    .block-controls {
-        flex-direction: column;
-        align-items: stretch;
-    }
+  .block-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-    .block-control-item {
-        justify-content: space-between;
-    }
+  .block-control-item {
+    justify-content: space-between;
+  }
 
-    .block-input {
-        flex-grow: 1;
-    }
+  .block-input {
+    flex-grow: 1;
+  }
 }
 
 @media (max-width: 480px) {
-    .block-modal-header {
-        font-size: 1rem;
-        padding: 0.4rem 0.8rem;
-    }
+  .block-modal-header {
+    font-size: 1rem;
+    padding: 0.4rem 0.8rem;
+  }
 
-    .block-modal-close {
-        font-size: 24px;
-    }
+  .block-modal-close {
+    font-size: 24px;
+  }
 
-    .block-modal-body {
-        padding: 0.8rem;
-    }
+  .block-modal-body {
+    padding: 0.8rem;
+  }
 
-    .block-detail-title {
-        font-size: 1rem;
-    }
+  .block-detail-title {
+    font-size: 1rem;
+  }
 
-    .block-detail-label,
-    .block-detail-value {
-        font-size: 0.85rem;
-    }
+  .block-detail-label,
+  .block-detail-value {
+    font-size: 0.85rem;
+  }
 
-    .block-hash {
-        font-size: 0.75rem;
-    }
+  .block-hash {
+    font-size: 0.75rem;
+  }
 }

--- a/static/css/boot.css
+++ b/static/css/boot.css
@@ -5,354 +5,369 @@
 
 /* ----- ROOT VARIABLES ----- */
 :root {
-    --bitcoin-color: #f7931a;
-    --bitcoin-rgb: 247, 147, 26;
-    --deepsea-color: #0088cc;
-    --deepsea-rgb: 0, 136, 204;
-    --bg-color: #0a0a0a;
-    --text-color: white;
-    --success-color: #32CD32;
-    --error-color: #ff0000;
-    --terminal-font: 'VT323', monospace;
+  --bitcoin-color: #f7931a;
+  --bitcoin-rgb: 247, 147, 26;
+  --deepsea-color: #0088cc;
+  --deepsea-rgb: 0, 136, 204;
+  --bg-color: #0a0a0a;
+  --text-color: white;
+  --success-color: #32cd32;
+  --error-color: #ff0000;
+  --terminal-font: "VT323", monospace;
 }
 
 /* ----- BASE STYLES ----- */
 body {
-    background: linear-gradient(135deg, #121212, #000000);
-    color: var(--bitcoin-color);
-    font-family: var(--terminal-font);
-    font-size: 20px;
-    line-height: 1.4;
-    margin: 0;
-    padding: 10px;
-    overflow-x: hidden;
-    height: calc(100vh - 100px);
-    display: flex;
-    flex-direction: column;
+  background: linear-gradient(135deg, #121212, #000000);
+  color: var(--bitcoin-color);
+  font-family: var(--terminal-font);
+  font-size: 20px;
+  line-height: 1.4;
+  margin: 0;
+  padding: 10px;
+  overflow-x: hidden;
+  height: calc(100vh - 100px);
+  display: flex;
+  flex-direction: column;
 }
 
-    /* CRT Screen Effect */
-    body::before {
-        content: " ";
-        display: block;
-        position: fixed;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        right: 0;
-        background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.1) 50%), linear-gradient(90deg, rgba(255, 0, 0, 0.03), rgba(0, 255, 0, 0.02), rgba(0, 0, 255, 0.03));
-        background-size: 100% 2px, 3px 100%;
-        pointer-events: none;
-        z-index: 2;
-        opacity: 0.15;
-    }
+/* CRT Screen Effect */
+body::before {
+  content: " ";
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background:
+    linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.1) 50%),
+    linear-gradient(
+      90deg,
+      rgba(255, 0, 0, 0.03),
+      rgba(0, 255, 0, 0.02),
+      rgba(0, 0, 255, 0.03)
+    );
+  background-size:
+    100% 2px,
+    3px 100%;
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0.15;
+}
 
 /* ----- CONFIGURATION FORM ----- */
 #config-form {
-    display: none;
-    width: 500px;
-    max-width: 90%;
-    margin: 30px auto;
-    padding: 20px;
-    background-color: #0d0d0d;
-    border: 1px solid var(--bitcoin-color);
-    box-shadow: 0 0 10px rgba(var(--bitcoin-rgb), 0.5);
-    border-radius: 4px;
-    z-index: 100;
-    position: relative;
+  display: none;
+  width: 500px;
+  max-width: 90%;
+  margin: 30px auto;
+  padding: 20px;
+  background-color: #0d0d0d;
+  border: 1px solid var(--bitcoin-color);
+  box-shadow: 0 0 10px rgba(var(--bitcoin-rgb), 0.5);
+  border-radius: 4px;
+  z-index: 100;
+  position: relative;
 }
 
 .config-title {
-    font-size: 24px;
-    text-align: center;
-    margin-bottom: 20px;
-    color: var(--bitcoin-color);
+  font-size: 24px;
+  text-align: center;
+  margin-bottom: 20px;
+  color: var(--bitcoin-color);
 }
 
 .form-group {
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 }
 
-    .form-group label {
-        display: block;
-        margin-bottom: 5px;
-        color: var(--bitcoin-color);
-    }
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--bitcoin-color);
+}
 
-    .form-group input,
-    .form-group select {
-        width: 97%;
-        padding: 8px;
-        background-color: #0d0d0d;
-        border: 1px solid var(--bitcoin-color);
-        color: var(--text-color);
-        font-family: var(--terminal-font);
-        font-size: 18px;
-    }
+.form-group input,
+.form-group select {
+  width: 97%;
+  padding: 8px;
+  background-color: #0d0d0d;
+  border: 1px solid var(--bitcoin-color);
+  color: var(--text-color);
+  font-family: var(--terminal-font);
+  font-size: 18px;
+}
 
-        .form-group input:focus,
-        .form-group select:focus {
-            outline: none;
-            box-shadow: 0 0 5px var(--bitcoin-color);
-        }
+.form-group input:focus,
+.form-group select:focus {
+  outline: none;
+  box-shadow: 0 0 5px var(--bitcoin-color);
+}
 
-    /* Style select dropdown with custom arrow */
-    .form-group select {
-        appearance: none;
-        -webkit-appearance: none;
-        -moz-appearance: none;
-        background-image: linear-gradient(45deg, transparent 50%, var(--bitcoin-color) 50%), linear-gradient(135deg, var(--bitcoin-color) 50%, transparent 50%);
-        background-position: calc(100% - 15px) calc(1em + 0px), calc(100% - 10px) calc(1em + 0px);
-        background-size: 5px 5px, 5px 5px;
-        background-repeat: no-repeat;
-        padding-right: 30px;
-    }
+/* Style select dropdown with custom arrow */
+.form-group select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--bitcoin-color) 50%),
+    linear-gradient(135deg, var(--bitcoin-color) 50%, transparent 50%);
+  background-position:
+    calc(100% - 15px) calc(1em + 0px),
+    calc(100% - 10px) calc(1em + 0px);
+  background-size:
+    5px 5px,
+    5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 30px;
+}
 
 .form-actions {
-    display: flex;
-    justify-content: space-between;
-    margin-top: 20px;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
 }
 
 .btn {
-    padding: 8px 16px;
-    background-color: var(--bitcoin-color);
-    color: #000;
-    border: none;
-    cursor: pointer;
-    font-family: var(--terminal-font);
-    font-size: 18px;
-    transition: all 0.2s ease;
+  padding: 8px 16px;
+  background-color: var(--bitcoin-color);
+  color: #000;
+  border: none;
+  cursor: pointer;
+  font-family: var(--terminal-font);
+  font-size: 18px;
+  transition: all 0.2s ease;
 }
 
-    .btn:hover {
-        background-color: #ffa32e;
-    }
+.btn:hover {
+  background-color: #ffa32e;
+}
 
 .btn-secondary {
-    background-color: #333;
-    color: var(--bitcoin-color);
+  background-color: #333;
+  color: var(--bitcoin-color);
 }
 
 /* Form message styling */
 #form-message {
-    margin-top: 15px;
-    padding: 10px;
-    border-radius: 3px;
-    display: none;
+  margin-top: 15px;
+  padding: 10px;
+  border-radius: 3px;
+  display: none;
 }
 
 .message-success {
-    background-color: rgba(50, 205, 50, 0.2);
-    border: 1px solid var(--success-color);
-    color: var(--success-color);
+  background-color: rgba(50, 205, 50, 0.2);
+  border: 1px solid var(--success-color);
+  color: var(--success-color);
 }
 
 .message-error {
-    background-color: rgba(255, 0, 0, 0.2);
-    border: 1px solid var(--error-color);
-    color: var(--error-color);
+  background-color: rgba(255, 0, 0, 0.2);
+  border: 1px solid var(--error-color);
+  color: var(--error-color);
 }
 
 /* ----- TOOLTIP STYLING ----- */
 .tooltip {
-    position: relative;
-    display: inline-block;
-    margin-left: 5px;
-    width: 14px;
-    height: 14px;
-    background-color: #333;
-    color: var(--text-color);
-    border-radius: 50%;
-    text-align: center;
-    line-height: 14px;
-    font-size: 10px;
-    cursor: help;
+  position: relative;
+  display: inline-block;
+  margin-left: 5px;
+  width: 14px;
+  height: 14px;
+  background-color: #333;
+  color: var(--text-color);
+  border-radius: 50%;
+  text-align: center;
+  line-height: 14px;
+  font-size: 10px;
+  cursor: help;
 }
 
-    .tooltip .tooltip-text {
-        visibility: hidden;
-        width: 200px;
-        background-color: #000;
-        color: var(--text-color);
-        text-align: center;
-        border-radius: 3px;
-        padding: 5px;
-        position: absolute;
-        z-index: 1;
-        bottom: 125%;
-        left: 50%;
-        margin-left: -100px;
-        opacity: 0;
-        transition: opacity 0.3s;
-        font-size: 14px;
-        border: 1px solid var(--bitcoin-color);
-    }
+.tooltip .tooltip-text {
+  visibility: hidden;
+  width: 200px;
+  background-color: #000;
+  color: var(--text-color);
+  text-align: center;
+  border-radius: 3px;
+  padding: 5px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -100px;
+  opacity: 0;
+  transition: opacity 0.3s;
+  font-size: 14px;
+  border: 1px solid var(--bitcoin-color);
+}
 
-    .tooltip:hover .tooltip-text {
-        visibility: visible;
-        opacity: 1;
-    }
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
 
 /* ----- TERMINAL STYLING ----- */
 #terminal {
-    width: 100%;
-    max-width: 900px;
-    margin: 0 auto;
-    white-space: pre-wrap;
-    word-break: break-word;
-    animation: flicker 4s infinite;
-    height: 400px;
-    overflow-y: auto;
-    position: relative;
-    flex: 1;
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  animation: flicker 4s infinite;
+  height: 400px;
+  overflow-y: auto;
+  position: relative;
+  flex: 1;
 }
 
 #terminal-content {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
 }
 
 .cursor {
-    display: inline-block;
-    width: 10px;
-    height: 16px;
-    background-color: var(--bitcoin-color);
-    animation: blink 1s step-end infinite;
-    vertical-align: middle;
-    box-shadow: 0 0 5px rgba(var(--bitcoin-rgb), 0.8);
+  display: inline-block;
+  width: 10px;
+  height: 16px;
+  background-color: var(--bitcoin-color);
+  animation: blink 1s step-end infinite;
+  vertical-align: middle;
+  box-shadow: 0 0 5px rgba(var(--bitcoin-rgb), 0.8);
 }
 
 #prompt-container {
-    display: none;
-    white-space: nowrap;
+  display: none;
+  white-space: nowrap;
 }
 
 #prompt-text {
-    color: var(--bitcoin-color);
-    margin-right: 5px;
-    display: inline;
+  color: var(--bitcoin-color);
+  margin-right: 5px;
+  display: inline;
 }
 
 #user-input {
-    background: transparent;
-    border: none;
-    color: var(--bitcoin-color);
-    font-family: var(--terminal-font);
-    font-size: 20px;
-    caret-color: transparent;
-    outline: none;
-    width: 35px;
-    height: 33px;
-    padding: 0;
-    margin: 0;
-    display: inline-block;
-    vertical-align: top;
+  background: transparent;
+  border: none;
+  color: var(--bitcoin-color);
+  font-family: var(--terminal-font);
+  font-size: 20px;
+  caret-color: transparent;
+  outline: none;
+  width: 35px;
+  height: 33px;
+  padding: 0;
+  margin: 0;
+  display: inline-block;
+  vertical-align: top;
 }
 
 .prompt-cursor {
-    display: inline-block;
-    width: 10px;
-    height: 16px;
-    background-color: var(--bitcoin-color);
-    animation: blink 1s step-end infinite;
-    vertical-align: middle;
-    box-shadow: 0 0 5px rgba(var(--bitcoin-rgb), 0.8);
-    position: relative;
-    top: 1px;
-    margin-left: -2px;
+  display: inline-block;
+  width: 10px;
+  height: 16px;
+  background-color: var(--bitcoin-color);
+  animation: blink 1s step-end infinite;
+  vertical-align: middle;
+  box-shadow: 0 0 5px rgba(var(--bitcoin-rgb), 0.8);
+  position: relative;
+  top: 1px;
+  margin-left: -2px;
 }
 
 /* ----- BITCOIN LOGO ----- */
 #bitcoin-logo {
-    display: block;
-    visibility: hidden;
-    text-align: center;
-    margin: 10px auto;
-    font-size: 10px;
-    line-height: 1;
-    color: var(--bitcoin-color);
-    text-shadow: 0 0 10px rgba(var(--bitcoin-rgb), 0.8);
-    white-space: pre;
-    width: 260px;
-    padding: 10px;
-    border: 2px solid var(--bitcoin-color);
-    background-color: #0a0a0a;
-    box-shadow: 0 0 15px rgba(var(--bitcoin-rgb), 0.5);
-    font-family: monospace;
-    opacity: 0;
-    transition: opacity 1s ease;
-    position: relative;
-    height: 130px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
+  display: block;
+  visibility: hidden;
+  text-align: center;
+  margin: 10px auto;
+  font-size: 10px;
+  line-height: 1;
+  color: var(--bitcoin-color);
+  text-shadow: 0 0 10px rgba(var(--bitcoin-rgb), 0.8);
+  white-space: pre;
+  width: 260px;
+  padding: 10px;
+  border: 2px solid var(--bitcoin-color);
+  background-color: #0a0a0a;
+  box-shadow: 0 0 15px rgba(var(--bitcoin-rgb), 0.5);
+  font-family: monospace;
+  opacity: 0;
+  transition: opacity 1s ease;
+  position: relative;
+  height: 130px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
 }
 
 /* ----- SKIP BUTTON ----- */
 #skip-button {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    background-color: var(--bitcoin-color);
-    color: #000;
-    border: none;
-    padding: 10px 15px;
-    border-radius: 5px;
-    cursor: pointer;
-    font-family: var(--terminal-font);
-    font-size: 16px;
-    box-shadow: 0 0 8px rgba(var(--bitcoin-rgb), 0.5);
-    transition: all 0.2s ease;
-    z-index: 50;
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background-color: var(--bitcoin-color);
+  color: #000;
+  border: none;
+  padding: 10px 15px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-family: var(--terminal-font);
+  font-size: 16px;
+  box-shadow: 0 0 8px rgba(var(--bitcoin-rgb), 0.5);
+  transition: all 0.2s ease;
+  z-index: 50;
 }
 
-    #skip-button:hover {
-        background-color: #ffa32e;
-        box-shadow: 0 0 12px rgba(var(--bitcoin-rgb), 0.7);
-    }
+#skip-button:hover {
+  background-color: #ffa32e;
+  box-shadow: 0 0 12px rgba(var(--bitcoin-rgb), 0.7);
+}
 
 /* ----- INFO & DEBUG ----- */
 #loading-message {
-    text-align: center;
-    margin-bottom: 10px;
-    color: var(--bitcoin-color);
+  text-align: center;
+  margin-bottom: 10px;
+  color: var(--bitcoin-color);
 }
 
 #debug-info {
-    position: fixed;
-    bottom: 10px;
-    left: 10px;
-    color: #666;
-    font-size: 12px;
-    z-index: 100;
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+  color: #666;
+  font-size: 12px;
+  z-index: 100;
 }
 
 /* ----- COLOR CLASSES ----- */
 .green {
-    color: #39ff14 !important;
+  color: #39ff14 !important;
 }
 
 .blue {
-    color: #00dfff !important;
+  color: #00dfff !important;
 }
 
 .yellow {
-    color: #ffd700 !important;
+  color: #ffd700 !important;
 }
 
 .white {
-    color: #ffffff !important;
+  color: #ffffff !important;
 }
 
 .red {
-    color: #ff2d2d !important;
+  color: #ff2d2d !important;
 }
 
 .magenta {
-    color: #ff2d95 !important;
+  color: #ff2d95 !important;
 }
 
 /* ----- DEEPSEA THEME ----- */
@@ -362,408 +377,438 @@ body.deepsea-theme #prompt-container,
 body.deepsea-theme #prompt-text,
 body.deepsea-theme #user-input,
 body.deepsea-theme #loading-message {
-    color: var(--deepsea-color);
+  color: var(--deepsea-color);
 }
 
 body.deepsea-theme .cursor,
 body.deepsea-theme .prompt-cursor {
-    background-color: var(--deepsea-color);
-    box-shadow: 0 0 5px rgba(var(--deepsea-rgb), 0.8);
+  background-color: var(--deepsea-color);
+  box-shadow: 0 0 5px rgba(var(--deepsea-rgb), 0.8);
 }
 
 body.deepsea-theme #bitcoin-logo {
-    color: transparent;
-    position: relative;
-    text-shadow: none;
-    min-height: 120px;
-    border: 2px solid var(--deepsea-color);
-    box-shadow: 0 0 15px rgba(var(--deepsea-rgb), 0.5);
+  color: transparent;
+  position: relative;
+  text-shadow: none;
+  min-height: 120px;
+  border: 2px solid var(--deepsea-color);
+  box-shadow: 0 0 15px rgba(var(--deepsea-rgb), 0.5);
 }
 
-    body.deepsea-theme #bitcoin-logo::after {
-        content: " ____                 ____             \A|  _ \\  ___  ___ _ __/ ___|  ___  __ _ \A| | | |/ _ \\/ _ \\ '_ \\___ \\ / _ \\/ _` |\A| |_| |  __/  __/ |_) |__) |  __/ (_| |\A|____/ \\___|\\___|_.__/____/ \\___|\\__,_|\A|_|    ";
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        font-size: 100%;
-        font-weight: bold;
-        line-height: 1.2;
-        color: var(--deepsea-color);
-        white-space: pre;
-        display: block;
-        text-shadow: 0 0 10px rgba(var(--deepsea-rgb), 0.5);
-        font-family: monospace;
-        z-index: 1;
-        padding: 10px 0;
-    }
+body.deepsea-theme #bitcoin-logo::after {
+  content: " ____                 ____             \A|  _ \\  ___  ___ _ __/ ___|  ___  __ _ \A| | | |/ _ \\/ _ \\ '_ \\___ \\ / _ \\/ _` |\A| |_| |  __/  __/ |_) |__) |  __/ (_| |\A|____/ \\___|\\___|_.__/____/ \\___|\\__,_|\A|_|    ";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 100%;
+  font-weight: bold;
+  line-height: 1.2;
+  color: var(--deepsea-color);
+  white-space: pre;
+  display: block;
+  text-shadow: 0 0 10px rgba(var(--deepsea-rgb), 0.5);
+  font-family: monospace;
+  z-index: 1;
+  padding: 10px 0;
+}
 
-    body.deepsea-theme #bitcoin-logo::before {
-        content: "v.21";
-        position: absolute;
-        bottom: 0;
-        right: 10px;
-        color: var(--deepsea-color);
-        font-size: 16px;
-        text-shadow: 0 0 5px rgba(var(--deepsea-rgb), 0.5);
-        font-family: var(--terminal-font);
-        z-index: 2;
-    }
+body.deepsea-theme #bitcoin-logo::before {
+  content: "v.21";
+  position: absolute;
+  bottom: 0;
+  right: 10px;
+  color: var(--deepsea-color);
+  font-size: 16px;
+  text-shadow: 0 0 5px rgba(var(--deepsea-rgb), 0.5);
+  font-family: var(--terminal-font);
+  z-index: 2;
+}
 
 body.deepsea-theme #config-form {
-    border: 1px solid var(--deepsea-color);
-    box-shadow: 0 0 10px rgba(var(--deepsea-rgb), 0.5);
+  border: 1px solid var(--deepsea-color);
+  box-shadow: 0 0 10px rgba(var(--deepsea-rgb), 0.5);
 }
 
 body.deepsea-theme .config-title {
-    color: var(--deepsea-color);
+  color: var(--deepsea-color);
 }
 
 body.deepsea-theme .form-group label {
-    color: var(--deepsea-color);
+  color: var(--deepsea-color);
 }
 
 body.deepsea-theme .form-group input,
 body.deepsea-theme .form-group select {
-    border: 1px solid var(--deepsea-color);
+  border: 1px solid var(--deepsea-color);
 }
 
-    body.deepsea-theme .form-group input:focus,
-    body.deepsea-theme .form-group select:focus {
-        box-shadow: 0 0 5px var(--deepsea-color);
-    }
+body.deepsea-theme .form-group input:focus,
+body.deepsea-theme .form-group select:focus {
+  box-shadow: 0 0 5px var(--deepsea-color);
+}
 
 body.deepsea-theme .btn {
-    background-color: var(--deepsea-color);
+  background-color: var(--deepsea-color);
 }
 
-    body.deepsea-theme .btn:hover {
-        background-color: #00b3ff;
-    }
+body.deepsea-theme .btn:hover {
+  background-color: #00b3ff;
+}
 
 body.deepsea-theme .btn-secondary {
-    background-color: #333;
-    color: var(--deepsea-color);
+  background-color: #333;
+  color: var(--deepsea-color);
 }
 
 body.deepsea-theme .tooltip .tooltip-text {
-    border: 1px solid var(--deepsea-color);
+  border: 1px solid var(--deepsea-color);
 }
 
 body.deepsea-theme .form-group select {
-    background-image: linear-gradient(45deg, transparent 50%, var(--deepsea-color) 50%), linear-gradient(135deg, var(--deepsea-color) 50%, transparent 50%);
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--deepsea-color) 50%),
+    linear-gradient(135deg, var(--deepsea-color) 50%, transparent 50%);
 }
 
 body.deepsea-theme #skip-button {
-    background-color: var(--deepsea-color);
-    box-shadow: 0 0 8px rgba(var(--deepsea-rgb), 0.5);
+  background-color: var(--deepsea-color);
+  box-shadow: 0 0 8px rgba(var(--deepsea-rgb), 0.5);
 }
 
-    body.deepsea-theme #skip-button:hover {
-        background-color: #00b3ff;
-        box-shadow: 0 0 12px rgba(var(--deepsea-rgb), 0.7);
-    }
+body.deepsea-theme #skip-button:hover {
+  background-color: #00b3ff;
+  box-shadow: 0 0 12px rgba(var(--deepsea-rgb), 0.7);
+}
 
 /* ----- UNDERWATER EFFECTS ----- */
 /* Ocean Wave Ripple Effect */
 body.deepsea-theme::after {
-    content: "";
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-    background: transparent;
-    opacity: 0.1;
-    z-index: 10;
-    animation: oceanRipple 8s infinite linear;
-    background-image: repeating-linear-gradient( 0deg, rgba(var(--deepsea-rgb), 0.1), rgba(var(--deepsea-rgb), 0.1) 1px, transparent 1px, transparent 6px );
-    background-size: 100% 6px;
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  background: transparent;
+  opacity: 0.1;
+  z-index: 10;
+  animation: oceanRipple 8s infinite linear;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(var(--deepsea-rgb), 0.1),
+    rgba(var(--deepsea-rgb), 0.1) 1px,
+    transparent 1px,
+    transparent 6px
+  );
+  background-size: 100% 6px;
 }
 
 /* Retro glitch effect */
 body.deepsea-theme::before {
-    content: "";
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-    z-index: 3;
-    opacity: 0.15;
-    background-image: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 73, 109, 0.1) 50%), linear-gradient(90deg, rgba(0, 81, 122, 0.03), rgba(0, 136, 204, 0.08), rgba(0, 191, 255, 0.03));
-    background-size: 100% 2px, 3px 100%;
-    animation: glitchEffect 2s infinite;
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  z-index: 3;
+  opacity: 0.15;
+  background-image:
+    linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 73, 109, 0.1) 50%),
+    linear-gradient(
+      90deg,
+      rgba(0, 81, 122, 0.03),
+      rgba(0, 136, 204, 0.08),
+      rgba(0, 191, 255, 0.03)
+    );
+  background-size:
+    100% 2px,
+    3px 100%;
+  animation: glitchEffect 2s infinite;
 }
 
 /* Deep underwater light rays */
 body.deepsea-theme {
-    position: relative;
-    overflow: hidden;
+  position: relative;
+  overflow: hidden;
 }
 
-    body.deepsea-theme .underwater-rays {
-        position: fixed;
-        top: -50%;
-        left: -50%;
-        right: -50%;
-        bottom: -50%;
-        width: 200%;
-        height: 200%;
-        background: rgba(0, 0, 0, 0);
-        pointer-events: none;
-        z-index: -1;
-        background-image: radial-gradient(ellipse at top, rgba(var(--deepsea-rgb), 0.1) 0%, rgba(var(--deepsea-rgb), 0) 70%), radial-gradient(ellipse at bottom, rgba(0, 91, 138, 0.15) 0%, rgba(0, 0, 0, 0) 70%);
-        animation: lightRays 15s ease infinite alternate;
-    }
+body.deepsea-theme .underwater-rays {
+  position: fixed;
+  top: -50%;
+  left: -50%;
+  right: -50%;
+  bottom: -50%;
+  width: 200%;
+  height: 200%;
+  background: rgba(0, 0, 0, 0);
+  pointer-events: none;
+  z-index: -1;
+  background-image:
+    radial-gradient(
+      ellipse at top,
+      rgba(var(--deepsea-rgb), 0.1) 0%,
+      rgba(var(--deepsea-rgb), 0) 70%
+    ),
+    radial-gradient(
+      ellipse at bottom,
+      rgba(0, 91, 138, 0.15) 0%,
+      rgba(0, 0, 0, 0) 70%
+    );
+  animation: lightRays 15s ease infinite alternate;
+}
 
-    /* Subtle digital noise texture */
-    body.deepsea-theme .digital-noise {
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH4woEFQwNDaabTQAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACASURBVGje7dixDcIwFEbhb8QMKWn5dwEWY4fswAasRJkBkhfAIarsNDEF5x5LrV/dJ1cEAAAAAOzHuefF5byzZ7tS6xDj6qoQpdRxUvNM6lH3rPeM1+ZJ3ROtqe9feGcjY8z74M8UvJGxEVHxTcIbGSsR+SECAAAAsC9/8G82GwHDD80AAAAASUVORK5CYII=');
-        opacity: 0.05;
-        z-index: 2;
-        pointer-events: none;
-        animation: noise 0.5s steps(5) infinite;
-    }
+/* Subtle digital noise texture */
+body.deepsea-theme .digital-noise {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH4woEFQwNDaabTQAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACASURBVGje7dixDcIwFEbhb8QMKWn5dwEWY4fswAasRJkBkhfAIarsNDEF5x5LrV/dJ1cEAAAAAOzHuefF5byzZ7tS6xDj6qoQpdRxUvNM6lH3rPeM1+ZJ3ROtqe9feGcjY8z74M8UvJGxEVHxTcIbGSsR+SECAAAAsC9/8G82GwHDD80AAAAASUVORK5CYII=");
+  opacity: 0.05;
+  z-index: 2;
+  pointer-events: none;
+  animation: noise 0.5s steps(5) infinite;
+}
 
 /* ----- ANIMATIONS ----- */
 /* Flicker Animation */
 @keyframes flicker {
-    0% {
-        opacity: 0.97;
-    }
+  0% {
+    opacity: 0.97;
+  }
 
-    5% {
-        opacity: 0.95;
-    }
+  5% {
+    opacity: 0.95;
+  }
 
-    10% {
-        opacity: 0.97;
-    }
+  10% {
+    opacity: 0.97;
+  }
 
-    15% {
-        opacity: 0.94;
-    }
+  15% {
+    opacity: 0.94;
+  }
 
-    20% {
-        opacity: 0.98;
-    }
+  20% {
+    opacity: 0.98;
+  }
 
-    50% {
-        opacity: 0.95;
-    }
+  50% {
+    opacity: 0.95;
+  }
 
-    80% {
-        opacity: 0.96;
-    }
+  80% {
+    opacity: 0.96;
+  }
 
-    90% {
-        opacity: 0.94;
-    }
+  90% {
+    opacity: 0.94;
+  }
 
-    100% {
-        opacity: 0.98;
-    }
+  100% {
+    opacity: 0.98;
+  }
 }
 
 /* Blink Animation for cursors */
 @keyframes blink {
-    0%, 100% {
-        opacity: 1;
-    }
+  0%,
+  100% {
+    opacity: 1;
+  }
 
-    50% {
-        opacity: 0;
-    }
+  50% {
+    opacity: 0;
+  }
 }
 
 /* Ocean waves animation */
 @keyframes oceanRipple {
-    0% {
-        transform: translateY(0);
-    }
+  0% {
+    transform: translateY(0);
+  }
 
-    100% {
-        transform: translateY(6px);
-    }
+  100% {
+    transform: translateY(6px);
+  }
 }
 
 /* Glitch animation */
 @keyframes glitchEffect {
-    0% {
-        opacity: 0.15;
-        background-position: 0 0;
-    }
+  0% {
+    opacity: 0.15;
+    background-position: 0 0;
+  }
 
-    20% {
-        opacity: 0.17;
-    }
+  20% {
+    opacity: 0.17;
+  }
 
-    40% {
-        opacity: 0.14;
-        background-position: -1px 0;
-    }
+  40% {
+    opacity: 0.14;
+    background-position: -1px 0;
+  }
 
-    60% {
-        opacity: 0.15;
-        background-position: 1px 0;
-    }
+  60% {
+    opacity: 0.15;
+    background-position: 1px 0;
+  }
 
-    80% {
-        opacity: 0.16;
-        background-position: -2px 0;
-    }
+  80% {
+    opacity: 0.16;
+    background-position: -2px 0;
+  }
 
-    100% {
-        opacity: 0.15;
-        background-position: 0 0;
-    }
+  100% {
+    opacity: 0.15;
+    background-position: 0 0;
+  }
 }
 
 /* Light ray animation */
 @keyframes lightRays {
-    0% {
-        transform: scale(1) skew(0deg);
-        opacity: 0.3;
-    }
+  0% {
+    transform: scale(1) skew(0deg);
+    opacity: 0.3;
+  }
 
-    50% {
-        transform: scale(1.05) skew(2deg);
-        opacity: 0.4;
-    }
+  50% {
+    transform: scale(1.05) skew(2deg);
+    opacity: 0.4;
+  }
 
-    100% {
-        transform: scale(1.1) skew(0deg);
-        opacity: 0.3;
-    }
+  100% {
+    transform: scale(1.1) skew(0deg);
+    opacity: 0.3;
+  }
 }
 
 /* Noise animation */
 @keyframes noise {
-    0% {
-        transform: translate(0, 0);
-    }
+  0% {
+    transform: translate(0, 0);
+  }
 
-    20% {
-        transform: translate(-1px, 1px);
-    }
+  20% {
+    transform: translate(-1px, 1px);
+  }
 
-    40% {
-        transform: translate(1px, -1px);
-    }
+  40% {
+    transform: translate(1px, -1px);
+  }
 
-    60% {
-        transform: translate(-2px, -1px);
-    }
+  60% {
+    transform: translate(-2px, -1px);
+  }
 
-    80% {
-        transform: translate(2px, 1px);
-    }
+  80% {
+    transform: translate(2px, 1px);
+  }
 
-    100% {
-        transform: translate(0, 0);
-    }
+  100% {
+    transform: translate(0, 0);
+  }
 }
 
 /* ----- RESPONSIVE STYLES ----- */
 @media (max-width: 768px) {
-    #skip-button {
-        bottom: 25px;
-        right: 10px;
-        padding: 10px 18px;
-        font-size: 18px;
-        height: 40px;
-        z-index: 50;
-        min-width: 100px;
-        /* Make button easier to tap */
-    }
+  #skip-button {
+    bottom: 25px;
+    right: 10px;
+    padding: 10px 18px;
+    font-size: 18px;
+    height: 40px;
+    z-index: 50;
+    min-width: 100px;
+    /* Make button easier to tap */
+  }
 
-    #bitcoin-logo {
-        transform: scale(0.9);
-    }
+  #bitcoin-logo {
+    transform: scale(0.9);
+  }
 
-    #config-form {
-        width: 95%;
-        max-width: 100%;
-        padding: 12px;
-        margin: 20px auto;
-        font-size: 16px;
-    }
+  #config-form {
+    width: 95%;
+    max-width: 100%;
+    padding: 12px;
+    margin: 20px auto;
+    font-size: 16px;
+  }
 
-    .form-group input,
-    .form-group select {
-        font-size: 16px;
-        padding: 10px;
-    }
+  .form-group input,
+  .form-group select {
+    font-size: 16px;
+    padding: 10px;
+  }
 
-    .btn, .btn-secondary {
-        font-size: 16px;
-        padding: 10px 12px;
-        min-width: 90px;
-    }
+  .btn,
+  .btn-secondary {
+    font-size: 16px;
+    padding: 10px 12px;
+    min-width: 90px;
+  }
 
-    .form-actions {
-        flex-direction: column;
-        gap: 10px;
-    }
+  .form-actions {
+    flex-direction: column;
+    gap: 10px;
+  }
 }
 
 @media (max-width: 600px) {
-    body {
-        font-size: 14px;
-        padding: 5px;
-    }
+  body {
+    font-size: 14px;
+    padding: 5px;
+  }
 
-    #terminal {
-        margin: 0;
-    }
+  #terminal {
+    margin: 0;
+  }
 
-    #bitcoin-logo {
-        transform: scale(0.8);
-        width: 100%;
-        padding: 5px;
-    }
+  #bitcoin-logo {
+    transform: scale(0.8);
+    width: 100%;
+    padding: 5px;
+  }
 
-    #config-form {
-        width: 90%;
-        max-width: 100%;
-        padding: 8px;
-        margin: 10px auto;
-        font-size: 14px;
-    }
+  #config-form {
+    width: 90%;
+    max-width: 100%;
+    padding: 8px;
+    margin: 10px auto;
+    font-size: 14px;
+  }
 
-    .form-group input,
-    .form-group select {
-        font-size: 14px;
-        padding: 8px;
-    }
+  .form-group input,
+  .form-group select {
+    font-size: 14px;
+    padding: 8px;
+  }
 
-    .btn, .btn-secondary {
-        font-size: 14px;
-        padding: 8px 10px;
-        min-width: 80px;
-    }
+  .btn,
+  .btn-secondary {
+    font-size: 14px;
+    padding: 8px 10px;
+    min-width: 80px;
+  }
 
-    .form-actions {
-        flex-direction: column;
-        gap: 8px;
-    }
+  .form-actions {
+    flex-direction: column;
+    gap: 8px;
+  }
 
-    #skip-button {
-        bottom: 10px;
-        right: 5px;
-        padding: 12px 20px;
-        font-size: 18px;
-        min-width: 110px;
-        width: auto;
-        height: 44px;
-        border-radius: 8px;
-    }
+  #skip-button {
+    bottom: 10px;
+    right: 5px;
+    padding: 12px 20px;
+    font-size: 18px;
+    min-width: 110px;
+    width: auto;
+    height: 44px;
+    border-radius: 8px;
+  }
 }

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -5,1134 +5,1226 @@
 
 /* ----- ROOT VARIABLES & THEME SETTINGS ----- */
 :root {
-    --bg-color: #0a0a0a;
-    --bg-gradient: linear-gradient(135deg, #0a0a0a, #1a1a1a);
-    --primary-color: #f7931a;
-    --primary-color-rgb: 247, 147, 26;
-    --accent-color: #00ffff;
-    --text-color: #ffffff;
-    --card-padding: 0.5rem;
-    --text-size-base: 16px;
-    --terminal-font: 'VT323', monospace;
-    --header-font: 'Orbitron', sans-serif;
-    --text-transform: uppercase;
+  --bg-color: #0a0a0a;
+  --bg-gradient: linear-gradient(135deg, #0a0a0a, #1a1a1a);
+  --primary-color: #f7931a;
+  --primary-color-rgb: 247, 147, 26;
+  --accent-color: #00ffff;
+  --text-color: #ffffff;
+  --card-padding: 0.5rem;
+  --text-size-base: 16px;
+  --terminal-font: "VT323", monospace;
+  --header-font: "Orbitron", sans-serif;
+  --text-transform: uppercase;
 }
 
 /* Theme-specific colors */
 html.bitcoin-theme {
-    background-color: #111111;
+  background-color: #111111;
 }
 
 html.deepsea-theme {
-    background-color: #0c141a;
+  background-color: #0c141a;
 }
 
 @media (min-width: 768px) {
-    :root {
-        --card-padding: 0.75rem;
-        --text-size-base: 18px;
-    }
+  :root {
+    --card-padding: 0.75rem;
+    --text-size-base: 18px;
+  }
 
-    h1 {
-        font-size: 26px;
-    }
+  h1 {
+    font-size: 26px;
+  }
 }
 
 /* ----- THEME LOADER ----- */
 #theme-loader {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
-    font-family: var(--terminal-font);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  font-family: var(--terminal-font);
 }
 
 html.bitcoin-theme #theme-loader {
-    background-color: #111111;
-    color: #f2a900;
+  background-color: #111111;
+  color: #f2a900;
 }
 
 html.deepsea-theme #theme-loader {
-    background-color: #0c141a;
-    color: #0088cc;
+  background-color: #0c141a;
+  color: #0088cc;
 }
 
 #loader-icon {
-    font-size: 48px;
-    margin-bottom: 20px;
-    animation: spin 2s infinite linear;
+  font-size: 48px;
+  margin-bottom: 20px;
+  animation: spin 2s infinite linear;
 }
 
 #loader-text {
-    font-size: 24px;
-    text-transform: uppercase;
+  font-size: 24px;
+  text-transform: uppercase;
 }
 
 /* Hide content during load */
 body {
-    visibility: hidden;
+  visibility: hidden;
 }
 
 /* ----- BASE ANIMATIONS ----- */
 @keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
+  0% {
+    transform: rotate(0deg);
+  }
 
-    100% {
-        transform: rotate(360deg);
-    }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes flicker {
-    0% {
-        opacity: 0.97;
-    }
+  0% {
+    opacity: 0.97;
+  }
 
-    5% {
-        opacity: 0.95;
-    }
+  5% {
+    opacity: 0.95;
+  }
 
-    10% {
-        opacity: 0.97;
-    }
+  10% {
+    opacity: 0.97;
+  }
 
-    15% {
-        opacity: 0.94;
-    }
+  15% {
+    opacity: 0.94;
+  }
 
-    20% {
-        opacity: 0.98;
-    }
+  20% {
+    opacity: 0.98;
+  }
 
-    50% {
-        opacity: 0.95;
-    }
+  50% {
+    opacity: 0.95;
+  }
 
-    80% {
-        opacity: 0.96;
-    }
+  80% {
+    opacity: 0.96;
+  }
 
-    90% {
-        opacity: 0.94;
-    }
+  90% {
+    opacity: 0.94;
+  }
 
-    100% {
-        opacity: 0.98;
-    }
+  100% {
+    opacity: 0.98;
+  }
 }
 
 @keyframes blink {
-    0%, 100% {
-        opacity: 1;
-    }
+  0%,
+  100% {
+    opacity: 1;
+  }
 
-    50% {
-        opacity: 0;
-    }
+  50% {
+    opacity: 0;
+  }
 }
 
 @keyframes pulse {
-    0%, 100% {
-        opacity: 1;
-    }
+  0%,
+  100% {
+    opacity: 1;
+  }
 
-    50% {
-        opacity: 0.8;
-    }
+  50% {
+    opacity: 0.8;
+  }
 }
 
 @keyframes shimmer {
-    0% {
-        transform: translateX(-100%);
-    }
+  0% {
+    transform: translateX(-100%);
+  }
 
-    100% {
-        transform: translateX(100%);
-    }
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 @keyframes subtle-pulse {
-    0%, 100% {
-        box-shadow: 0 0 12px rgba(var(--primary-color-rgb), 0.6);
-    }
+  0%,
+  100% {
+    box-shadow: 0 0 12px rgba(var(--primary-color-rgb), 0.6);
+  }
 
-    50% {
-        box-shadow: 0 0 20px rgba(var(--primary-color-rgb), 0.8);
-    }
+  50% {
+    box-shadow: 0 0 20px rgba(var(--primary-color-rgb), 0.8);
+  }
 }
 
 @keyframes waitingPulse {
-    0%, 100% {
-        box-shadow: 0 0 10px var(--primary-color), 0 0 15px var(--primary-color);
-        opacity: 0.8;
-    }
+  0%,
+  100% {
+    box-shadow:
+      0 0 10px var(--primary-color),
+      0 0 15px var(--primary-color);
+    opacity: 0.8;
+  }
 
-    50% {
-        box-shadow: 0 0 20px var(--primary-color), 0 0 35px var(--primary-color);
-        opacity: 1;
-    }
+  50% {
+    box-shadow:
+      0 0 20px var(--primary-color),
+      0 0 35px var(--primary-color);
+    opacity: 1;
+  }
 }
 
 /* ----- ENHANCED DEEPSEA UNDERWATER EFFECTS ----- */
 
 /* Deep ocean background for DeepSea theme */
 html.deepsea-theme {
-    background-color: #030c14;
+  background-color: #030c14;
 }
 
-    html.deepsea-theme body {
-        background: linear-gradient(135deg, #030c14 0%, #071a30 100%);
-        background-size: 400% 400%;
-        animation: water-movement 30s ease infinite;
-    }
+html.deepsea-theme body {
+  background: linear-gradient(135deg, #030c14 0%, #071a30 100%);
+  background-size: 400% 400%;
+  animation: water-movement 30s ease infinite;
+}
 
 /* Deep water overlay for darker appearance */
 .deep-water-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: radial-gradient(circle at center, rgba(3, 12, 20, 0) 0%, rgba(1, 6, 12, 0.4) 100%);
-    pointer-events: none;
-    z-index: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(
+    circle at center,
+    rgba(3, 12, 20, 0) 0%,
+    rgba(1, 6, 12, 0.4) 100%
+  );
+  pointer-events: none;
+  z-index: 0;
 }
 
 /* Enhanced underwater light rays effect */
 .underwater-rays {
-    position: fixed;
-    top: -50%;
-    left: -50%;
-    right: -50%;
-    bottom: -50%;
-    width: 200%;
-    height: 200%;
-    background: rgba(0, 0, 0, 0);
-    pointer-events: none;
-    z-index: -1;
-    background-image: radial-gradient(ellipse at top, rgba(0, 136, 204, 0.1) 0%, rgba(0, 136, 204, 0) 70%), radial-gradient(ellipse at bottom, rgba(0, 91, 138, 0.15) 0%, rgba(0, 0, 0, 0) 70%);
-    animation: lightRays 15s ease infinite alternate;
+  position: fixed;
+  top: -50%;
+  left: -50%;
+  right: -50%;
+  bottom: -50%;
+  width: 200%;
+  height: 200%;
+  background: rgba(0, 0, 0, 0);
+  pointer-events: none;
+  z-index: -1;
+  background-image:
+    radial-gradient(
+      ellipse at top,
+      rgba(0, 136, 204, 0.1) 0%,
+      rgba(0, 136, 204, 0) 70%
+    ),
+    radial-gradient(
+      ellipse at bottom,
+      rgba(0, 91, 138, 0.15) 0%,
+      rgba(0, 0, 0, 0) 70%
+    );
+  animation: lightRays 15s ease infinite alternate;
 }
 
 /* Digital noise effect */
 .digital-noise {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH4woEFQwNDaabTQAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACASURBVGje7dixDcIwFEbhb8QMKWn5dwEWY4fswAasRJkBkhfAIarsNDEF5x5LrV/dJ1cEAAAAAOzHuefF5byzZ7tS6xDj6qoQpdRxUvNM6lH3rPeM1+ZJ3ROtqe9feGcjY8z74M8UvJGxEVHxTcIbGSsR+SECAAAAsC9/8G82GwHDD80AAAAASUVORK5CYII=');
-    opacity: 0.03;
-    z-index: 1;
-    pointer-events: none;
-    animation: noise 0.5s steps(5) infinite;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH4woEFQwNDaabTQAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAACASURBVGje7dixDcIwFEbhb8QMKWn5dwEWY4fswAasRJkBkhfAIarsNDEF5x5LrV/dJ1cEAAAAAOzHuefF5byzZ7tS6xDj6qoQpdRxUvNM6lH3rPeM1+ZJ3ROtqe9feGcjY8z74M8UvJGxEVHxTcIbGSsR+SECAAAAsC9/8G82GwHDD80AAAAASUVORK5CYII=");
+  opacity: 0.03;
+  z-index: 1;
+  pointer-events: none;
+  animation: noise 0.5s steps(5) infinite;
 }
 
 /* Bubble container and bubbles */
 .underwater-bubbles {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    pointer-events: none;
-    z-index: 1;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 1;
 }
 
 .bubble {
-    position: absolute;
-    bottom: -20px;
-    background: rgba(120, 205, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    border-radius: 50%;
-    box-shadow: 0 0 5px rgba(255, 255, 255, 0.025), inset 0 0 5px rgba(255, 255, 255, 0.025);
-    animation: bubble-rise linear infinite;
-    pointer-events: none;
+  position: absolute;
+  bottom: -20px;
+  background: rgba(120, 205, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 50%;
+  box-shadow:
+    0 0 5px rgba(255, 255, 255, 0.025),
+    inset 0 0 5px rgba(255, 255, 255, 0.025);
+  animation: bubble-rise linear infinite;
+  pointer-events: none;
 }
 
 /* Additional animations from boot.css */
 @keyframes lightRays {
-    0% {
-        transform: scale(1) skew(0deg);
-        opacity: 0.3;
-    }
+  0% {
+    transform: scale(1) skew(0deg);
+    opacity: 0.3;
+  }
 
-    50% {
-        transform: scale(1.05) skew(2deg);
-        opacity: 0.4;
-    }
+  50% {
+    transform: scale(1.05) skew(2deg);
+    opacity: 0.4;
+  }
 
-    100% {
-        transform: scale(1.1) skew(0deg);
-        opacity: 0.3;
-    }
+  100% {
+    transform: scale(1.1) skew(0deg);
+    opacity: 0.3;
+  }
 }
 
 @keyframes noise {
-    0% {
-        transform: translate(0, 0);
-    }
+  0% {
+    transform: translate(0, 0);
+  }
 
-    20% {
-        transform: translate(-1px, 1px);
-    }
+  20% {
+    transform: translate(-1px, 1px);
+  }
 
-    40% {
-        transform: translate(1px, -1px);
-    }
+  40% {
+    transform: translate(1px, -1px);
+  }
 
-    60% {
-        transform: translate(-2px, -1px);
-    }
+  60% {
+    transform: translate(-2px, -1px);
+  }
 
-    80% {
-        transform: translate(2px, 1px);
-    }
+  80% {
+    transform: translate(2px, 1px);
+  }
 
-    100% {
-        transform: translate(0, 0);
-    }
+  100% {
+    transform: translate(0, 0);
+  }
 }
 
 @keyframes oceanRipple {
-    0% {
-        transform: translateY(0);
-    }
+  0% {
+    transform: translateY(0);
+  }
 
-    100% {
-        transform: translateY(6px);
-    }
+  100% {
+    transform: translateY(6px);
+  }
 }
 
 /* Add ocean ripple effect similar to boot.css */
 html.deepsea-theme body::after {
-    content: "";
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-    background: transparent;
-    opacity: 0.1;
-    z-index: 1;
-    animation: oceanRipple 8s infinite linear;
-    background-image: repeating-linear-gradient( 0deg, rgba(0, 136, 204, 0.1), rgba(0, 136, 204, 0.1) 1px, transparent 1px, transparent 6px );
-    background-size: 100% 6px;
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  background: transparent;
+  opacity: 0.1;
+  z-index: 1;
+  animation: oceanRipple 8s infinite linear;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(0, 136, 204, 0.1),
+    rgba(0, 136, 204, 0.1) 1px,
+    transparent 1px,
+    transparent 6px
+  );
+  background-size: 100% 6px;
 }
 
 /* Modified CRT effect for DeepSea theme */
 html.deepsea-theme body::before {
-    content: "";
-    background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 73, 109, 0.1) 50%), linear-gradient(90deg, rgba(0, 81, 122, 0.03), rgba(0, 136, 204, 0.08), rgba(0, 191, 255, 0.03));
-    background-size: 100% 2px, 3px 100%;
-    animation: glitchEffect 2s infinite;
+  content: "";
+  background:
+    linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 73, 109, 0.1) 50%),
+    linear-gradient(
+      90deg,
+      rgba(0, 81, 122, 0.03),
+      rgba(0, 136, 204, 0.08),
+      rgba(0, 191, 255, 0.03)
+    );
+  background-size:
+    100% 2px,
+    3px 100%;
+  animation: glitchEffect 2s infinite;
 }
 
 @keyframes glitchEffect {
-    0% {
-        opacity: 0.15;
-        background-position: 0 0;
-    }
+  0% {
+    opacity: 0.15;
+    background-position: 0 0;
+  }
 
-    20% {
-        opacity: 0.17;
-    }
+  20% {
+    opacity: 0.17;
+  }
 
-    40% {
-        opacity: 0.14;
-        background-position: -1px 0;
-    }
+  40% {
+    opacity: 0.14;
+    background-position: -1px 0;
+  }
 
-    60% {
-        opacity: 0.15;
-        background-position: 1px 0;
-    }
+  60% {
+    opacity: 0.15;
+    background-position: 1px 0;
+  }
 
-    80% {
-        opacity: 0.16;
-        background-position: -2px 0;
-    }
+  80% {
+    opacity: 0.16;
+    background-position: -2px 0;
+  }
 
-    100% {
-        opacity: 0.15;
-        background-position: 0 0;
-    }
+  100% {
+    opacity: 0.15;
+    background-position: 0 0;
+  }
 }
 
 /* Add the bubble-rise animation that was missing */
 @keyframes bubble-rise {
-    0% {
-        transform: translateY(0) translateX(0) scale(1);
-        opacity: 0.8;
-    }
+  0% {
+    transform: translateY(0) translateX(0) scale(1);
+    opacity: 0.8;
+  }
 
-    50% {
-        opacity: 0.6;
-    }
+  50% {
+    opacity: 0.6;
+  }
 
-    100% {
-        transform: translateY(-100vh) translateX(var(--bubble-drift)) scale(0.7);
-        opacity: 0;
-    }
+  100% {
+    transform: translateY(-100vh) translateX(var(--bubble-drift)) scale(0.7);
+    opacity: 0;
+  }
 }
 
 /* Add this for subtle water movement in the background */
 @keyframes water-movement {
-    0% {
-        background-position: 0% 50%;
-    }
+  0% {
+    background-position: 0% 50%;
+  }
 
-    50% {
-        background-position: 100% 50%;
-    }
+  50% {
+    background-position: 100% 50%;
+  }
 
-    100% {
-        background-position: 0% 50%;
-    }
+  100% {
+    background-position: 0% 50%;
+  }
 }
 
 /* Theme-specific animations */
 @keyframes ocean-wave {
-    0% {
-        background-position: 0% 50%;
-    }
+  0% {
+    background-position: 0% 50%;
+  }
 
-    50% {
-        background-position: 100% 50%;
-    }
+  50% {
+    background-position: 100% 50%;
+  }
 
-    100% {
-        background-position: 0% 50%;
-    }
+  100% {
+    background-position: 0% 50%;
+  }
 }
 
 @keyframes glitch-offset {
-    0%, 100% {
-        transform: translate(0, 0);
-    }
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
 
-    25% {
-        transform: translate(-1px, 1px);
-    }
+  25% {
+    transform: translate(-1px, 1px);
+  }
 
-    50% {
-        transform: translate(1px, -1px);
-    }
+  50% {
+    transform: translate(1px, -1px);
+  }
 
-    75% {
-        transform: translate(-0.5px, 0.5px);
-    }
+  75% {
+    transform: translate(-0.5px, 0.5px);
+  }
 }
 
 /* ----- BASE STYLES ----- */
 body {
-    background: var(--bg-gradient);
-    color: var(--text-color);
-    padding-top: 0.5rem;
-    font-size: var(--text-size-base);
-    font-family: var(--terminal-font);
-    text-transform: uppercase;
+  background: var(--bg-gradient);
+  color: var(--text-color);
+  padding-top: 0.5rem;
+  font-size: var(--text-size-base);
+  font-family: var(--terminal-font);
+  text-transform: uppercase;
 }
 
-    /* CRT Screen Effect */
-    body::before {
-        content: " ";
-        display: block;
-        position: fixed;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        right: 0;
-        background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.1) 50%), linear-gradient(90deg, rgba(255, 0, 0, 0.03), rgba(0, 255, 0, 0.02), rgba(0, 0, 255, 0.03));
-        background-size: 100% 2px, 3px 100%;
-        pointer-events: none;
-        z-index: 2;
-        opacity: 0.15;
-    }
+/* CRT Screen Effect */
+body::before {
+  content: " ";
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background:
+    linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.1) 50%),
+    linear-gradient(
+      90deg,
+      rgba(255, 0, 0, 0.03),
+      rgba(0, 255, 0, 0.02),
+      rgba(0, 0, 255, 0.03)
+    );
+  background-size:
+    100% 2px,
+    3px 100%;
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0.15;
+}
 
 .container-fluid {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding-left: 1rem;
-    padding-right: 1rem;
-    position: relative;
-    padding-bottom: 6rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  position: relative;
+  padding-bottom: 6rem;
 }
 
 /* ----- HEADERS & TYPOGRAPHY ----- */
 h1 {
-    font-size: 24px;
-    font-weight: bold;
-    font-family: var(--header-font);
-    letter-spacing: 1px;
-    position: relative;
-    color: var(--primary-color);
-    overflow: hidden;
-    z-index: 1;
+  font-size: 24px;
+  font-weight: bold;
+  font-family: var(--header-font);
+  letter-spacing: 1px;
+  position: relative;
+  color: var(--primary-color);
+  overflow: hidden;
+  z-index: 1;
 }
 
 /* Bitcoin theme header styling */
 html.bitcoin-theme h1 {
-    text-shadow: 0 0 5px rgba(242, 169, 0, 0.5);
+  text-shadow: 0 0 5px rgba(242, 169, 0, 0.5);
 }
 
 /* DeepSea theme header styling */
 html.deepsea-theme h1 {
-    animation: ocean-wave 10s ease-in-out infinite;
+  animation: ocean-wave 10s ease-in-out infinite;
 }
 
-    html.deepsea-theme h1::before,
-    html.deepsea-theme h1::after {
-        content: attr(data-text);
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: linear-gradient(45deg, #0088cc, #00bfff, #0077be, #005f8b, #00bfff);
-        background-size: 300% 300%;
-        -webkit-background-clip: text;
-        background-clip: text;
-        color: transparent;
-        opacity: 0.7;
-        animation: ocean-wave 10s ease-in-out infinite, glitch-offset 3s infinite;
-        pointer-events: none;
-    }
+html.deepsea-theme h1::before,
+html.deepsea-theme h1::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    45deg,
+    #0088cc,
+    #00bfff,
+    #0077be,
+    #005f8b,
+    #00bfff
+  );
+  background-size: 300% 300%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  opacity: 0.7;
+  animation:
+    ocean-wave 10s ease-in-out infinite,
+    glitch-offset 3s infinite;
+  pointer-events: none;
+}
 
-    html.deepsea-theme h1::before {
-        left: 1px;
-        text-shadow: -1px 0 rgba(0, 255, 255, 0.4);
-        clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
-    }
+html.deepsea-theme h1::before {
+  left: 1px;
+  text-shadow: -1px 0 rgba(0, 255, 255, 0.4);
+  clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
+}
 
-    html.deepsea-theme h1::after {
-        left: -1px;
-        text-shadow: 1px 0 rgba(0, 0, 255, 0.4);
-        clip-path: polygon(0 50%, 100% 50%, 100% 100%, 0 100%);
-    }
+html.deepsea-theme h1::after {
+  left: -1px;
+  text-shadow: 1px 0 rgba(0, 0, 255, 0.4);
+  clip-path: polygon(0 50%, 100% 50%, 100% 100%, 0 100%);
+}
 
 /* ----- NAVIGATION ----- */
 .navigation-links {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 12px;
-    margin-top: 12px;
-    margin-bottom: 18px;
-    position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+  margin-bottom: 18px;
+  position: relative;
 }
 
 .nav-link {
-    padding: 6px 16px;
-    margin: 0;
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    text-decoration: none;
-    font-family: var(--terminal-font);
-    transition: all 0.3s ease;
-    position: relative;
-    overflow: hidden;
-    letter-spacing: 1px;
-    z-index: 1;
+  padding: 6px 16px;
+  margin: 0;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  text-decoration: none;
+  font-family: var(--terminal-font);
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+  letter-spacing: 1px;
+  z-index: 1;
 }
 
-    .nav-link::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: -1;
-    }
+.nav-link::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: -1;
+}
 
-    .nav-link:hover {
-        background-color: var(--primary-color);
-        color: var(--bg-color);
-        box-shadow: 0 0 12px rgba(var(--primary-color-rgb), 0.6);
-        transform: translateY(-1px);
-    }
+.nav-link:hover {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  box-shadow: 0 0 12px rgba(var(--primary-color-rgb), 0.6);
+  transform: translateY(-1px);
+}
 
-    .nav-link.active {
-        background-color: var(--primary-color);
-        color: var(--bg-color);
-        box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.7);
-        font-weight: bold;
-        animation: subtle-pulse 3s infinite;
-    }
+.nav-link.active {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.7);
+  font-weight: bold;
+  animation: subtle-pulse 3s infinite;
+}
 
 /* Navigation badges for notifications */
 .nav-badge {
-    background-color: var(--primary-color);
-    color: var(--bg-color);
-    border-radius: 10px;
-    font-size: 0.7rem;
-    padding: 1px 5px;
-    min-width: 16px;
-    text-align: center;
-    display: none;
-    margin-left: 5px;
-    vertical-align: middle;
-    font-weight: bold;
-    box-shadow: 0 0 4px var(--primary-color);
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  border-radius: 10px;
+  font-size: 0.7rem;
+  padding: 1px 5px;
+  min-width: 16px;
+  text-align: center;
+  display: none;
+  margin-left: 5px;
+  vertical-align: middle;
+  font-weight: bold;
+  box-shadow: 0 0 4px var(--primary-color);
 }
 
 /* ----- TOP RIGHT LINK ----- */
 #topRightLink {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    color: grey;
-    text-decoration: none;
-    font-size: 0.7rem;
-    padding: 5px 10px;
-    transition: background-color 0.3s ease;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  color: grey;
+  text-decoration: none;
+  font-size: 0.7rem;
+  padding: 5px 10px;
+  transition: background-color 0.3s ease;
 }
 
-    #topRightLink:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-    }
+#topRightLink:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
 
 /* ----- CARDS ----- */
 .card,
 .card-header,
 .card-body,
 .card-footer {
-    border-radius: 0 !important;
-    text-transform: uppercase;
+  border-radius: 0 !important;
+  text-transform: uppercase;
 }
 
 .card {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    margin-bottom: 0.5rem;
-    padding: var(--card-padding);
-    flex: 1;
-    position: relative;
-    overflow: hidden;
-    box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  margin-bottom: 0.5rem;
+  padding: var(--card-padding);
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
 }
 
-    .card::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+.card::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 .card-header {
-    background-color: #000;
-    color: var(--primary-color);
-    font-weight: bold;
-    padding: 0.3rem 0.5rem;
-    font-size: 1.1rem;
-    border-bottom: 1px solid var(--primary-color);
-    animation: flicker 4s infinite;
-    font-family: var(--header-font);
+  background-color: #000;
+  color: var(--primary-color);
+  font-weight: bold;
+  padding: 0.3rem 0.5rem;
+  font-size: 1.1rem;
+  border-bottom: 1px solid var(--primary-color);
+  animation: flicker 4s infinite;
+  font-family: var(--header-font);
 }
 
 .card-body hr {
-    border-top: 1px solid var(--primary-color);
-    margin: 0.25rem 0;
+  border-top: 1px solid var(--primary-color);
+  margin: 0.25rem 0;
 }
 
 /* ----- STATUS INDICATORS ----- */
 #connectionStatus {
-    display: none;
-    position: fixed;
-    top: 10px;
-    right: 10px;
-    background: rgba(255, 0, 0, 0.7);
-    color: white;
-    padding: 10px;
-    border-radius: 5px;
-    z-index: 9999;
-    font-size: 0.9rem;
-    box-shadow: 0 0 10px rgba(255, 0, 0, 0.5);
+  display: none;
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: rgba(255, 0, 0, 0.7);
+  color: white;
+  padding: 10px;
+  border-radius: 5px;
+  z-index: 9999;
+  font-size: 0.9rem;
+  box-shadow: 0 0 10px rgba(255, 0, 0, 0.5);
 }
 
 #lastUpdated {
-    color: var(--primary-color);
-    animation: flicker 5s infinite;
-    text-align: center;
+  color: var(--primary-color);
+  animation: flicker 5s infinite;
+  text-align: center;
 }
 
 /* Terminal cursor */
 #terminal-cursor {
-    display: inline-block;
-    width: 10px;
-    height: 16px;
-    background-color: var(--primary-color);
-    margin-left: 2px;
-    animation: blink 1s step-end infinite;
-    vertical-align: middle;
-    box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.8);
+  display: inline-block;
+  width: 10px;
+  height: 16px;
+  background-color: var(--primary-color);
+  margin-left: 2px;
+  animation: blink 1s step-end infinite;
+  vertical-align: middle;
+  box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.8);
 }
 
 /* Status dots */
 .online-dot {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    background: #32CD32;
-    border-radius: 50%;
-    margin-left: 0.5em;
-    position: relative;
-    top: -1px;
-    animation: pulse 2s infinite;
-    box-shadow: 0 0 10px #32CD32, 0 0 20px #32CD32;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: #32cd32;
+  border-radius: 50%;
+  margin-left: 0.5em;
+  position: relative;
+  top: -1px;
+  animation: pulse 2s infinite;
+  box-shadow:
+    0 0 10px #32cd32,
+    0 0 20px #32cd32;
 }
 
 .offline-dot {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    background: red;
-    border-radius: 50%;
-    margin-left: 0.5em;
-    position: relative;
-    top: -1px;
-    animation: pulse 2s infinite;
-    box-shadow: 0 0 10px red, 0 0 20px red !important;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: red;
+  border-radius: 50%;
+  margin-left: 0.5em;
+  position: relative;
+  top: -1px;
+  animation: pulse 2s infinite;
+  box-shadow:
+    0 0 10px red,
+    0 0 20px red !important;
 }
 
 /* ----- COLOR UTILITY CLASSES ----- */
-.green-glow, .status-green {
-    color: #39ff14 !important;
+.green-glow,
+.status-green {
+  color: #39ff14 !important;
 }
 
-.red-glow, .status-red {
-    color: #ff2d2d !important;
+.red-glow,
+.status-red {
+  color: #ff2d2d !important;
 }
 
 .yellow-glow {
-    color: #ffd700 !important;
+  color: #ffd700 !important;
 }
 
 .blue-glow {
-    color: #00dfff !important;
+  color: #00dfff !important;
 }
 
 .white-glow {
-    color: #ffffff !important;
+  color: #ffffff !important;
 }
 
 /* Legacy color classes */
 .green {
-    color: #39ff14 !important;
+  color: #39ff14 !important;
 }
 
 .blue {
-    color: #00dfff !important;
+  color: #00dfff !important;
 }
 
 .yellow {
-    color: #ffd700 !important;
+  color: #ffd700 !important;
 }
 
 .white {
-    color: #ffffff !important;
+  color: #ffffff !important;
 }
 
 .red {
-    color: #ff2d2d !important;
+  color: #ff2d2d !important;
 }
 
 .magenta {
-    color: #ff2d95 !important;
+  color: #ff2d95 !important;
 }
 
 /* ----- FOOTER ----- */
 .footer {
-    padding: 10px 0;
-    color: grey;
-    font-size: 0.9rem;
-    border-top: 1px solid rgba(128, 128, 128, 0.2);
+  padding: 10px 0;
+  color: grey;
+  font-size: 0.9rem;
+  border-top: 1px solid rgba(128, 128, 128, 0.2);
 }
 
 /* ----- PROGRESS BAR COMPONENTS ----- */
 .bitcoin-progress-container {
-    width: 100%;
-    max-width: 300px;
-    height: 20px;
-    background-color: #111;
-    border: 1px solid var(--primary-color);
-    border-radius: 0;
-    margin: 0.5rem auto;
-    position: relative;
-    overflow: hidden;
-    box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.5);
-    align-self: center;
+  width: 100%;
+  max-width: 300px;
+  height: 20px;
+  background-color: #111;
+  border: 1px solid var(--primary-color);
+  border-radius: 0;
+  margin: 0.5rem auto;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.5);
+  align-self: center;
 }
 
 .bitcoin-progress-inner {
-    height: 100%;
-    width: 0;
-    background: linear-gradient(90deg, var(--primary-color), #ffa500);
-    border-radius: 0;
-    transition: width 0.3s ease;
-    position: relative;
-    overflow: hidden;
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--primary-color), #ffa500);
+  border-radius: 0;
+  transition: width 0.3s ease;
+  position: relative;
+  overflow: hidden;
 }
 
-    .bitcoin-progress-inner::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: linear-gradient( 90deg, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.2) 20%, rgba(255, 255, 255, 0.1) 40% );
-        animation: shimmer 2s infinite;
-    }
+.bitcoin-progress-inner::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.1) 0%,
+    rgba(255, 255, 255, 0.2) 20%,
+    rgba(255, 255, 255, 0.1) 40%
+  );
+  animation: shimmer 2s infinite;
+}
 
 .bitcoin-icons {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    width: 100%;
-    transform: translateY(-50%);
-    display: flex;
-    justify-content: space-around;
-    font-size: 12px;
-    color: rgba(0, 0, 0, 0.7);
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  transform: translateY(-50%);
+  display: flex;
+  justify-content: space-around;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.7);
 }
 
 .glow-effect {
-    box-shadow: 0 0 15px var(--primary-color), 0 0 25px var(--primary-color);
-    animation: pulse 1s infinite;
+  box-shadow:
+    0 0 15px var(--primary-color),
+    0 0 25px var(--primary-color);
+  animation: pulse 1s infinite;
 }
 
 .waiting-for-update {
-    animation: waitingPulse 2s infinite !important;
+  animation: waitingPulse 2s infinite !important;
 }
 
 #progress-text {
-    font-size: 1rem;
-    color: var(--primary-color);
-    margin-top: 0.3rem;
-    text-align: center;
-    width: 100%;
+  font-size: 1rem;
+  color: var(--primary-color);
+  margin-top: 0.3rem;
+  text-align: center;
+  width: 100%;
 }
 
 /* ----- RESPONSIVE STYLES ----- */
 @media (max-width: 576px) {
-    .container-fluid {
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
-    }
+  .container-fluid {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
 
-    .card-body {
-        padding: 0.5rem;
-    }
+  .card-body {
+    padding: 0.5rem;
+  }
 
-    h1 {
-        font-size: 22px;
-    }
+  h1 {
+    font-size: 22px;
+  }
 
-    .card-header {
-        font-size: 1rem;
-    }
+  .card-header {
+    font-size: 1rem;
+  }
 
-    #topRightLink {
-        position: static;
-        display: block;
-        text-align: right;
-        margin-bottom: 0.5rem;
-    }
+  #topRightLink {
+    position: static;
+    display: block;
+    text-align: right;
+    margin-bottom: 0.5rem;
+  }
 
-    /* Navigation mobile optimization */
-    .navigation-links {
-        gap: 8px;
-        margin-top: 10px;
-        margin-bottom: 15px;
-    }
+  /* Navigation mobile optimization */
+  .navigation-links {
+    gap: 8px;
+    margin-top: 10px;
+    margin-bottom: 15px;
+  }
 
-    .nav-link {
-        font-size: 0.8rem;
-        padding: 5px 12px;
-        letter-spacing: 0.5px;
-    }
+  .nav-link {
+    font-size: 0.8rem;
+    padding: 5px 12px;
+    letter-spacing: 0.5px;
+  }
 
-        .nav-link:active {
-            transform: scale(0.97);
-        }
+  .nav-link:active {
+    transform: scale(0.97);
+  }
 
-    .nav-badge {
-        font-size: 0.65rem;
-        padding: 1px 4px;
-        min-width: 14px;
-        margin-left: 3px;
-        position: relative;
-        top: -1px;
-    }
+  .nav-badge {
+    font-size: 0.65rem;
+    padding: 1px 4px;
+    min-width: 14px;
+    margin-left: 3px;
+    position: relative;
+    top: -1px;
+  }
 }
 
 @media (max-width: 360px) {
-    .navigation-links {
-        justify-content: space-between;
-    }
+  .navigation-links {
+    justify-content: space-between;
+  }
 
-    .nav-link {
-        font-size: 0.75rem;
-        padding: 4px 8px;
-        flex: 1;
-        text-align: center;
-        letter-spacing: 0;
-    }
+  .nav-link {
+    font-size: 0.75rem;
+    padding: 4px 8px;
+    flex: 1;
+    text-align: center;
+    letter-spacing: 0;
+  }
 }
 
 /* Congratulations Message Styling */
 #congratsMessage {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: rgba(0, 0, 0, 0.85);
-    border: 2px solid var(--primary-color);
-    color: var(--primary-color);
-    padding: 15px 30px;
-    font-family: var(--terminal-font);
-    font-size: 1.2rem;
-    z-index: 9999;
-    text-align: center;
-    border-radius: 3px;
-    box-shadow: 0 0 20px rgba(var(--primary-color-rgb), 0.7);
-    animation: congratsAppear 0.5s ease-out;
-    cursor: pointer;
-    max-width: 80vw;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.85);
+  border: 2px solid var(--primary-color);
+  color: var(--primary-color);
+  padding: 15px 30px;
+  font-family: var(--terminal-font);
+  font-size: 1.2rem;
+  z-index: 9999;
+  text-align: center;
+  border-radius: 3px;
+  box-shadow: 0 0 20px rgba(var(--primary-color-rgb), 0.7);
+  animation: congratsAppear 0.5s ease-out;
+  cursor: pointer;
+  max-width: 80vw;
 }
 
-    #congratsMessage::before {
-        content: '';
-        position: absolute;
-        top: -2px;
-        left: -2px;
-        right: -2px;
-        bottom: -2px;
-        border: 1px solid var(--primary-color);
-        border-radius: 3px;
-        animation: pulseBorder 1.5s infinite;
-        z-index: -1;
-    }
+#congratsMessage::before {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: -2px;
+  right: -2px;
+  bottom: -2px;
+  border: 1px solid var(--primary-color);
+  border-radius: 3px;
+  animation: pulseBorder 1.5s infinite;
+  z-index: -1;
+}
 
 .congrats-text {
-    position: relative;
-    display: inline-block;
+  position: relative;
+  display: inline-block;
 }
 
 /* Theme-specific congrats styling */
 html.bitcoin-theme #congratsMessage {
-    box-shadow: 0 0 25px rgba(247, 147, 26, 0.6);
-    animation: congratsAppear 0.5s ease-out, orangePulse 2s infinite alternate;
+  box-shadow: 0 0 25px rgba(247, 147, 26, 0.6);
+  animation:
+    congratsAppear 0.5s ease-out,
+    orangePulse 2s infinite alternate;
 }
 
 html.deepsea-theme #congratsMessage {
-    box-shadow: 0 0 25px rgba(0, 136, 204, 0.6);
-    animation: congratsAppear 0.5s ease-out, bluePulse 2s infinite alternate;
+  box-shadow: 0 0 25px rgba(0, 136, 204, 0.6);
+  animation:
+    congratsAppear 0.5s ease-out,
+    bluePulse 2s infinite alternate;
 }
 
 /* Bubble container and bubbles for DeepSea theme */
 .congrats-bubbles {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-    pointer-events: none;
-    overflow: hidden;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  overflow: hidden;
 }
 
 .congrats-bubble {
-    position: absolute;
-    bottom: 0;
-    background: rgba(0, 191, 255, 0.15);
-    border: 1px solid rgba(0, 136, 204, 0.2);
-    border-radius: 50%;
-    box-shadow: 0 0 3px rgba(0, 191, 255, 0.3);
-    animation: bubbleRise 4s ease-in forwards;
+  position: absolute;
+  bottom: 0;
+  background: rgba(0, 191, 255, 0.15);
+  border: 1px solid rgba(0, 136, 204, 0.2);
+  border-radius: 50%;
+  box-shadow: 0 0 3px rgba(0, 191, 255, 0.3);
+  animation: bubbleRise 4s ease-in forwards;
 }
 
 /* Animations for congrats message */
 @keyframes congratsAppear {
-    0% {
-        opacity: 0;
-        transform: translate(-50%, -50%) scale(0.9);
-    }
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
 
-    100% {
-        opacity: 1;
-        transform: translate(-50%, -50%) scale(1);
-    }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
 }
 
 @keyframes pulseBorder {
-    0%, 100% {
-        opacity: 0.4;
-    }
+  0%,
+  100% {
+    opacity: 0.4;
+  }
 
-    50% {
-        opacity: 1;
-    }
+  50% {
+    opacity: 1;
+  }
 }
 
 @keyframes orangePulse {
-    0% {
-        text-shadow: 0 0 5px rgba(247, 147, 26, 0.7);
-    }
+  0% {
+    text-shadow: 0 0 5px rgba(247, 147, 26, 0.7);
+  }
 
-    100% {
-        text-shadow: 0 0 15px rgba(247, 147, 26, 0.9), 0 0 20px rgba(247, 147, 26, 0.5);
-    }
+  100% {
+    text-shadow:
+      0 0 15px rgba(247, 147, 26, 0.9),
+      0 0 20px rgba(247, 147, 26, 0.5);
+  }
 }
 
 @keyframes bluePulse {
-    0% {
-        text-shadow: 0 0 5px rgba(0, 136, 204, 0.7);
-    }
+  0% {
+    text-shadow: 0 0 5px rgba(0, 136, 204, 0.7);
+  }
 
-    100% {
-        text-shadow: 0 0 15px rgba(0, 191, 255, 0.9), 0 0 20px rgba(0, 136, 204, 0.5);
-    }
+  100% {
+    text-shadow:
+      0 0 15px rgba(0, 191, 255, 0.9),
+      0 0 20px rgba(0, 136, 204, 0.5);
+  }
 }
 
 @keyframes bubbleRise {
-    0% {
-        opacity: 0;
-        transform: translateY(0) translateX(0);
-    }
+  0% {
+    opacity: 0;
+    transform: translateY(0) translateX(0);
+  }
 
-    10% {
-        opacity: 0.8;
-    }
+  10% {
+    opacity: 0.8;
+  }
 
-    80% {
-        opacity: 0.6;
-    }
+  80% {
+    opacity: 0.6;
+  }
 
-    100% {
-        opacity: 0;
-        transform: translateY(-300px) translateX(calc(var(--drift, 0) * 40px));
-    }
+  100% {
+    opacity: 0;
+    transform: translateY(-300px) translateX(calc(var(--drift, 0) * 40px));
+  }
 }
 
 /* Responsive styling */
 @media (max-width: 768px) {
-    #congratsMessage {
-        font-size: 1rem;
-        padding: 12px 20px;
-        max-width: 90vw;
-    }
+  #congratsMessage {
+    font-size: 1rem;
+    padding: 12px 20px;
+    max-width: 90vw;
+  }
 }
 
 /* Mobile Navigation System - Updated with 600px breakpoint */
 .nav-container {
-    position: relative;
-    width: 100%;
-    margin-top: 12px;
+  position: relative;
+  width: 100%;
+  margin-top: 12px;
 }
 
 /* Wrapper for centering hamburger button */
 .mobile-nav-wrapper {
-    display: none;
-    text-align: center;
-    margin-bottom: 10px;
+  display: none;
+  text-align: center;
+  margin-bottom: 10px;
 }
 
 /* Hamburger button styling with theme compatibility */
 .mobile-nav-toggle {
-    display: inline-block;
-    background: black;
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    font-size: 1.25rem;
-    padding: 0.3rem 0.65rem;
-    cursor: pointer;
-    position: relative;
-    z-index: 1010;
-    border-radius: 0;
-    font-family: var(--terminal-font);
-    transition: all 0.3s ease;
-    box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
+  display: inline-block;
+  background: black;
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  font-size: 1.25rem;
+  padding: 0.3rem 0.65rem;
+  cursor: pointer;
+  position: relative;
+  z-index: 1010;
+  border-radius: 0;
+  font-family: var(--terminal-font);
+  transition: all 0.3s ease;
+  box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
 }
 
-    .mobile-nav-toggle:hover {
-        background-color: rgba(var(--primary-color-rgb), 0.1);
-    }
+.mobile-nav-toggle:hover {
+  background-color: rgba(var(--primary-color-rgb), 0.1);
+}
 
-    .mobile-nav-toggle:active {
-        transform: translateY(1px);
-    }
+.mobile-nav-toggle:active {
+  transform: translateY(1px);
+}
 
-    .mobile-nav-toggle:focus {
-        outline: none;
-    }
+.mobile-nav-toggle:focus {
+  outline: none;
+}
 
 /* Mobile navigation adjustments - Changed from 767px to 599px */
 @media (max-width: 599px) {
-    .mobile-nav-wrapper {
-        display: block;
-    }
+  .mobile-nav-wrapper {
+    display: block;
+  }
 
-    .navigation-links {
-        flex-direction: column;
-        max-height: 0;
-        overflow: hidden;
-        transition: max-height 0.3s ease-in-out;
-        width: 100%;
-        margin: 0;
-        padding: 0;
-        gap: 0;
-        background-color: var(--bg-color);
-        border-left: 1px solid var(--primary-color);
-        border-right: 1px solid var(--primary-color);
-        border-bottom: 1px solid var(--primary-color);
-        position: absolute;
-        z-index: 1000;
-        box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.3);
-    }
+  .navigation-links {
+    flex-direction: column;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease-in-out;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    gap: 0;
+    background-color: var(--bg-color);
+    border-left: 1px solid var(--primary-color);
+    border-right: 1px solid var(--primary-color);
+    border-bottom: 1px solid var(--primary-color);
+    position: absolute;
+    z-index: 1000;
+    box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.3);
+  }
 
-        .navigation-links.is-open {
-            max-height: 300px;
-        }
+  .navigation-links.is-open {
+    max-height: 300px;
+  }
 
-    .nav-link {
-        width: 100%;
-        margin: 0;
-        padding: 10px 16px;
-        border: none;
-        border-bottom: 1px solid rgba(var(--primary-color-rgb), 0.3);
-        text-align: center;
-    }
+  .nav-link {
+    width: 100%;
+    margin: 0;
+    padding: 10px 16px;
+    border: none;
+    border-bottom: 1px solid rgba(var(--primary-color-rgb), 0.3);
+    text-align: center;
+  }
 
-        .nav-link:last-child {
-            border-bottom: none;
-        }
+  .nav-link:last-child {
+    border-bottom: none;
+  }
 
-        .nav-link:hover {
-            transform: none;
-        }
+  .nav-link:hover {
+    transform: none;
+  }
 
-        .nav-link.active {
-            border-left: 3px solid var(--primary-color);
-            border-right: 3px solid var(--primary-color);
-        }
+  .nav-link.active {
+    border-left: 3px solid var(--primary-color);
+    border-right: 3px solid var(--primary-color);
+  }
 }

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -5,221 +5,239 @@
 
 /* ----- CHART & GRAPH COMPONENTS ----- */
 .chart-container-relative {
-    position: relative;
+  position: relative;
 }
 
 #graphContainer {
-    background-color: var(--bg-color);
-    padding: 0.5rem;
-    margin-bottom: 1rem;
-    height: 230px;
-    border: 1px solid var(--primary-color);
-    box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2);
-    position: relative;
+  background-color: var(--bg-color);
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  height: 230px;
+  border: 1px solid var(--primary-color);
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2);
+  position: relative;
 }
 
-    #graphContainer::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+#graphContainer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 /* Chart controls styling */
 .chart-controls {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    padding: 0 10px 15px 0;
-    font-family: var(--terminal-font);
-    gap: 8px;
-    margin-top: 5px;
-    position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 10px 15px 0;
+  font-family: var(--terminal-font);
+  gap: 8px;
+  margin-top: 5px;
+  position: relative;
 }
 
 .chart-controls-label {
-    font-size: 0.9rem;
-    color: var(--primary-color);
-    text-transform: uppercase;
-    font-weight: bold;
+  font-size: 0.9rem;
+  color: var(--primary-color);
+  text-transform: uppercase;
+  font-weight: bold;
 }
 
 .chart-points-toggle {
-    display: flex;
-    background-color: rgba(0, 0, 0, 0.3);
-    border-radius: 3px;
-    overflow: hidden;
-    border: 1px solid var(--primary-color);
-    box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
-    position: relative;
+  display: flex;
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 3px;
+  overflow: hidden;
+  border: 1px solid var(--primary-color);
+  box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
+  position: relative;
 }
 
-    .chart-points-toggle::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+.chart-points-toggle::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 .toggle-btn {
-    background: none;
-    color: var(--primary-color);
-    border: none;
-    padding: 5px 12px;
-    font-size: 0.9rem;
-    font-family: var(--terminal-font);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    min-width: 40px;
-    position: relative;
-    z-index: 2;
+  background: none;
+  color: var(--primary-color);
+  border: none;
+  padding: 5px 12px;
+  font-size: 0.9rem;
+  font-family: var(--terminal-font);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 40px;
+  position: relative;
+  z-index: 2;
 }
 
-    .toggle-btn:not(:last-child) {
-        border-right: 1px solid var(--primary-color);
-    }
+.toggle-btn:not(:last-child) {
+  border-right: 1px solid var(--primary-color);
+}
 
-    .toggle-btn:hover:not(.active) {
-        background-color: rgba(var(--primary-color-rgb), 0.15);
-    }
+.toggle-btn:hover:not(.active) {
+  background-color: rgba(var(--primary-color-rgb), 0.15);
+}
 
-    .toggle-btn.active {
-        background-color: var(--primary-color);
-        font-weight: bold;
-        animation: subtle-pulse 3s infinite;
-        position: relative;
-    }
+.toggle-btn.active {
+  background-color: var(--primary-color);
+  font-weight: bold;
+  animation: subtle-pulse 3s infinite;
+  position: relative;
+}
 
 /* Theme-specific button text color */
 html.bitcoin-theme .toggle-btn.active {
-    color: #000 !important;
+  color: #000 !important;
 }
 
 html.deepsea-theme .toggle-btn.active {
-    color: #ffffff !important;
+  color: #ffffff !important;
 }
 
 /* Button effects */
 .toggle-btn.active::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 2px );
-    pointer-events: none;
-    z-index: 3;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 3;
 }
 
 .toggle-btn.active::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    box-shadow: 0 0 6px var(--primary-color);
-    opacity: 0.7;
-    pointer-events: none;
-    animation: subtle-glow 3s infinite;
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  box-shadow: 0 0 6px var(--primary-color);
+  opacity: 0.7;
+  pointer-events: none;
+  animation: subtle-glow 3s infinite;
 }
 
 /* ----- LAYOUT & STRUCTURE ----- */
 .row.equal-height {
-    display: flex;
-    flex-wrap: wrap;
-    margin-bottom: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
 }
 
-    .row.equal-height > [class*="col-"] {
-        display: flex;
-        margin-bottom: 0.5rem;
-    }
+.row.equal-height > [class*="col-"] {
+  display: flex;
+  margin-bottom: 0.5rem;
+}
 
-        .row.equal-height > [class*="col-"] .card {
-            width: 100%;
-        }
+.row.equal-height > [class*="col-"] .card {
+  width: 100%;
+}
 
 #payoutMiscCard {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 /* ----- INDICATORS & STATUS ELEMENTS ----- */
 .arrow {
-    display: inline-block;
-    font-weight: bold;
-    margin-left: 0.5rem;
+  display: inline-block;
+  font-weight: bold;
+  margin-left: 0.5rem;
 }
 
 .chevron {
-    font-size: 0.8rem;
-    position: relative;
+  font-size: 0.8rem;
+  position: relative;
 }
 
 .bounce-up {
-    animation: bounceUp 1s infinite;
+  animation: bounceUp 1s infinite;
 }
 
 .bounce-down {
-    animation: bounceDown 1s infinite;
+  animation: bounceDown 1s infinite;
 }
 
 /* ----- SPECIAL INDICATORS ----- */
 /* Pool luck indicators */
 .very-lucky {
-    color: #32CD32 !important;
-    font-weight: bold !important;
+  color: #32cd32 !important;
+  font-weight: bold !important;
 }
 
 .lucky {
-    color: #90EE90 !important;
+  color: #90ee90 !important;
 }
 
 .normal-luck {
-    color: #ffd700 !important;
+  color: #ffd700 !important;
 }
 
 .unlucky {
-    color: #ff5555 !important;
+  color: #ff5555 !important;
 }
 
 /* ----- REFRESH & UPTIME ELEMENTS ----- */
 #refreshUptime {
-    text-align: center;
-    margin-top: 0.5rem;
+  text-align: center;
+  margin-top: 0.5rem;
 }
 
 #refreshContainer {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
 }
 
 #uptimeTimer {
-    margin-top: 0;
+  margin-top: 0;
 }
 
-    #uptimeTimer strong {
-        font-weight: bold;
-    }
+#uptimeTimer strong {
+  font-weight: bold;
+}
 
 /* ----- METRIC COLOR STYLING ----- */
 .metric-value {
-    color: var(--text-color);
-    font-weight: bold;
+  color: var(--text-color);
+  font-weight: bold;
 }
 
 /* Yellow color family */
@@ -230,7 +248,7 @@ html.deepsea-theme .toggle-btn.active {
 #estimated_earnings_next_block_sats,
 #estimated_rewards_in_window_sats,
 #est_time_to_payout {
-    color: #ffd700;
+  color: #ffd700;
 }
 
 /* Green color family */
@@ -238,13 +256,13 @@ html.deepsea-theme .toggle-btn.active {
 #daily_revenue,
 #daily_profit_usd,
 #monthly_profit_usd {
-    color: #32CD32;
+  color: #32cd32;
 }
 
 /* Red color family */
 #daily_power_cost,
 #pool_fees_sats {
-    color: #ff5555 !important;
+  color: #ff5555 !important;
 }
 
 /* White metrics */
@@ -257,453 +275,505 @@ html.deepsea-theme .toggle-btn.active {
 #blocks_found,
 #last_block_height,
 #pool_fees_percentage {
-    color: #ffffff;
+  color: #ffffff;
 }
 
 /* Blue metrics */
 #last_block_time {
-    color: #00dfff;
+  color: #00dfff;
 }
 
 /* ----- CARD CONTENT STYLING ----- */
 .card-body strong {
-    color: var(--primary-color);
-    margin-right: 0.25rem;
+  color: var(--primary-color);
+  margin-right: 0.25rem;
 }
 
 .card-body p {
-    margin: 0.25rem 0;
-    line-height: 1.2;
+  margin: 0.25rem 0;
+  line-height: 1.2;
 }
 
 /* ----- ANIMATIONS ----- */
 @keyframes bounceUp {
-    0%, 50%, 100% {
-        transform: translateY(0);
-    }
+  0%,
+  50%,
+  100% {
+    transform: translateY(0);
+  }
 
-    25%, 75% {
-        transform: translateY(-2px);
-    }
+  25%,
+  75% {
+    transform: translateY(-2px);
+  }
 }
 
 @keyframes bounceDown {
-    0%, 50%, 100% {
-        transform: translateY(0);
-    }
+  0%,
+  50%,
+  100% {
+    transform: translateY(0);
+  }
 
-    25%, 75% {
-        transform: translateY(2px);
-    }
+  25%,
+  75% {
+    transform: translateY(2px);
+  }
 }
 
 @keyframes pulse-block-marker {
-    0% {
-        transform: translate(-50%, -50%) rotate(45deg) scale(1);
-        opacity: 1;
-    }
+  0% {
+    transform: translate(-50%, -50%) rotate(45deg) scale(1);
+    opacity: 1;
+  }
 
-    50% {
-        transform: translate(-50%, -50%) rotate(45deg) scale(1.3);
-        opacity: 0.8;
-    }
+  50% {
+    transform: translate(-50%, -50%) rotate(45deg) scale(1.3);
+    opacity: 0.8;
+  }
 
-    100% {
-        transform: translate(-50%, -50%) rotate(45deg) scale(1);
-        opacity: 1;
-    }
+  100% {
+    transform: translate(-50%, -50%) rotate(45deg) scale(1);
+    opacity: 1;
+  }
 }
 
 @keyframes glitch-anim {
-    0%, 10%, 27%, 35%, 52%, 50%, 72%, 80%, 100% {
-        transform: none;
-        opacity: 1;
-    }
+  0%,
+  10%,
+  27%,
+  35%,
+  52%,
+  50%,
+  72%,
+  80%,
+  100% {
+    transform: none;
+    opacity: 1;
+  }
 
-    7% {
-        transform: skew(-0.5deg, -0.9deg);
-        opacity: 0.75;
-    }
+  7% {
+    transform: skew(-0.5deg, -0.9deg);
+    opacity: 0.75;
+  }
 
-    30% {
-        transform: skew(0.8deg, -0.1deg);
-        opacity: 0.75;
-    }
+  30% {
+    transform: skew(0.8deg, -0.1deg);
+    opacity: 0.75;
+  }
 
-    55% {
-        transform: skew(-1deg, 0.2deg);
-        opacity: 0.75;
-    }
+  55% {
+    transform: skew(-1deg, 0.2deg);
+    opacity: 0.75;
+  }
 
-    75% {
-        transform: skew(0.4deg, 1deg);
-        opacity: 0.75;
-    }
+  75% {
+    transform: skew(0.4deg, 1deg);
+    opacity: 0.75;
+  }
 }
 
 @keyframes pulse-glow {
-    0%, 100% {
-        filter: brightness(1);
-    }
+  0%,
+  100% {
+    filter: brightness(1);
+  }
 
-    50% {
-        filter: brightness(1.3);
-    }
+  50% {
+    filter: brightness(1.3);
+  }
 }
 
 @keyframes glitch-frames {
-    0% {
-        clip: rect(19px, 450px, 23px, 0);
-    }
+  0% {
+    clip: rect(19px, 450px, 23px, 0);
+  }
 
-    5% {
-        clip: rect(36px, 450px, 16px, 0);
-    }
+  5% {
+    clip: rect(36px, 450px, 16px, 0);
+  }
 
-    10% {
-        clip: rect(11px, 450px, 41px, 0);
-    }
+  10% {
+    clip: rect(11px, 450px, 41px, 0);
+  }
 
-    15% {
-        clip: rect(22px, 450px, 33px, 0);
-    }
+  15% {
+    clip: rect(22px, 450px, 33px, 0);
+  }
 
-    20% {
-        clip: rect(9px, 450px, 47px, 0);
-    }
+  20% {
+    clip: rect(9px, 450px, 47px, 0);
+  }
 
-    25% {
-        clip: rect(31px, 450px, 21px, 0);
-    }
+  25% {
+    clip: rect(31px, 450px, 21px, 0);
+  }
 
-    30% {
-        clip: rect(44px, 450px, 9px, 0);
-    }
+  30% {
+    clip: rect(44px, 450px, 9px, 0);
+  }
 
-    35% {
-        clip: rect(17px, 450px, 38px, 0);
-    }
+  35% {
+    clip: rect(17px, 450px, 38px, 0);
+  }
 
-    40% {
-        clip: rect(26px, 450px, 25px, 0);
-    }
+  40% {
+    clip: rect(26px, 450px, 25px, 0);
+  }
 
-    45% {
-        clip: rect(12px, 450px, 43px, 0);
-    }
+  45% {
+    clip: rect(12px, 450px, 43px, 0);
+  }
 
-    50% {
-        clip: rect(35px, 450px, 18px, 0);
-    }
+  50% {
+    clip: rect(35px, 450px, 18px, 0);
+  }
 
-    55% {
-        clip: rect(8px, 450px, 49px, 0);
-    }
+  55% {
+    clip: rect(8px, 450px, 49px, 0);
+  }
 
-    60% {
-        clip: rect(29px, 450px, 23px, 0);
-    }
+  60% {
+    clip: rect(29px, 450px, 23px, 0);
+  }
 
-    65% {
-        clip: rect(42px, 450px, 11px, 0);
-    }
+  65% {
+    clip: rect(42px, 450px, 11px, 0);
+  }
 
-    70% {
-        clip: rect(15px, 450px, 40px, 0);
-    }
+  70% {
+    clip: rect(15px, 450px, 40px, 0);
+  }
 
-    75% {
-        clip: rect(24px, 450px, 27px, 0);
-    }
+  75% {
+    clip: rect(24px, 450px, 27px, 0);
+  }
 
-    80% {
-        clip: rect(10px, 450px, 45px, 0);
-    }
+  80% {
+    clip: rect(10px, 450px, 45px, 0);
+  }
 
-    85% {
-        clip: rect(33px, 450px, 20px, 0);
-    }
+  85% {
+    clip: rect(33px, 450px, 20px, 0);
+  }
 
-    90% {
-        clip: rect(46px, 450px, 7px, 0);
-    }
+  90% {
+    clip: rect(46px, 450px, 7px, 0);
+  }
 
-    95% {
-        clip: rect(13px, 450px, 42px, 0);
-    }
+  95% {
+    clip: rect(13px, 450px, 42px, 0);
+  }
 
-    100% {
-        clip: rect(28px, 450px, 26px, 0);
-    }
+  100% {
+    clip: rect(28px, 450px, 26px, 0);
+  }
 }
 
 /* ----- RESPONSIVE STYLES ----- */
 @media (max-width: 768px) {
-    .chart-controls {
-        justify-content: space-between;
-        padding: 0 10px 10px 10px;
-    }
+  .chart-controls {
+    justify-content: space-between;
+    padding: 0 10px 10px 10px;
+  }
 
-    .toggle-btn {
-        padding: 4px 10px;
-        min-width: 35px;
-        font-size: 0.85rem;
-    }
+  .toggle-btn {
+    padding: 4px 10px;
+    min-width: 35px;
+    font-size: 0.85rem;
+  }
 }
 
 @media (max-width: 576px) {
-    .chart-controls {
-        justify-content: space-between;
-        padding: 0 10px 10px 10px;
-        flex-wrap: nowrap;
-    }
+  .chart-controls {
+    justify-content: space-between;
+    padding: 0 10px 10px 10px;
+    flex-wrap: nowrap;
+  }
 
-    .chart-controls-label {
-        font-size: 0.8rem;
-        width: auto;
-        margin-bottom: 0;
-        text-align: left;
-        white-space: nowrap;
-    }
+  .chart-controls-label {
+    font-size: 0.8rem;
+    width: auto;
+    margin-bottom: 0;
+    text-align: left;
+    white-space: nowrap;
+  }
 
-    .toggle-btn {
-        padding: 4px 8px;
-        min-width: 30px;
-        font-size: 0.8rem;
-    }
+  .toggle-btn {
+    padding: 4px 8px;
+    min-width: 30px;
+    font-size: 0.8rem;
+  }
 
-    .fee-star {
-        font-size: 1em;
-    }
+  .fee-star {
+    font-size: 1em;
+  }
 
-    .datum-label {
-        font-size: 0.85em;
-        letter-spacing: 1px;
-    }
+  .datum-label {
+    font-size: 0.85em;
+    letter-spacing: 1px;
+  }
 }
 
 /* ----- RETRO LED ----- */
 .retro-led {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    background: #00ff00;
-    border-radius: 2px;
-    margin-left: 6px;
-    box-shadow: 0 0 4px #00ff00, 0 0 2px #00ff00;
-    position: relative;
-    top: -1.5px;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: #00ff00;
+  border-radius: 2px;
+  margin-left: 6px;
+  box-shadow:
+    0 0 4px #00ff00,
+    0 0 2px #00ff00;
+  position: relative;
+  top: -1.5px;
 }
 
 /* ----- RETRO LED (OFFLINE) ----- */
 .retro-led-offline {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    background: #ff5555;
-    border-radius: 2px;
-    margin-left: 6px;
-    box-shadow: 0 0 4px #ff5555, 0 0 2px #ff5555;
-    position: relative;
-    top: -1.5px;
-    opacity: 0.7;
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: #ff5555;
+  border-radius: 2px;
+  margin-left: 6px;
+  box-shadow:
+    0 0 4px #ff5555,
+    0 0 2px #ff5555;
+  position: relative;
+  top: -1.5px;
+  opacity: 0.7;
 }
 
 /* ----- SATELLITE DISH INDICATOR ----- */
 .satellite-dish {
-    display: inline-block;
-    margin-left: 6px;
-    font-size: .75rem;
-    position: relative;
-    top: -1px;
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 0.75rem;
+  position: relative;
+  top: -1px;
 }
 
 /* Connected state - uses theme-aware colors */
 .satellite-dish-connected {
-    color: #00ff00; /* Default green */
-    text-shadow: 0 0 5px #00ff00, 0 0 3px #00ff00;
-    animation: pulse-satellite 2s infinite;
+  color: #00ff00; /* Default green */
+  text-shadow:
+    0 0 5px #00ff00,
+    0 0 3px #00ff00;
+  animation: pulse-satellite 2s infinite;
 }
 
 /* Offline state */
 .satellite-dish-offline {
-    color: #ff5555;
-    text-shadow: 0 0 3px #ff5555;
-    opacity: 0.7;
+  color: #ff5555;
+  text-shadow: 0 0 3px #ff5555;
+  opacity: 0.7;
 }
 
 /* Theme-specific colors for the satellite dish */
 html.deepsea-theme .satellite-dish-connected {
-    color: #32CD32; /* Use same green for consistency */
-    text-shadow: 0 0 5px #32CD32, 0 0 3px #32CD32;
+  color: #32cd32; /* Use same green for consistency */
+  text-shadow:
+    0 0 5px #32cd32,
+    0 0 3px #32cd32;
 }
 
 @keyframes pulse-satellite {
-    0%, 100% {
-        opacity: 0.9;
-        transform: scale(1);
-    }
+  0%,
+  100% {
+    opacity: 0.9;
+    transform: scale(1);
+  }
 
-    50% {
-        opacity: 1;
-        transform: scale(1.1);
-    }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
 }
-
 
 /* ----- FLOATING WINDOW (Theme Compatible & Clickable) ----- */
 .floating-tab-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0,0,0,0.45);
-    z-index: 2000;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer; /* Makes overlay look clickable */
-    transition: background 0.2s;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer; /* Makes overlay look clickable */
+  transition: background 0.2s;
 }
 
-    .floating-tab-overlay:hover {
-        background: rgba(0,0,0,0.55);
-    }
+.floating-tab-overlay:hover {
+  background: rgba(0, 0, 0, 0.55);
+}
 
 .floating-tab {
-    background: var(--bg-color, #181c24);
-    border: 2px solid var(--primary-color, #ffd700);
-    box-shadow: 0 8px 32px rgba(var(--primary-color-rgb, 255,215,0), 0.18), 0 0 0 1px rgba(0,0,0,0.12);
-    padding: 1.5rem 1.5rem 1rem 1.5rem;
-    position: relative;
-    max-width: 95vw;
-    max-height: 90vh;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    font-family: var(--terminal-font, 'VT323', monospace);
-    cursor: default; /* Prevents pointer on content itself */
-    transition: box-shadow 0.2s, transform 0.2s;
-    width: 80%;
+  background: var(--bg-color, #181c24);
+  border: 2px solid var(--primary-color, #ffd700);
+  box-shadow:
+    0 8px 32px rgba(var(--primary-color-rgb, 255, 215, 0), 0.18),
+    0 0 0 1px rgba(0, 0, 0, 0.12);
+  padding: 1.5rem 1.5rem 1rem 1.5rem;
+  position: relative;
+  max-width: 95vw;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-family: var(--terminal-font, "VT323", monospace);
+  cursor: default; /* Prevents pointer on content itself */
+  transition:
+    box-shadow 0.2s,
+    transform 0.2s;
+  width: 80%;
 }
 
-    .floating-tab:hover {
-        box-shadow: 0 12px 40px 4px rgba(var(--primary-color-rgb, 255,215,0), 0.28), 0 0 0 2px var(--primary-color, #ffd700);
-        transform: scale(1.015);
-    }
+.floating-tab:hover {
+  box-shadow:
+    0 12px 40px 4px rgba(var(--primary-color-rgb, 255, 215, 0), 0.28),
+    0 0 0 2px var(--primary-color, #ffd700);
+  transform: scale(1.015);
+}
 
-    .floating-tab iframe {
-        border: none;
-        width: 100%;
-        height: 600px;
-        max-width: 80vw;
-        max-height: 60vh;
-        background: #000;
-        border-radius: 4px;
-        box-shadow: 0 2px 12px rgba(var(--primary-color-rgb, 255,215,0), 0.10);
-    }
+.floating-tab iframe {
+  border: none;
+  width: 100%;
+  height: 600px;
+  max-width: 80vw;
+  max-height: 60vh;
+  background: #000;
+  border-radius: 4px;
+  box-shadow: 0 2px 12px rgba(var(--primary-color-rgb, 255, 215, 0), 0.1);
+}
 
 .floating-tab-close {
-    position: absolute;
-    top: 8px;
-    right: 12px;
-    background: var(--primary-color, #ffd700);
-    color: #181c24;
-    border: none;
-    font-size: 2rem;
-    font-weight: bold;
-    border-radius: 50%;
-    width: 36px;
-    height: 36px;
-    cursor: pointer;
-    z-index: 10;
-    transition: background 0.2s, color 0.2s, box-shadow 0.2s, opacity 0.2s;
-    box-shadow: 0 2px 8px rgba(var(--primary-color-rgb, 255,215,0), 0.15);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    line-height: 1;
-    opacity: 0.95;
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  background: var(--primary-color, #ffd700);
+  color: #181c24;
+  border: none;
+  font-size: 2rem;
+  font-weight: bold;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  z-index: 10;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    box-shadow 0.2s,
+    opacity 0.2s;
+  box-shadow: 0 2px 8px rgba(var(--primary-color-rgb, 255, 215, 0), 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  opacity: 0.95;
 }
 
-    .floating-tab-close:hover,
-    .floating-tab-close:focus {
-        background: #222;
-        color: var(--primary-color, #ffd700);
-        box-shadow: 0 0 0 3px var(--primary-color, #ffd700), 0 2px 8px rgba(var(--primary-color-rgb, 255,215,0), 0.25);
-        opacity: 1;
-        outline: none;
-    }
+.floating-tab-close:hover,
+.floating-tab-close:focus {
+  background: #222;
+  color: var(--primary-color, #ffd700);
+  box-shadow:
+    0 0 0 3px var(--primary-color, #ffd700),
+    0 2px 8px rgba(var(--primary-color-rgb, 255, 215, 0), 0.25);
+  opacity: 1;
+  outline: none;
+}
 
-    .floating-tab-close:active {
-        opacity: 0.8;
-        background: var(--primary-color, #ffd700);
-        color: #181c24;
-    }
+.floating-tab-close:active {
+  opacity: 0.8;
+  background: var(--primary-color, #ffd700);
+  color: #181c24;
+}
 
 /* Theme overrides for deepsea/bitcoin */
 html.deepsea-theme .floating-tab {
-    background: var(--bg-color, #181c24);
-    border-color: var(--primary-color, #00dfff);
-    box-shadow: 0 8px 32px rgba(var(--primary-color-rgb, 0,223,255), 0.18), 0 0 0 1px rgba(0,0,0,0.12);
+  background: var(--bg-color, #181c24);
+  border-color: var(--primary-color, #00dfff);
+  box-shadow:
+    0 8px 32px rgba(var(--primary-color-rgb, 0, 223, 255), 0.18),
+    0 0 0 1px rgba(0, 0, 0, 0.12);
 }
 
 html.deepsea-theme .floating-tab-close {
-    background: var(--primary-color, #00dfff);
-    color: #181c24;
+  background: var(--primary-color, #00dfff);
+  color: #181c24;
 }
 
-    html.deepsea-theme .floating-tab-close:hover,
-    html.deepsea-theme .floating-tab-close:focus {
-        background: #222;
-        color: var(--primary-color, #00dfff);
-        box-shadow: 0 0 0 3px var(--primary-color, #00dfff), 0 2px 8px rgba(var(--primary-color-rgb, 0,223,255), 0.25);
-    }
+html.deepsea-theme .floating-tab-close:hover,
+html.deepsea-theme .floating-tab-close:focus {
+  background: #222;
+  color: var(--primary-color, #00dfff);
+  box-shadow:
+    0 0 0 3px var(--primary-color, #00dfff),
+    0 2px 8px rgba(var(--primary-color-rgb, 0, 223, 255), 0.25);
+}
 
 html.bitcoin-theme .floating-tab {
-    background: var(--bg-color, #fffbe6);
-    border-color: var(--primary-color, #ffd700);
-    box-shadow: 0 8px 32px rgba(var(--primary-color-rgb, 255,215,0), 0.18), 0 0 0 1px rgba(0,0,0,0.12);
+  background: var(--bg-color, #fffbe6);
+  border-color: var(--primary-color, #ffd700);
+  box-shadow:
+    0 8px 32px rgba(var(--primary-color-rgb, 255, 215, 0), 0.18),
+    0 0 0 1px rgba(0, 0, 0, 0.12);
 }
 
 html.bitcoin-theme .floating-tab-close {
-    background: var(--primary-color, #ffd700);
-    color: #181c24;
+  background: var(--primary-color, #ffd700);
+  color: #181c24;
 }
 
-    html.bitcoin-theme .floating-tab-close:hover,
-    html.bitcoin-theme .floating-tab-close:focus {
-        background: #222;
-        color: var(--primary-color, #ffd700);
-        box-shadow: 0 0 0 3px var(--primary-color, #ffd700), 0 2px 8px rgba(var(--primary-color-rgb, 255,215,0), 0.25);
-    }
+html.bitcoin-theme .floating-tab-close:hover,
+html.bitcoin-theme .floating-tab-close:focus {
+  background: #222;
+  color: var(--primary-color, #ffd700);
+  box-shadow:
+    0 0 0 3px var(--primary-color, #ffd700),
+    0 2px 8px rgba(var(--primary-color-rgb, 255, 215, 0), 0.25);
+}
 
 /* BTC Price Hover Effect - Theme Specific */
 #btc_price {
-    cursor: pointer !important;
-    transition: color 0.2s !important;
-    /* text-shadow and text-decoration transitions are not widely supported, but included for completeness */
-    transition: color 0.2s, text-shadow 0.2s, text-decoration 0.2s !important;
+  cursor: pointer !important;
+  transition: color 0.2s !important;
+  /* text-shadow and text-decoration transitions are not widely supported, but included for completeness */
+  transition:
+    color 0.2s,
+    text-shadow 0.2s,
+    text-decoration 0.2s !important;
 }
 
-    #btc_price:hover {
-        text-decoration: underline !important;
-        text-underline-offset: 2px !important;
-        text-shadow: 0 0 8px #ffd700, 0 0 2px #fff !important;
-        color: #fff700 !important;
-    }
+#btc_price:hover {
+  text-decoration: underline !important;
+  text-underline-offset: 2px !important;
+  text-shadow:
+    0 0 8px #ffd700,
+    0 0 2px #fff !important;
+  color: #fff700 !important;
+}
 
 /* DeepSea Theme */
 html.deepsea-theme #btc_price:hover {
-    color: #00dfff !important;
-    text-shadow: 0 0 10px #00dfff, 0 0 2px #fff !important;
-    text-decoration: underline wavy #00dfff !important;
+  color: #00dfff !important;
+  text-shadow:
+    0 0 10px #00dfff,
+    0 0 2px #fff !important;
+  text-decoration: underline wavy #00dfff !important;
 }
 
 /* Bitcoin Theme */
 html.bitcoin-theme #btc_price:hover {
-    color: #ffd700 !important;
-    text-shadow: 0 0 10px #ffd700 , 0 0 2px #fff !important;
-    text-decoration: underline wavy #ffd700 !important;
+  color: #ffd700 !important;
+  text-shadow:
+    0 0 10px #ffd700,
+    0 0 2px #fff !important;
+  text-decoration: underline wavy #ffd700 !important;
 }

--- a/static/css/earnings.css
+++ b/static/css/earnings.css
@@ -5,521 +5,558 @@
 
 /* ----- ROOT VARIABLES ----- */
 :root {
-    /* Shared colors for both themes */
-    --yellow-color: #ffd700;
-    --green-color: #32CD32;
-    --light-green-color: #90EE90;
-    --red-color: #ff5555;
-    --accent-color: #00dfff;
-    --accent-color-rgb: 0, 223, 255;
-    --bg-color: #000;
-    --card-header-bg: #000;
+  /* Shared colors for both themes */
+  --yellow-color: #ffd700;
+  --green-color: #32cd32;
+  --light-green-color: #90ee90;
+  --red-color: #ff5555;
+  --accent-color: #00dfff;
+  --accent-color-rgb: 0, 223, 255;
+  --bg-color: #000;
+  --card-header-bg: #000;
 }
 
 /* Theme-specific variables */
 html.bitcoin-theme {
-    --primary-color: #f2a900;
-    --primary-color-rgb: 242, 169, 0;
-    --border-color: #333;
-    --primary-gradient-end: #bf7d00; /* Darker orange */
+  --primary-color: #f2a900;
+  --primary-color-rgb: 242, 169, 0;
+  --border-color: #333;
+  --primary-gradient-end: #bf7d00; /* Darker orange */
 }
 
 html.deepsea-theme {
-    --primary-color: #0088cc;
-    --primary-color-rgb: 0, 136, 204;
-    --border-color: #224;
-    --primary-gradient-end: #006699; /* Darker blue */
+  --primary-color: #0088cc;
+  --primary-color-rgb: 0, 136, 204;
+  --border-color: #224;
+  --primary-gradient-end: #006699; /* Darker blue */
 }
 
 /* ----- LAYOUT COMPONENTS ----- */
 .earnings-section {
-    margin: 2rem 0;
+  margin: 2rem 0;
 }
 
-    .earnings-section h2 {
-        color: var(--primary-color);
-        padding: 0.5rem;
-        font-weight: bold;
-        font-family: var(--header-font);
-        text-transform: uppercase;
-        margin-bottom: 0.5rem;
-        position: relative;
-    }
+.earnings-section h2 {
+  color: var(--primary-color);
+  padding: 0.5rem;
+  font-weight: bold;
+  font-family: var(--header-font);
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+  position: relative;
+}
 
-        .earnings-section h2::after {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 1px, transparent 1px, transparent 2px );
-            pointer-events: none;
-            z-index: 1;
-        }
+.earnings-section h2::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1rem;
-    margin: 2rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin: 2rem 0;
 }
 
 .dashboard-container {
-    position: relative;
-    z-index: 0;
+  position: relative;
+  z-index: 0;
 }
 
-    .dashboard-container::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: -1;
-    }
+.dashboard-container::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: -1;
+}
 
 /* ----- CARD STYLING ----- */
 .stat-card {
-    color: white;
-    padding: 1rem;
-    border: 1px solid var(--primary-color);
-    box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.3);
-    position: relative;
-    background-color: var(--bg-color);
-    overflow: hidden;
+  color: white;
+  padding: 1rem;
+  border: 1px solid var(--primary-color);
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.3);
+  position: relative;
+  background-color: var(--bg-color);
+  overflow: hidden;
 }
 
-    .stat-card::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+.stat-card::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
-    .stat-card h2 {
-        padding: 0.5rem;
-        color: var(--primary-color);
-        font-size: 1.2rem;
-        margin: -1rem -1rem 0.5rem -1rem;
-        text-transform: uppercase;
-        font-weight: bold;
-        font-family: var(--header-font);
-        position: relative;
-        z-index: 2;
-    }
+.stat-card h2 {
+  padding: 0.5rem;
+  color: var(--primary-color);
+  font-size: 1.2rem;
+  margin: -1rem -1rem 0.5rem -1rem;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-family: var(--header-font);
+  position: relative;
+  z-index: 2;
+}
 
 .stat-value {
-    font-size: 1.8rem;
-    font-weight: bold;
-    margin-bottom: 0.5rem;
-    position: relative;
-    z-index: 2;
+  font-size: 1.8rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  position: relative;
+  z-index: 2;
 }
 
 .stat-unit {
-    font-size: 1rem;
-    color: var(--text-color);
-    margin-left: 0.25rem;
-    position: relative;
-    z-index: 2;
+  font-size: 1rem;
+  color: var(--text-color);
+  margin-left: 0.25rem;
+  position: relative;
+  z-index: 2;
 }
 
 .stat-secondary {
-    font-size: 0.9rem;
-    margin-bottom: 0.25rem;
-    color: rgba(255, 255, 255, 0.8);
-    position: relative;
-    z-index: 2;
+  font-size: 0.9rem;
+  margin-bottom: 0.25rem;
+  color: rgba(255, 255, 255, 0.8);
+  position: relative;
+  z-index: 2;
 }
 
 .stat-time {
-    margin-top: 0.5rem;
-    font-size: 0.9rem;
-    color: var(--accent-color);
-    position: relative;
-    z-index: 2;
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--accent-color);
+  position: relative;
+  z-index: 2;
 }
 
 /* ----- TABLE STYLING ----- */
 .table-container {
-    overflow-x: auto;
-    margin: 1rem 0;
-    background-color: var(--bg-color);
-    padding: 0.5rem;
-    border: 1px solid var(--primary-color);
-    box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2);
-    position: relative;
-    -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
+  margin: 1rem 0;
+  background-color: var(--bg-color);
+  padding: 0.5rem;
+  border: 1px solid var(--primary-color);
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2);
+  position: relative;
+  -webkit-overflow-scrolling: touch;
 }
 
-    .table-container::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+.table-container::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 .earnings-table {
-    width: 100%;
-    border-collapse: collapse;
-    position: relative;
-    z-index: 2;
+  width: 100%;
+  border-collapse: collapse;
+  position: relative;
+  z-index: 2;
 }
 
-    .earnings-table th,
-    .earnings-table td {
-        padding: 0.75rem;
-        text-align: left;
-        border-bottom: 1px solid var(--border-color);
-    }
+.earnings-table th,
+.earnings-table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border-color);
+}
 
-    .earnings-table th {
-        background-color: var(--card-header-bg);
-        color: var(--primary-color);
-        font-family: var(--header-font);
-        text-transform: uppercase;
-        font-size: 0.9rem;
-    }
+.earnings-table th {
+  background-color: var(--card-header-bg);
+  color: var(--primary-color);
+  font-family: var(--header-font);
+  text-transform: uppercase;
+  font-size: 0.9rem;
+}
 
-    .earnings-table tr td[colspan] {
-        text-align: center;
-        padding: 2rem;
-        color: var(--text-color);
-        font-style: italic;
-    }
+.earnings-table tr td[colspan] {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-color);
+  font-style: italic;
+}
 
-    /* ----- COLOR CODING FOR DATA ----- */
-    /* Yellow color - BTC/sats values */
-    #unpaid-sats,
-    #total-paid-sats,
-    .earnings-table td:nth-child(4),
-    #unpaid-btc,
-    #total-paid-btc,
-    .earnings-table td:nth-child(3) {
-        color: var(--yellow-color);
-    }
+/* ----- COLOR CODING FOR DATA ----- */
+/* Yellow color - BTC/sats values */
+#unpaid-sats,
+#total-paid-sats,
+.earnings-table td:nth-child(4),
+#unpaid-btc,
+#total-paid-btc,
+.earnings-table td:nth-child(3) {
+  color: var(--yellow-color);
+}
 
-    /* Green color - Earnings/profits */
-    #total-paid-usd,
-    #total-paid-fiat,
-    .earnings-table td:nth-child(5) {
-        color: var(--green-color);
-    }
+/* Green color - Earnings/profits */
+#total-paid-usd,
+#total-paid-fiat,
+.earnings-table td:nth-child(5) {
+  color: var(--green-color);
+}
 
 /* Red color - Fees/costs */
 .earnings-fee,
 .earnings-cost {
-    color: var(--red-color) !important;
+  color: var(--red-color) !important;
 }
 
 /* Blue color - Dates */
 .earnings-table td:nth-child(1) {
-    color: var(--accent-color);
+  color: var(--accent-color);
 }
 
 /* ----- STATUS INDICATORS ----- */
 .status-label {
-    display: inline-block;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    font-size: 0.8rem;
-    font-weight: bold;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    text-align: center;
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  text-align: center;
 }
 
 .status-confirmed {
-    background-color: rgba(75, 181, 67, 0.15);
-    color: var(--green-color);
+  background-color: rgba(75, 181, 67, 0.15);
+  color: var(--green-color);
 }
 
 .status-pending {
-    background-color: rgba(247, 147, 26, 0.15);
-    color: var(--yellow-color);
+  background-color: rgba(247, 147, 26, 0.15);
+  color: var(--yellow-color);
 }
 
 .status-processing {
-    background-color: rgba(52, 152, 219, 0.15);
-    color: var(--accent-color);
+  background-color: rgba(52, 152, 219, 0.15);
+  color: var(--accent-color);
 }
 
 /* ----- LINKS & INTERACTIVE ELEMENTS ----- */
 .tx-link {
-    color: var(--accent-color);
-    text-decoration: none;
-    letter-spacing: 1px;
-    text-decoration: underline;
-    transition: all 0.2s ease;
+  color: var(--accent-color);
+  text-decoration: none;
+  letter-spacing: 1px;
+  text-decoration: underline;
+  transition: all 0.2s ease;
 }
 
-    .tx-link:hover {
-        text-decoration: underline;
-        text-shadow: 0 0 5px rgba(var(--accent-color-rgb), 0.7);
-    }
+.tx-link:hover {
+  text-decoration: underline;
+  text-shadow: 0 0 5px rgba(var(--accent-color-rgb), 0.7);
+}
 
 /* ----- UTILITY CLASSES ----- */
 .arrow {
-    display: inline-block;
-    font-weight: bold;
-    margin-left: 0.5rem;
+  display: inline-block;
+  font-weight: bold;
+  margin-left: 0.5rem;
 }
 
 .currency-symbol {
-    display: inline-block;
-    margin-right: 2px;
+  display: inline-block;
+  margin-right: 2px;
 }
 
 .metric-value {
-    color: var(--text-color);
-    font-weight: bold;
+  color: var(--text-color);
+  font-weight: bold;
 }
 
 .card-body strong {
-    color: var(--primary-color);
-    margin-right: 0.25rem;
+  color: var(--primary-color);
+  margin-right: 0.25rem;
 }
 
 .card-body p {
-    margin: 0.25rem 0;
-    line-height: 1.2;
+  margin: 0.25rem 0;
+  line-height: 1.2;
 }
 
 /* Pool luck indicators */
 .very-lucky {
-    color: var(--green-color) !important;
-    font-weight: bold !important;
+  color: var(--green-color) !important;
+  font-weight: bold !important;
 }
 
 .lucky {
-    color: var(--light-green-color) !important;
+  color: var(--light-green-color) !important;
 }
 
 .normal-luck {
-    color: var(--yellow-color) !important;
+  color: var(--yellow-color) !important;
 }
 
 .unlucky {
-    color: var(--red-color) !important;
+  color: var(--red-color) !important;
 }
 
 /* ----- USER SETTINGS INFO ----- */
 .settings-info {
-    display: flex;
-    justify-content: flex-end;
-    font-size: 0.9em;
-    color: #888;
+  display: flex;
+  justify-content: flex-end;
+  font-size: 0.9em;
+  color: #888;
 }
 
 .setting-item {
-    margin-left: 20px;
+  margin-left: 20px;
 }
 
-    .setting-item strong {
-        color: var(--accent-color);
-    }
+.setting-item strong {
+  color: var(--accent-color);
+}
 
 /* ----- CHARTS & VISUALIZATIONS ----- */
 .chart-container {
-    background-color: var(--bg-color);
-    padding: 0.5rem;
-    margin-bottom: 1rem;
-    height: 230px;
-    border: 1px solid var(--primary-color);
-    box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2);
-    position: relative;
+  background-color: var(--bg-color);
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  height: 230px;
+  border: 1px solid var(--primary-color);
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2);
+  position: relative;
 }
 
-    .chart-container::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+.chart-container::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 /* ----- ANIMATIONS ----- */
 @keyframes bounceUp {
-    0%, 50%, 100% {
-        transform: translateY(0);
-    }
+  0%,
+  50%,
+  100% {
+    transform: translateY(0);
+  }
 
-    25%, 75% {
-        transform: translateY(-2px);
-    }
+  25%,
+  75% {
+    transform: translateY(-2px);
+  }
 }
 
 @keyframes bounceDown {
-    0%, 50%, 100% {
-        transform: translateY(0);
-    }
+  0%,
+  50%,
+  100% {
+    transform: translateY(0);
+  }
 
-    25%, 75% {
-        transform: translateY(2px);
-    }
+  25%,
+  75% {
+    transform: translateY(2px);
+  }
 }
 
 @keyframes pulse-highlight {
-    0%, 100% {
-        background-color: rgba(var(--primary-color-rgb), 0.1);
-    }
+  0%,
+  100% {
+    background-color: rgba(var(--primary-color-rgb), 0.1);
+  }
 
-    50% {
-        background-color: rgba(var(--primary-color-rgb), 0.3);
-    }
+  50% {
+    background-color: rgba(var(--primary-color-rgb), 0.3);
+  }
 }
 
 .bounce-up {
-    animation: bounceUp 1s infinite;
+  animation: bounceUp 1s infinite;
 }
 
 .bounce-down {
-    animation: bounceDown 1s infinite;
+  animation: bounceDown 1s infinite;
 }
 
 .new-payment {
-    animation: pulse-highlight 2s infinite;
+  animation: pulse-highlight 2s infinite;
 }
 
 /* ----- RESPONSIVE STYLES ----- */
 /* Tablets and smaller desktops */
 @media (max-width: 768px) {
-    .stats-grid {
-        grid-template-columns: 1fr;
-    }
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
 
-    .earnings-table th,
-    .earnings-table td {
-        padding: 0.5rem;
-        font-size: 0.85rem;
-    }
+  .earnings-table th,
+  .earnings-table td {
+    padding: 0.5rem;
+    font-size: 0.85rem;
+  }
 
-    .status-label {
-        font-size: 0.7rem;
-        padding: 0.15rem 0.3rem;
-    }
+  .status-label {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.3rem;
+  }
 
-    .stat-value {
-        font-size: 1.5rem;
-    }
+  .stat-value {
+    font-size: 1.5rem;
+  }
 
-    .tx-link {
-        font-size: 0.8rem;
-    }
+  .tx-link {
+    font-size: 0.8rem;
+  }
 
-    .settings-info {
-        flex-direction: column;
-        align-items: flex-start;
-    }
+  .settings-info {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 
-    .setting-item {
-        margin-left: 0;
-        margin-bottom: 5px;
-    }
+  .setting-item {
+    margin-left: 0;
+    margin-bottom: 5px;
+  }
 }
 
 /* Mobile phones */
 @media (max-width: 480px) {
-    /* Card-like table layout for small screens */
-    .earnings-table thead {
-        display: none;
-    }
+  /* Card-like table layout for small screens */
+  .earnings-table thead {
+    display: none;
+  }
 
-    .earnings-table,
-    .earnings-table tbody,
-    .earnings-table tr {
-        display: block;
-        width: 100%;
-    }
+  .earnings-table,
+  .earnings-table tbody,
+  .earnings-table tr {
+    display: block;
+    width: 100%;
+  }
 
-        .earnings-table tr {
-            margin-bottom: 15px;
-            border: 1px solid var(--border-color);
-            padding: 8px;
-        }
+  .earnings-table tr {
+    margin-bottom: 15px;
+    border: 1px solid var(--border-color);
+    padding: 8px;
+  }
 
-        .earnings-table td {
-            display: flex;
-            padding: 6px 3px;
-            border: none;
-            border-bottom: 1px solid var(--border-color);
-        }
+  .earnings-table td {
+    display: flex;
+    padding: 6px 3px;
+    border: none;
+    border-bottom: 1px solid var(--border-color);
+  }
 
-            .earnings-table td:last-child {
-                border-bottom: none;
-            }
+  .earnings-table td:last-child {
+    border-bottom: none;
+  }
 
-            /* Responsive labels for table cells */
-            .earnings-table td::before {
-                content: attr(data-label);
-                font-weight: bold;
-                width: 40%;
-                color: var(--primary-color);
-                margin-right: 5%;
-            }
+  /* Responsive labels for table cells */
+  .earnings-table td::before {
+    content: attr(data-label);
+    font-weight: bold;
+    width: 40%;
+    color: var(--primary-color);
+    margin-right: 5%;
+  }
 
-    /* Table-specific cell labels */
-    #payment-history-table td:nth-child(1)::before {
-        content: "Date: ";
-    }
+  /* Table-specific cell labels */
+  #payment-history-table td:nth-child(1)::before {
+    content: "Date: ";
+  }
 
-    #payment-history-table td:nth-child(2)::before {
-        content: "₿: ";
-    }
+  #payment-history-table td:nth-child(2)::before {
+    content: "₿: ";
+  }
 
-    #payment-history-table td:nth-child(3)::before {
-        content: "Sats: ";
-    }
+  #payment-history-table td:nth-child(3)::before {
+    content: "Sats: ";
+  }
 
-    #payment-history-table td:nth-child(4)::before {
-        content: "TX: ";
-    }
+  #payment-history-table td:nth-child(4)::before {
+    content: "TX: ";
+  }
 
-    #payment-history-table td:nth-child(5)::before {
-        content: "Status: ";
-    }
+  #payment-history-table td:nth-child(5)::before {
+    content: "Status: ";
+  }
 
-    #monthly-summary-table td:nth-child(1)::before {
-        content: "Month: ";
-    }
+  #monthly-summary-table td:nth-child(1)::before {
+    content: "Month: ";
+  }
 
-    #monthly-summary-table td:nth-child(2)::before {
-        content: "Payments: ";
-    }
+  #monthly-summary-table td:nth-child(2)::before {
+    content: "Payments: ";
+  }
 
-    #monthly-summary-table td:nth-child(3)::before {
-        content: "₿: ";
-    }
+  #monthly-summary-table td:nth-child(3)::before {
+    content: "₿: ";
+  }
 
-    #monthly-summary-table td:nth-child(4)::before {
-        content: "Sats: ";
-    }
+  #monthly-summary-table td:nth-child(4)::before {
+    content: "Sats: ";
+  }
 
-    #monthly-summary-table td:nth-child(5)::before {
-        content: "Fiat: ";
-    }
+  #monthly-summary-table td:nth-child(5)::before {
+    content: "Fiat: ";
+  }
 
-    /* Fix truncated transaction links */
-    .tx-link {
-        word-break: break-all;
-        font-size: 0.75rem;
-    }
+  /* Fix truncated transaction links */
+  .tx-link {
+    word-break: break-all;
+    font-size: 0.75rem;
+  }
 }

--- a/static/css/error.css
+++ b/static/css/error.css
@@ -6,343 +6,382 @@
 
 /* ----- ROOT VARIABLES ----- */
 :root {
-    --bg-color: #0a0a0a;
-    --bg-gradient: linear-gradient(135deg, #0a0a0a, #1a1a1a);
-    --primary-color: #f7931a;
-    --primary-color-rgb: 247, 147, 26;
-    --text-color: white;
-    --error-text: #ff5555;
-    --code-text: #00dfff;
-    --terminal-font: 'VT323', monospace;
-    --header-font: 'Orbitron', sans-serif;
+  --bg-color: #0a0a0a;
+  --bg-gradient: linear-gradient(135deg, #0a0a0a, #1a1a1a);
+  --primary-color: #f7931a;
+  --primary-color-rgb: 247, 147, 26;
+  --text-color: white;
+  --error-text: #ff5555;
+  --code-text: #00dfff;
+  --terminal-font: "VT323", monospace;
+  --header-font: "Orbitron", sans-serif;
 }
 
 /* DeepSea theme variables - applied to html element */
 html.deepsea-theme {
-    --primary-color: #0088cc;
-    --primary-color-rgb: 0, 136, 204;
-    --bg-gradient: linear-gradient(135deg, #0a0a0a, #0d1a20);
-    --code-text: #39ff14;
-    --error-text: #ff7777;
+  --primary-color: #0088cc;
+  --primary-color-rgb: 0, 136, 204;
+  --bg-gradient: linear-gradient(135deg, #0a0a0a, #0d1a20);
+  --code-text: #39ff14;
+  --error-text: #ff7777;
 }
 
 /* ----- BASE STYLES ----- */
 body {
-    background: var(--bg-gradient);
-    color: var(--text-color);
-    padding-top: 50px;
-    font-family: var(--terminal-font);
-    margin: 0;
-    min-height: 100vh;
+  background: var(--bg-gradient);
+  color: var(--text-color);
+  padding-top: 50px;
+  font-family: var(--terminal-font);
+  margin: 0;
+  min-height: 100vh;
 }
 
-    /* CRT Screen Effect */
-    body::before {
-        content: " ";
-        display: block;
-        position: fixed;
-        top: 0;
-        left: 0;
-        bottom: 0;
-        right: 0;
-        background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.1) 50%), linear-gradient(90deg, rgba(255, 0, 0, 0.03), rgba(0, 255, 0, 0.02), rgba(0, 0, 255, 0.03));
-        background-size: 100% 2px, 3px 100%;
-        pointer-events: none;
-        z-index: 2;
-        opacity: 0.15;
-    }
+/* CRT Screen Effect */
+body::before {
+  content: " ";
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background:
+    linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.1) 50%),
+    linear-gradient(
+      90deg,
+      rgba(255, 0, 0, 0.03),
+      rgba(0, 255, 0, 0.02),
+      rgba(0, 0, 255, 0.03)
+    );
+  background-size:
+    100% 2px,
+    3px 100%;
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0.15;
+}
 
 /* DeepSea underwater effects */
 html.deepsea-theme body::after {
-    content: "";
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    pointer-events: none;
-    background: transparent;
-    opacity: 0.1;
-    z-index: 10;
-    animation: oceanRipple 8s infinite linear;
-    background-image: repeating-linear-gradient( 0deg, rgba(var(--primary-color-rgb), 0.1), rgba(var(--primary-color-rgb), 0.1) 1px, transparent 1px, transparent 6px );
-    background-size: 100% 6px;
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  background: transparent;
+  opacity: 0.1;
+  z-index: 10;
+  animation: oceanRipple 8s infinite linear;
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(var(--primary-color-rgb), 0.1),
+    rgba(var(--primary-color-rgb), 0.1) 1px,
+    transparent 1px,
+    transparent 6px
+  );
+  background-size: 100% 6px;
 }
 
 html.deepsea-theme body::before {
-    opacity: 0.15;
-    background-image: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 73, 109, 0.1) 50%), linear-gradient(90deg, rgba(0, 81, 122, 0.03), rgba(0, 136, 204, 0.08), rgba(0, 191, 255, 0.03));
-    animation: glitchEffect 2s infinite;
+  opacity: 0.15;
+  background-image:
+    linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 73, 109, 0.1) 50%),
+    linear-gradient(
+      90deg,
+      rgba(0, 81, 122, 0.03),
+      rgba(0, 136, 204, 0.08),
+      rgba(0, 191, 255, 0.03)
+    );
+  animation: glitchEffect 2s infinite;
 }
 
 /* ----- ERROR CONTAINER ----- */
 .error-container {
-    max-width: 600px;
-    margin: 0 auto;
-    text-align: center;
-    padding: 2rem;
-    border: 1px solid var(--primary-color);
-    border-radius: 0;
-    background-color: rgba(0, 0, 0, 0.3);
-    box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.3);
-    position: relative;
-    overflow: hidden;
-    animation: flicker 4s infinite;
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+  padding: 2rem;
+  border: 1px solid var(--primary-color);
+  border-radius: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.3);
+  position: relative;
+  overflow: hidden;
+  animation: flicker 4s infinite;
 }
 
-    /* Scanline effect for error container */
-    .error-container::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+/* Scanline effect for error container */
+.error-container::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.1),
+    rgba(0, 0, 0, 0.1) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 /* ----- TYPOGRAPHY ----- */
 h1 {
-    color: var(--primary-color);
-    margin-bottom: 1rem;
-    font-family: var(--header-font);
-    font-weight: bold;
-    position: relative;
-    z-index: 2;
-    letter-spacing: 2px;
-    text-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.5);
+  color: var(--primary-color);
+  margin-bottom: 1rem;
+  font-family: var(--header-font);
+  font-weight: bold;
+  position: relative;
+  z-index: 2;
+  letter-spacing: 2px;
+  text-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.5);
 }
 
 p {
-    margin-bottom: 1.5rem;
-    font-size: 1.5rem;
-    position: relative;
-    z-index: 2;
-    color: var(--error-text);
+  margin-bottom: 1.5rem;
+  font-size: 1.5rem;
+  position: relative;
+  z-index: 2;
+  color: var(--error-text);
 }
 
 /* Error code styling */
 .error-code {
-    font-family: var(--terminal-font);
-    font-size: 1.2rem;
-    color: var(--code-text);
-    margin-bottom: 1rem;
-    position: relative;
-    z-index: 2;
-    letter-spacing: 1px;
+  font-family: var(--terminal-font);
+  font-size: 1.2rem;
+  color: var(--code-text);
+  margin-bottom: 1rem;
+  position: relative;
+  z-index: 2;
+  letter-spacing: 1px;
 }
 
 /* ----- INTERACTIVE ELEMENTS ----- */
 a.btn-primary {
-    background-color: var(--primary-color);
-    border-color: var(--primary-color);
-    color: black;
-    margin-top: 20px;
-    font-family: var(--header-font);
-    text-shadow: none;
-    box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
-    transition: all 0.3s ease;
-    position: relative;
-    z-index: 2;
-    text-transform: uppercase;
-    letter-spacing: 1px;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+  color: black;
+  margin-top: 20px;
+  font-family: var(--header-font);
+  text-shadow: none;
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
+  transition: all 0.3s ease;
+  position: relative;
+  z-index: 2;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
-    a.btn-primary:hover {
-        background-color: #ffa64d; /* Default hover for Bitcoin theme */
-        box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.7);
-        transform: translateY(-2px);
-    }
+a.btn-primary:hover {
+  background-color: #ffa64d; /* Default hover for Bitcoin theme */
+  box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.7);
+  transform: translateY(-2px);
+}
 
 html.deepsea-theme a.btn-primary:hover {
-    background-color: #00b3ff; /* DeepSea theme hover */
+  background-color: #00b3ff; /* DeepSea theme hover */
 }
 
 a.btn-primary:active {
-    transform: translateY(0);
+  transform: translateY(0);
 }
 
 /* Terminal cursor */
 .terminal-cursor {
-    display: inline-block;
-    width: 10px;
-    height: 20px;
-    background-color: var(--primary-color);
-    margin-left: 2px;
-    animation: blink 1s step-end infinite;
-    vertical-align: middle;
-    box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.8);
+  display: inline-block;
+  width: 10px;
+  height: 20px;
+  background-color: var(--primary-color);
+  margin-left: 2px;
+  animation: blink 1s step-end infinite;
+  vertical-align: middle;
+  box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.8);
 }
 
 /* ----- ANIMATIONS ----- */
 @keyframes flicker {
-    0% {
-        opacity: 0.97;
-    }
+  0% {
+    opacity: 0.97;
+  }
 
-    5% {
-        opacity: 0.95;
-    }
+  5% {
+    opacity: 0.95;
+  }
 
-    10% {
-        opacity: 0.97;
-    }
+  10% {
+    opacity: 0.97;
+  }
 
-    15% {
-        opacity: 0.94;
-    }
+  15% {
+    opacity: 0.94;
+  }
 
-    20% {
-        opacity: 0.98;
-    }
+  20% {
+    opacity: 0.98;
+  }
 
-    50% {
-        opacity: 0.95;
-    }
+  50% {
+    opacity: 0.95;
+  }
 
-    80% {
-        opacity: 0.96;
-    }
+  80% {
+    opacity: 0.96;
+  }
 
-    90% {
-        opacity: 0.94;
-    }
+  90% {
+    opacity: 0.94;
+  }
 
-    100% {
-        opacity: 0.98;
-    }
+  100% {
+    opacity: 0.98;
+  }
 }
 
 @keyframes blink {
-    0%, 100% {
-        opacity: 1;
-    }
+  0%,
+  100% {
+    opacity: 1;
+  }
 
-    50% {
-        opacity: 0;
-    }
+  50% {
+    opacity: 0;
+  }
 }
 
 @keyframes oceanRipple {
-    0% {
-        transform: translateY(0);
-    }
+  0% {
+    transform: translateY(0);
+  }
 
-    100% {
-        transform: translateY(6px);
-    }
+  100% {
+    transform: translateY(6px);
+  }
 }
 
 @keyframes glitchEffect {
-    0% {
-        opacity: 0.15;
-        background-position: 0 0;
-    }
+  0% {
+    opacity: 0.15;
+    background-position: 0 0;
+  }
 
-    20% {
-        opacity: 0.17;
-    }
+  20% {
+    opacity: 0.17;
+  }
 
-    40% {
-        opacity: 0.14;
-        background-position: -1px 0;
-    }
+  40% {
+    opacity: 0.14;
+    background-position: -1px 0;
+  }
 
-    60% {
-        opacity: 0.15;
-        background-position: 1px 0;
-    }
+  60% {
+    opacity: 0.15;
+    background-position: 1px 0;
+  }
 
-    80% {
-        opacity: 0.16;
-        background-position: -2px 0;
-    }
+  80% {
+    opacity: 0.16;
+    background-position: -2px 0;
+  }
 
-    100% {
-        opacity: 0.15;
-        background-position: 0 0;
-    }
+  100% {
+    opacity: 0.15;
+    background-position: 0 0;
+  }
 }
 
 /* Deep Sea underwater light rays */
 html.deepsea-theme .underwater-rays {
-    position: fixed;
-    top: -50%;
-    left: -50%;
-    right: -50%;
-    bottom: -50%;
-    width: 200%;
-    height: 200%;
-    background: rgba(0, 0, 0, 0);
-    pointer-events: none;
-    z-index: -1;
-    background-image: radial-gradient(ellipse at top, rgba(var(--primary-color-rgb), 0.1) 0%, rgba(var(--primary-color-rgb), 0) 70%), radial-gradient(ellipse at bottom, rgba(0, 91, 138, 0.15) 0%, rgba(0, 0, 0, 0) 70%);
-    animation: lightRays 15s ease infinite alternate;
+  position: fixed;
+  top: -50%;
+  left: -50%;
+  right: -50%;
+  bottom: -50%;
+  width: 200%;
+  height: 200%;
+  background: rgba(0, 0, 0, 0);
+  pointer-events: none;
+  z-index: -1;
+  background-image:
+    radial-gradient(
+      ellipse at top,
+      rgba(var(--primary-color-rgb), 0.1) 0%,
+      rgba(var(--primary-color-rgb), 0) 70%
+    ),
+    radial-gradient(
+      ellipse at bottom,
+      rgba(0, 91, 138, 0.15) 0%,
+      rgba(0, 0, 0, 0) 70%
+    );
+  animation: lightRays 15s ease infinite alternate;
 }
 
 @keyframes lightRays {
-    0% {
-        transform: scale(1) skew(0deg);
-        opacity: 0.3;
-    }
+  0% {
+    transform: scale(1) skew(0deg);
+    opacity: 0.3;
+  }
 
-    50% {
-        transform: scale(1.05) skew(2deg);
-        opacity: 0.4;
-    }
+  50% {
+    transform: scale(1.05) skew(2deg);
+    opacity: 0.4;
+  }
 
-    100% {
-        transform: scale(1.1) skew(0deg);
-        opacity: 0.3;
-    }
+  100% {
+    transform: scale(1.1) skew(0deg);
+    opacity: 0.3;
+  }
 }
 
 /* ----- RESPONSIVE STYLES ----- */
 @media (max-width: 767px) {
-    .error-container {
-        max-width: 90%;
-        padding: 1.5rem;
-        margin-top: 10px;
-    }
+  .error-container {
+    max-width: 90%;
+    padding: 1.5rem;
+    margin-top: 10px;
+  }
 
-    h1 {
-        font-size: 24px;
-    }
+  h1 {
+    font-size: 24px;
+  }
 
-    p {
-        font-size: 1.2rem;
-    }
+  p {
+    font-size: 1.2rem;
+  }
 
-    .terminal-cursor {
-        height: 16px;
-    }
+  .terminal-cursor {
+    height: 16px;
+  }
 
-    body {
-        padding-top: 30px;
-    }
+  body {
+    padding-top: 30px;
+  }
 }
 
 @media (max-width: 480px) {
-    .error-container {
-        padding: 1rem;
-    }
+  .error-container {
+    padding: 1rem;
+  }
 
-    h1 {
-        font-size: 20px;
-    }
+  h1 {
+    font-size: 20px;
+  }
 
-    p {
-        font-size: 1rem;
-    }
+  p {
+    font-size: 1rem;
+  }
 
-    .error-code {
-        font-size: 1rem;
-    }
+  .error-code {
+    font-size: 1rem;
+  }
 
-    a.btn-primary {
-        font-size: 0.9rem;
-        padding: 0.5rem 1rem;
-    }
+  a.btn-primary {
+    font-size: 0.9rem;
+    padding: 0.5rem 1rem;
+  }
 }

--- a/static/css/notifications.css
+++ b/static/css/notifications.css
@@ -5,350 +5,352 @@
 
 /* ----- NOTIFICATION CONTROLS ----- */
 .notification-controls {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .filter-buttons {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
 }
 
 .filter-button {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    padding: 5px 10px;
-    font-family: var(--terminal-font);
-    cursor: pointer;
-    transition: all 0.3s ease;
-    text-transform: uppercase;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  padding: 5px 10px;
+  font-family: var(--terminal-font);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-transform: uppercase;
 }
 
-    .filter-button:hover {
-        background-color: rgba(var(--primary-color-rgb), 0.2);
-        box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.3);
-    }
+.filter-button:hover {
+  background-color: rgba(var(--primary-color-rgb), 0.2);
+  box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.3);
+}
 
-    .filter-button.active {
-        background-color: var(--primary-color);
-        color: var(--bg-color);
-        box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
-    }
+.filter-button.active {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
+}
 
 /* ----- ACTION BUTTONS ----- */
 .notification-actions {
-    display: flex;
-    gap: 5px;
-    align-items: center;
-    text-transform: uppercase;
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  text-transform: uppercase;
 }
 
 .action-button {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    padding: 6px 12px;
-    font-family: var(--terminal-font);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    min-width: 80px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.9rem;
-    line-height: 1;
-    text-transform: uppercase;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  padding: 6px 12px;
+  font-family: var(--terminal-font);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 80px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  line-height: 1;
+  text-transform: uppercase;
 }
 
-    .action-button:hover {
-        background-color: rgba(var(--primary-color-rgb), 0.2);
-        box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.3);
-    }
+.action-button:hover {
+  background-color: rgba(var(--primary-color-rgb), 0.2);
+  box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.3);
+}
 
-    .action-button.danger {
-        border-color: #ff5555;
-        color: #ff5555;
-    }
+.action-button.danger {
+  border-color: #ff5555;
+  color: #ff5555;
+}
 
-        .action-button.danger:hover {
-            background-color: rgba(255, 85, 85, 0.2);
-            box-shadow: 0 0 8px rgba(255, 85, 85, 0.3);
-        }
+.action-button.danger:hover {
+  background-color: rgba(255, 85, 85, 0.2);
+  box-shadow: 0 0 8px rgba(255, 85, 85, 0.3);
+}
 
 /* ----- CARD HEADER WITH BADGE ----- */
 .card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .unread-badge {
-    background-color: var(--primary-color);
-    color: var(--bg-color);
-    padding: 2px 8px;
-    border-radius: 10px;
-    font-size: 0.8rem;
-    min-width: 25px;
-    text-align: center;
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.8rem;
+  min-width: 25px;
+  text-align: center;
 }
 
-    .unread-badge:empty {
-        display: none;
-    }
+.unread-badge:empty {
+  display: none;
+}
 
 /* ----- NOTIFICATIONS CONTAINER ----- */
 #notifications-container {
-    min-height: 200px;
-    position: relative;
+  min-height: 200px;
+  position: relative;
 }
 
 .loading-message {
-    text-align: center;
-    padding: 20px;
-    color: #888;
+  text-align: center;
+  padding: 20px;
+  color: #888;
 }
 
 .empty-state {
-    text-align: center;
-    padding: 40px 20px;
-    color: #888;
+  text-align: center;
+  padding: 40px 20px;
+  color: #888;
 }
 
-    .empty-state i {
-        font-size: 3rem;
-        margin-bottom: 15px;
-        opacity: 0.5;
-    }
+.empty-state i {
+  font-size: 3rem;
+  margin-bottom: 15px;
+  opacity: 0.5;
+}
 
 /* ----- NOTIFICATION ITEMS ----- */
 .notification-item {
-    display: flex;
-    padding: 12px;
-    border-bottom: 1px solid rgba(var(--primary-color-rgb), 0.2);
-    transition: background-color 0.2s ease;
-    position: relative;
-    background-color: rgba(0, 0, 0, 0.15);
-    animation: fadeIn 0.3s ease-out;
+  display: flex;
+  padding: 12px;
+  border-bottom: 1px solid rgba(var(--primary-color-rgb), 0.2);
+  transition: background-color 0.2s ease;
+  position: relative;
+  background-color: rgba(0, 0, 0, 0.15);
+  animation: fadeIn 0.3s ease-out;
 }
 
-    .notification-item:hover {
-        background-color: rgba(var(--primary-color-rgb), 0.05);
-    }
+.notification-item:hover {
+  background-color: rgba(var(--primary-color-rgb), 0.05);
+}
 
-    .notification-item[data-read="true"] {
-        opacity: 0.6;
-    }
+.notification-item[data-read="true"] {
+  opacity: 0.6;
+}
 
-    /* Level-specific styling */
-    .notification-item[data-level="success"] {
-        border-left: 3px solid #32CD32;
-    }
+/* Level-specific styling */
+.notification-item[data-level="success"] {
+  border-left: 3px solid #32cd32;
+}
 
-    .notification-item[data-level="info"] {
-        border-left: 3px solid #00dfff;
-    }
+.notification-item[data-level="info"] {
+  border-left: 3px solid #00dfff;
+}
 
-    .notification-item[data-level="warning"] {
-        border-left: 3px solid #ffd700;
-    }
+.notification-item[data-level="warning"] {
+  border-left: 3px solid #ffd700;
+}
 
-    .notification-item[data-level="error"] {
-        border-left: 3px solid #ff5555;
-    }
+.notification-item[data-level="error"] {
+  border-left: 3px solid #ff5555;
+}
 
 /* ----- NOTIFICATION COMPONENTS ----- */
 .notification-icon {
-    flex: 0 0 40px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2rem;
+  flex: 0 0 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
 }
 
 .notification-content {
-    flex: 1;
-    padding: 0 15px;
+  flex: 1;
+  padding: 0 15px;
 }
 
 .notification-message {
-    margin-bottom: 5px;
-    word-break: break-word;
-    color: white;
+  margin-bottom: 5px;
+  word-break: break-word;
+  color: white;
 }
 
 .notification-meta {
-    font-size: 0.8rem;
-    color: #888;
-    display: flex;
-    gap: 15px;
+  font-size: 0.8rem;
+  color: #888;
+  display: flex;
+  gap: 15px;
 }
 
 .full-timestamp {
-    font-size: 0.8em;
-    color: #888;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .notification-category {
-    text-transform: uppercase;
-    font-size: 0.7rem;
-    color: #aaa;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: #aaa;
 }
 
 /* Level-specific icon colors */
 .notification-item[data-level="success"] .notification-icon i {
-    color: #32CD32;
+  color: #32cd32;
 }
 
 .notification-item[data-level="info"] .notification-icon i {
-    color: #00dfff;
+  color: #00dfff;
 }
 
 .notification-item[data-level="warning"] .notification-icon i {
-    color: #ffd700;
+  color: #ffd700;
 }
 
 .notification-item[data-level="error"] .notification-icon i {
-    color: #ff5555;
+  color: #ff5555;
 }
 
 /* ----- NOTIFICATION ITEM ACTIONS ----- */
 .notification-actions {
-    flex: 0 0 80px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 5px;
+  flex: 0 0 80px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 5px;
 }
 
-    .notification-actions button {
-        background: none;
-        border: none;
-        color: #888;
-        cursor: pointer;
-        transition: color 0.2s ease, background-color 0.2s ease;
-        width: 30px;
-        height: 30px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border-radius: 3px;
-    }
+.notification-actions button {
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+}
 
 .mark-read-button:hover {
-    color: #32CD32;
-    background-color: rgba(50, 205, 50, 0.1);
+  color: #32cd32;
+  background-color: rgba(50, 205, 50, 0.1);
 }
 
 .delete-button:hover {
-    color: #ff5555;
-    background-color: rgba(255, 85, 85, 0.1);
+  color: #ff5555;
+  background-color: rgba(255, 85, 85, 0.1);
 }
 
 /* ----- PAGINATION ----- */
 .pagination-controls {
-    margin-top: 15px;
-    text-align: center;
+  margin-top: 15px;
+  text-align: center;
 }
 
 .load-more-button {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    padding: 5px 15px;
-    font-family: var(--terminal-font);
-    cursor: pointer;
-    transition: all 0.3s ease;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  padding: 5px 15px;
+  font-family: var(--terminal-font);
+  cursor: pointer;
+  transition: all 0.3s ease;
 }
 
-    .load-more-button:hover {
-        background-color: rgba(var(--primary-color-rgb), 0.2);
-        box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.3);
-    }
+.load-more-button:hover {
+  background-color: rgba(var(--primary-color-rgb), 0.2);
+  box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.3);
+}
 
-    .load-more-button:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
+.load-more-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 /* ----- ANIMATIONS ----- */
 @keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(-10px);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
 
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ----- RESPONSIVE STYLES ----- */
 @media (max-width: 768px) {
-    .notification-controls {
-        flex-direction: column;
-        align-items: stretch;
-    }
+  .notification-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-    .filter-buttons {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 8px;
-        padding-bottom: 5px;
-        margin-bottom: 10px;
-        width: 100%;
-    }
+  .filter-buttons {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    padding-bottom: 5px;
+    margin-bottom: 10px;
+    width: 100%;
+  }
 
-    .filter-button {
-        text-align: center;
-        white-space: normal;
-        font-size: 0.9rem;
-        padding: 8px 5px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 38px;
-    }
+  .filter-button {
+    text-align: center;
+    white-space: normal;
+    font-size: 0.9rem;
+    padding: 8px 5px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 38px;
+  }
 
-    .notification-actions {
-        flex-direction: column;
-        gap: 8px;
-        margin-top: 10px;
-        justify-content: stretch;
-    }
+  .notification-actions {
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 10px;
+    justify-content: stretch;
+  }
 
-    .action-button {
-        width: 100%;
-        padding: 8px 12px;
-        font-size: 0.95rem;
-    }
+  .action-button {
+    width: 100%;
+    padding: 8px 12px;
+    font-size: 0.95rem;
+  }
 
-    /* Notification item adjustments */
-    .notification-item {
-        padding: 8px;
-    }
+  /* Notification item adjustments */
+  .notification-item {
+    padding: 8px;
+  }
 
-    .notification-icon {
-        flex: 0 0 30px;
-    }
+  .notification-icon {
+    flex: 0 0 30px;
+  }
 
-    .notification-content {
-        padding: 0 8px;
-    }
+  .notification-content {
+    padding: 0 8px;
+  }
 
-    .notification-actions {
-        flex: 0 0 60px;
-    }
+  .notification-actions {
+    flex: 0 0 60px;
+  }
 }
 
 /* Very small screens */
 @media (max-width: 375px) {
-    .filter-buttons {
-        grid-template-columns: repeat(2, 1fr);
-    }
+  .filter-buttons {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }

--- a/static/css/retro-refresh.css
+++ b/static/css/retro-refresh.css
@@ -5,440 +5,457 @@
 
 /* ----- ROOT VARIABLES ----- */
 :root {
-    --terminal-bg: #000000;
-    --terminal-border: #f7931a;
-    --terminal-text: #f7931a;
-    --terminal-glow: rgba(247, 147, 26, 0.7);
-    --terminal-width: 300px;
+  --terminal-bg: #000000;
+  --terminal-border: #f7931a;
+  --terminal-text: #f7931a;
+  --terminal-glow: rgba(247, 147, 26, 0.7);
+  --terminal-width: 300px;
 }
 
 @media (min-width: 768px) {
-    :root {
-        --terminal-width: 340px;
-    }
+  :root {
+    --terminal-width: 340px;
+  }
 }
 
 /* ----- HIDE ORIGINAL REFRESH TIMER ----- */
 #refreshUptime {
-    visibility: hidden !important;
-    height: 0 !important;
-    overflow: hidden !important;
-    margin: 0 !important;
-    padding: 0 !important;
+  visibility: hidden !important;
+  height: 0 !important;
+  overflow: hidden !important;
+  margin: 0 !important;
+  padding: 0 !important;
 }
 
 /* ----- TERMINAL CONTAINER ----- */
 #retro-terminal-bar {
-    position: fixed;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: var(--terminal-width);
-    background-color: var(--terminal-bg);
-    border: 2px solid var(--terminal-border);
-    z-index: 1000;
-    font-family: var(--terminal-font, 'VT323', monospace);
-    overflow: hidden;
-    padding: 5px;
-    will-change: transform, width;
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: var(--terminal-width);
+  background-color: var(--terminal-bg);
+  border: 2px solid var(--terminal-border);
+  z-index: 1000;
+  font-family: var(--terminal-font, "VT323", monospace);
+  overflow: hidden;
+  padding: 5px;
+  will-change: transform, width;
 }
 
 /* Desktop positioning */
 @media (min-width: 768px) {
-    #retro-terminal-bar {
-        left: auto;
-        right: 20px;
-        transform: none;
-        cursor: grab;
-        user-select: none;
-    }
+  #retro-terminal-bar {
+    left: auto;
+    right: 20px;
+    transform: none;
+    cursor: grab;
+    user-select: none;
+  }
 
-        #retro-terminal-bar.dragging {
-            cursor: grabbing;
-        }
+  #retro-terminal-bar.dragging {
+    cursor: grabbing;
+  }
 }
 
 /* ----- TERMINAL HEADER ----- */
 .terminal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 5px;
-    border-bottom: 1px solid var(--terminal-border);
-    padding-bottom: 3px;
-    background-color: #000;
-    position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 5px;
+  border-bottom: 1px solid var(--terminal-border);
+  padding-bottom: 3px;
+  background-color: #000;
+  position: relative;
 }
 
 @media (min-width: 768px) {
-    .terminal-header {
-        cursor: grab;
-    }
+  .terminal-header {
+    cursor: grab;
+  }
 
-        .terminal-header::before {
-            content: "⋮⋮";
-            position: absolute;
-            left: 10px;
-            opacity: 0.5;
-        }
+  .terminal-header::before {
+    content: "⋮⋮";
+    position: absolute;
+    left: 10px;
+    opacity: 0.5;
+  }
 }
 
 .terminal-title {
-    color: var(--primary-color, var(--terminal-text));
-    font-weight: bold;
-    font-size: 1.1rem;
-    border-bottom: none;
-    animation: flicker 4s infinite;
-    font-family: var(--header-font, 'Orbitron', sans-serif);
-    padding: 0.3rem 0;
-    letter-spacing: 1px;
+  color: var(--primary-color, var(--terminal-text));
+  font-weight: bold;
+  font-size: 1.1rem;
+  border-bottom: none;
+  animation: flicker 4s infinite;
+  font-family: var(--header-font, "Orbitron", sans-serif);
+  padding: 0.3rem 0;
+  letter-spacing: 1px;
 }
 
 /* ----- TERMINAL CONTROLS ----- */
 .terminal-controls {
-    display: flex;
-    gap: 5px;
+  display: flex;
+  gap: 5px;
 }
 
 .terminal-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background-color: #555;
-    transition: background-color 0.3s;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #555;
+  transition: background-color 0.3s;
 }
 
-    .terminal-dot:hover {
-        background-color: #999;
-        cursor: pointer;
-    }
+.terminal-dot:hover {
+  background-color: #999;
+  cursor: pointer;
+}
 
-    .terminal-dot.minimize:hover {
-        background-color: #ffcc00;
-    }
+.terminal-dot.minimize:hover {
+  background-color: #ffcc00;
+}
 
-    .terminal-dot.close:hover {
-        background-color: #ff3b30;
-    }
+.terminal-dot.close:hover {
+  background-color: #ff3b30;
+}
 
 /* ----- TERMINAL CONTENT ----- */
 .terminal-content {
-    position: relative;
-    color: #ffffff;
-    padding: 5px 0;
+  position: relative;
+  color: #ffffff;
+  padding: 5px 0;
 }
 
-    /* CRT Scanline effect */
-    .terminal-content::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.15) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-        animation: flicker 0.15s infinite;
-    }
+/* CRT Scanline effect */
+.terminal-content::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.15),
+    rgba(0, 0, 0, 0.15) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+  animation: flicker 0.15s infinite;
+}
 
 /* ----- PROGRESS BAR ----- */
 #retro-terminal-bar .bitcoin-progress-container {
-    width: 100%;
-    height: 20px;
-    background-color: #111;
-    border: 1px solid var(--terminal-border);
-    margin-bottom: 10px;
-    position: relative;
-    overflow: hidden;
-    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.8);
-    will-change: contents;
+  width: 100%;
+  height: 20px;
+  background-color: #111;
+  border: 1px solid var(--terminal-border);
+  margin-bottom: 10px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.8);
+  will-change: contents;
 }
 
 #retro-terminal-bar #bitcoin-progress-inner {
-    height: 100%;
-    width: 0;
-    background: linear-gradient(90deg, #f7931a, #ffa500);
-    position: relative;
-    transition: width 0.3s ease-out;
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #f7931a, #ffa500);
+  position: relative;
+  transition: width 0.3s ease-out;
 }
 
-    #retro-terminal-bar #bitcoin-progress-inner.glow-effect {
-        box-shadow: 0 0 15px #f7931a, 0 0 25px #f7931a;
-    }
+#retro-terminal-bar #bitcoin-progress-inner.glow-effect {
+  box-shadow:
+    0 0 15px #f7931a,
+    0 0 25px #f7931a;
+}
 
-    #retro-terminal-bar #bitcoin-progress-inner.waiting-for-update {
-        animation: waitingPulse 2s infinite !important;
-        transition: width 0.3s ease-out, box-shadow 1s ease;
-    }
+#retro-terminal-bar #bitcoin-progress-inner.waiting-for-update {
+  animation: waitingPulse 2s infinite !important;
+  transition:
+    width 0.3s ease-out,
+    box-shadow 1s ease;
+}
 
 /* Tick marks on progress bar */
 .progress-ticks {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: space-between;
-    padding: 0 5px;
-    color: rgba(255, 255, 255, 0.6);
-    font-size: 10px;
-    pointer-events: none;
-    z-index: 3;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 5px;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 10px;
+  pointer-events: none;
+  z-index: 3;
 }
 
-    .progress-ticks span {
-        display: flex;
-        align-items: flex-end;
-        height: 100%;
-        padding-bottom: 2px;
-    }
+.progress-ticks span {
+  display: flex;
+  align-items: flex-end;
+  height: 100%;
+  padding-bottom: 2px;
+}
 
 .tick-mark {
-    position: absolute;
-    top: 0;
-    width: 1px;
-    height: 5px;
-    background-color: rgba(255, 255, 255, 0.4);
+  position: absolute;
+  top: 0;
+  width: 1px;
+  height: 5px;
+  background-color: rgba(255, 255, 255, 0.4);
 }
 
-    .tick-mark.major {
-        height: 8px;
-        background-color: rgba(255, 255, 255, 0.6);
-    }
+.tick-mark.major {
+  height: 8px;
+  background-color: rgba(255, 255, 255, 0.6);
+}
 
 /* Scan line effect */
 .scan-line {
-    position: absolute;
-    height: 2px;
-    width: 100%;
-    background-color: rgba(255, 255, 255, 0.7);
-    animation: scan 3s linear infinite;
-    box-shadow: 0 0 8px 1px rgba(255, 255, 255, 0.5);
-    z-index: 2;
-    will-change: transform;
+  position: absolute;
+  height: 2px;
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.7);
+  animation: scan 3s linear infinite;
+  box-shadow: 0 0 8px 1px rgba(255, 255, 255, 0.5);
+  z-index: 2;
+  will-change: transform;
 }
 
 /* ----- TEXT ELEMENTS ----- */
 #retro-terminal-bar #refreshContainer {
-    display: block;
-    width: 100%;
+  display: block;
+  width: 100%;
 }
 
 #retro-terminal-bar #progress-text {
-    font-size: 16px;
-    color: var(--terminal-text);
-    margin-top: 5px;
-    text-align: center;
-    position: relative;
-    z-index: 2;
+  font-size: 16px;
+  color: var(--terminal-text);
+  margin-top: 5px;
+  text-align: center;
+  position: relative;
+  z-index: 2;
 }
 
 #retro-terminal-bar #uptimeTimer {
-    font-size: 16px;
-    color: var(--terminal-text);
-    text-align: center;
-    position: relative;
-    z-index: 2;
-    border-top: 1px solid rgba(247, 147, 26, 0.3);
-    padding-top: 5px;
-    margin-top: 5px;
+  font-size: 16px;
+  color: var(--terminal-text);
+  text-align: center;
+  position: relative;
+  z-index: 2;
+  border-top: 1px solid rgba(247, 147, 26, 0.3);
+  padding-top: 5px;
+  margin-top: 5px;
 }
 
 /* Terminal cursor */
 #retro-terminal-bar #terminal-cursor {
-    display: inline-block;
-    width: 8px;
-    height: 14px;
-    background-color: var(--terminal-text);
-    margin-left: 2px;
-    animation: blink 1s step-end infinite;
-    box-shadow: 0 0 8px var(--terminal-text);
+  display: inline-block;
+  width: 8px;
+  height: 14px;
+  background-color: var(--terminal-text);
+  margin-left: 2px;
+  animation: blink 1s step-end infinite;
+  box-shadow: 0 0 8px var(--terminal-text);
 }
 
 /* ----- STATUS INDICATORS ----- */
 .status-indicators {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 5px;
-    font-size: 12px;
-    color: #aaa;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 5px;
+  font-size: 12px;
+  color: #aaa;
 }
 
 .status-indicator {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 
 .status-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    margin-right: 4px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  margin-right: 4px;
 }
 
-    .status-dot.connected {
-        background-color: #32CD32;
-        box-shadow: 0 0 5px #32CD32;
-        animation: pulse 2s infinite;
-    }
+.status-dot.connected {
+  background-color: #32cd32;
+  box-shadow: 0 0 5px #32cd32;
+  animation: pulse 2s infinite;
+}
 
 /* ----- COLLAPSED STATE ----- */
 #retro-terminal-bar.collapsed .terminal-content {
-    display: none;
+  display: none;
 }
 
 #retro-terminal-bar.collapsed {
-    width: 180px;
+  width: 180px;
 }
 
 @media (min-width: 768px) {
-    #retro-terminal-bar.collapsed {
-        right: 20px;
-        transform: none;
-    }
+  #retro-terminal-bar.collapsed {
+    right: 20px;
+    transform: none;
+  }
 }
 
 /* Show button */
 #show-terminal-button {
-    position: fixed;
-    bottom: 10px;
-    right: 10px;
-    z-index: 1000;
-    background-color: #f7931a;
-    color: #000;
-    border: none;
-    padding: 8px 12px;
-    cursor: pointer;
-    font-family: var(--terminal-font, 'VT323', monospace);
-    font-size: 14px;
-    box-shadow: 0 0 10px rgba(247, 147, 26, 0.5);
-    transition: background-color 0.3s ease;
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  z-index: 1000;
+  background-color: #f7931a;
+  color: #000;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-family: var(--terminal-font, "VT323", monospace);
+  font-size: 14px;
+  box-shadow: 0 0 10px rgba(247, 147, 26, 0.5);
+  transition: background-color 0.3s ease;
 }
 
-    #show-terminal-button:hover {
-        background-color: #ffaa33;
-    }
+#show-terminal-button:hover {
+  background-color: #ffaa33;
+}
 
 /* ----- MOBILE STYLES ----- */
 @media (max-width: 767px) {
-    #retro-terminal-bar.collapsed,
-    .bitcoin-terminal.collapsed,
-    .retro-terminal-bar.collapsed,
-    div[id*="terminal"].collapsed {
-        left: 50% !important;
-        right: auto !important;
-        transform: translateX(-50%) !important;
-        width: auto !important;
-        max-width: 300px !important;
-    }
+  #retro-terminal-bar.collapsed,
+  .bitcoin-terminal.collapsed,
+  .retro-terminal-bar.collapsed,
+  div[id*="terminal"].collapsed {
+    left: 50% !important;
+    right: auto !important;
+    transform: translateX(-50%) !important;
+    width: auto !important;
+    max-width: 300px !important;
+  }
 
-    .terminal-minimized {
-        height: 40px;
-        display: flex;
-        align-items: center;
-    }
+  .terminal-minimized {
+    height: 40px;
+    display: flex;
+    align-items: center;
+  }
 }
 
 @media (max-width: 576px) {
-    #retro-terminal-bar {
-        width: 280px;
-        bottom: 10px;
-    }
+  #retro-terminal-bar {
+    width: 280px;
+    bottom: 10px;
+  }
 
-    .terminal-title {
-        font-size: 12px;
-    }
+  .terminal-title {
+    font-size: 12px;
+  }
 
-    .terminal-dot {
-        width: 6px;
-        height: 6px;
-    }
+  .terminal-dot {
+    width: 6px;
+    height: 6px;
+  }
 
-    #show-terminal-button {
-        padding: 6px 10px;
-        font-size: 12px;
-    }
+  #show-terminal-button {
+    padding: 6px 10px;
+    font-size: 12px;
+  }
 }
 
 /* ----- ANIMATIONS ----- */
 @keyframes flicker {
-    0% {
-        opacity: 0.97;
-    }
+  0% {
+    opacity: 0.97;
+  }
 
-    5% {
-        opacity: 0.95;
-    }
+  5% {
+    opacity: 0.95;
+  }
 
-    10% {
-        opacity: 0.97;
-    }
+  10% {
+    opacity: 0.97;
+  }
 
-    15% {
-        opacity: 0.94;
-    }
+  15% {
+    opacity: 0.94;
+  }
 
-    20% {
-        opacity: 0.98;
-    }
+  20% {
+    opacity: 0.98;
+  }
 
-    50% {
-        opacity: 0.95;
-    }
+  50% {
+    opacity: 0.95;
+  }
 
-    80% {
-        opacity: 0.96;
-    }
+  80% {
+    opacity: 0.96;
+  }
 
-    90% {
-        opacity: 0.94;
-    }
+  90% {
+    opacity: 0.94;
+  }
 
-    100% {
-        opacity: 0.98;
-    }
+  100% {
+    opacity: 0.98;
+  }
 }
 
 @keyframes pulse {
-    0%, 100% {
-        opacity: 0.8;
-    }
+  0%,
+  100% {
+    opacity: 0.8;
+  }
 
-    50% {
-        opacity: 1;
-    }
+  50% {
+    opacity: 1;
+  }
 }
 
 @keyframes waitingPulse {
-    0%, 100% {
-        box-shadow: 0 0 10px #f7931a, 0 0 15px #f7931a;
-        opacity: 0.8;
-    }
+  0%,
+  100% {
+    box-shadow:
+      0 0 10px #f7931a,
+      0 0 15px #f7931a;
+    opacity: 0.8;
+  }
 
-    50% {
-        box-shadow: 0 0 20px #f7931a, 0 0 35px #f7931a;
-        opacity: 1;
-    }
+  50% {
+    box-shadow:
+      0 0 20px #f7931a,
+      0 0 35px #f7931a;
+    opacity: 1;
+  }
 }
 
 @keyframes scan {
-    0% {
-        top: -2px;
-    }
+  0% {
+    top: -2px;
+  }
 
-    100% {
-        top: 22px;
-    }
+  100% {
+    top: 22px;
+  }
 }
 
 @keyframes blink {
-    0%, 100% {
-        opacity: 1;
-    }
+  0%,
+  100% {
+    opacity: 1;
+  }
 
-    50% {
-        opacity: 0;
-    }
+  50% {
+    opacity: 0;
+  }
 }

--- a/static/css/theme-toggle.css
+++ b/static/css/theme-toggle.css
@@ -6,204 +6,205 @@
 /* ----- THEME TOGGLE BUTTON ----- */
 #themeToggle,
 .theme-toggle-btn {
-    position: absolute;
-    z-index: 1000;
-    background: transparent;
-    border-width: 1px;
-    border-style: solid;
-    font-family: var(--terminal-font, 'VT323', monospace);
-    transition: all 0.3s ease;
-    cursor: pointer;
-    white-space: nowrap;
-    text-transform: uppercase;
-    outline: none;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    top: 30px;
-    left: 15px;
+  position: absolute;
+  z-index: 1000;
+  background: transparent;
+  border-width: 1px;
+  border-style: solid;
+  font-family: var(--terminal-font, "VT323", monospace);
+  transition: all 0.3s ease;
+  cursor: pointer;
+  white-space: nowrap;
+  text-transform: uppercase;
+  outline: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  top: 30px;
+  left: 15px;
 }
 
-    /* Active and focus states for accessibility */
-    #themeToggle:active,
-    .theme-toggle-btn:active {
-        transform: translateY(1px);
-        box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
-    }
+/* Active and focus states for accessibility */
+#themeToggle:active,
+.theme-toggle-btn:active {
+  transform: translateY(1px);
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.3);
+}
 
-    #themeToggle:focus,
-    .theme-toggle-btn:focus {
-        box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.3);
-        outline: none;
-    }
+#themeToggle:focus,
+.theme-toggle-btn:focus {
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.3);
+  outline: none;
+}
 
 /* ----- THEME VARIABLES ----- */
 /* Bitcoin theme (orange) */
 html.bitcoin-theme {
-    --primary-color: #f2a900;
-    --primary-color-rgb: 242, 169, 0;
+  --primary-color: #f2a900;
+  --primary-color-rgb: 242, 169, 0;
 }
 
 body:not(.deepsea-theme) #themeToggle,
 body:not(.deepsea-theme) .theme-toggle-btn {
-    color: #f2a900;
-    border-color: #f2a900;
+  color: #f2a900;
+  border-color: #f2a900;
 }
 
-    body:not(.deepsea-theme) #themeToggle:hover,
-    body:not(.deepsea-theme) .theme-toggle-btn:hover {
-        background-color: rgba(242, 169, 0, 0.1);
-        box-shadow: 0 4px 8px rgba(242, 169, 0, 0.3);
-    }
+body:not(.deepsea-theme) #themeToggle:hover,
+body:not(.deepsea-theme) .theme-toggle-btn:hover {
+  background-color: rgba(242, 169, 0, 0.1);
+  box-shadow: 0 4px 8px rgba(242, 169, 0, 0.3);
+}
 
-    body:not(.deepsea-theme) #themeToggle:focus,
-    body:not(.deepsea-theme) .theme-toggle-btn:focus {
-        box-shadow: 0 0 0 3px rgba(242, 169, 0, 0.3);
-    }
+body:not(.deepsea-theme) #themeToggle:focus,
+body:not(.deepsea-theme) .theme-toggle-btn:focus {
+  box-shadow: 0 0 0 3px rgba(242, 169, 0, 0.3);
+}
 
 /* DeepSea theme (blue) */
 html.deepsea-theme {
-    --primary-color: #0088cc;
-    --primary-color-rgb: 0, 136, 204;
+  --primary-color: #0088cc;
+  --primary-color-rgb: 0, 136, 204;
 }
 
 body.deepsea-theme #themeToggle,
 body.deepsea-theme .theme-toggle-btn {
-    color: #0088cc;
-    border-color: #0088cc;
+  color: #0088cc;
+  border-color: #0088cc;
 }
 
-    body.deepsea-theme #themeToggle:hover,
-    body.deepsea-theme .theme-toggle-btn:hover {
-        background-color: rgba(0, 136, 204, 0.1);
-        box-shadow: 0 4px 8px rgba(0, 136, 204, 0.3);
-    }
+body.deepsea-theme #themeToggle:hover,
+body.deepsea-theme .theme-toggle-btn:hover {
+  background-color: rgba(0, 136, 204, 0.1);
+  box-shadow: 0 4px 8px rgba(0, 136, 204, 0.3);
+}
 
-    body.deepsea-theme #themeToggle:focus,
-    body.deepsea-theme .theme-toggle-btn:focus {
-        box-shadow: 0 0 0 3px rgba(0, 136, 204, 0.3);
-    }
+body.deepsea-theme #themeToggle:focus,
+body.deepsea-theme .theme-toggle-btn:focus {
+  box-shadow: 0 0 0 3px rgba(0, 136, 204, 0.3);
+}
 
 /* ----- RESPONSIVE STYLING ----- */
 /* Desktop view */
 @media screen and (min-width: 768px) {
-    #themeToggle,
-    .theme-toggle-btn {
-        padding: 6px 0px 6px 6px;
-        font-size: 14px;
-        border-radius: 3px;
-        letter-spacing: 0.5px;
-    }
+  #themeToggle,
+  .theme-toggle-btn {
+    padding: 6px 0px 6px 6px;
+    font-size: 14px;
+    border-radius: 3px;
+    letter-spacing: 0.5px;
+  }
 
-        #themeToggle:before,
-        .theme-toggle-btn:before {
-            content: " ₿|🌊";
-            margin-right: 5px;
-            font-size: 14px;
-        }
+  #themeToggle:before,
+  .theme-toggle-btn:before {
+    content: " ₿|🌊";
+    margin-right: 5px;
+    font-size: 14px;
+  }
 
-        #themeToggle:hover,
-        .theme-toggle-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-        }
+  #themeToggle:hover,
+  .theme-toggle-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  }
 }
 
 /* Mobile view */
 @media screen and (max-width: 767px) {
-    #themeToggle,
-    .theme-toggle-btn {
-        padding: 10px;
-        font-size: 12px;
-        border-radius: 3px;
-        width: 40px;
-        height: 35px;
-    }
+  #themeToggle,
+  .theme-toggle-btn {
+    padding: 10px;
+    font-size: 12px;
+    border-radius: 3px;
+    width: 40px;
+    height: 35px;
+  }
 
-        #themeToggle:before,
-        .theme-toggle-btn:before {
-            content: " ₿|🌊";
-            margin-right: 0;
-            font-size: 14px;
-        }
+  #themeToggle:before,
+  .theme-toggle-btn:before {
+    content: " ₿|🌊";
+    margin-right: 0;
+    font-size: 14px;
+  }
 
-        #themeToggle span,
-        .theme-toggle-btn span {
-            display: none;
-        }
+  #themeToggle span,
+  .theme-toggle-btn span {
+    display: none;
+  }
 }
 
 /* Small mobile and landscape view */
 @media screen and (max-width: 767px) and (max-height: 500px) {
-    #themeToggle,
-    .theme-toggle-btn {
-        top: 5px;
-        left: 5px;
-        width: 35px;
-        height: 35px;
-        font-size: 10px;
-    }
+  #themeToggle,
+  .theme-toggle-btn {
+    top: 5px;
+    left: 5px;
+    width: 35px;
+    height: 35px;
+    font-size: 10px;
+  }
 }
 
 /* ----- THEME LOADING STYLES ----- */
 #theme-loader {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
-    font-family: var(--terminal-font, 'VT323', monospace);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  font-family: var(--terminal-font, "VT323", monospace);
 }
 
 html.bitcoin-theme #theme-loader {
-    background-color: #111111;
-    color: #f2a900;
+  background-color: #111111;
+  color: #f2a900;
 }
 
 html.deepsea-theme #theme-loader {
-    background-color: #0c141a;
-    color: #0088cc;
+  background-color: #0c141a;
+  color: #0088cc;
 }
 
 #loader-icon {
-    font-size: 48px;
-    margin-bottom: 20px;
-    animation: spin 2s infinite linear;
+  font-size: 48px;
+  margin-bottom: 20px;
+  animation: spin 2s infinite linear;
 }
 
 #loader-text {
-    font-size: 24px;
-    text-transform: uppercase;
-    letter-spacing: 1px;
+  font-size: 24px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 /* ----- ANIMATIONS ----- */
 @keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
+  0% {
+    transform: rotate(0deg);
+  }
 
-    100% {
-        transform: rotate(360deg);
-    }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes pulse {
-    0%, 100% {
-        opacity: 0.8;
-    }
+  0%,
+  100% {
+    opacity: 0.8;
+  }
 
-    50% {
-        opacity: 1;
-    }
+  50% {
+    opacity: 1;
+  }
 }
 
 /* Theme-specific graph container */
 #graphContainer {
-    box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2) !important;
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2) !important;
 }

--- a/static/css/workers.css
+++ b/static/css/workers.css
@@ -5,433 +5,442 @@
 
 /* ----- SEARCH & FILTER CONTROLS ----- */
 .controls-bar {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 15px;
-    flex-wrap: wrap;
-    gap: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 15px;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
 .search-box {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    color: var(--text-color);
-    padding: 5px 10px;
-    font-family: var(--terminal-font);
-    min-width: 200px;
-    transition: box-shadow 0.3s ease;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  color: var(--text-color);
+  padding: 5px 10px;
+  font-family: var(--terminal-font);
+  min-width: 200px;
+  transition: box-shadow 0.3s ease;
 }
 
-    .search-box:focus {
-        outline: none;
-        box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.6);
-    }
+.search-box:focus {
+  outline: none;
+  box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.6);
+}
 
 .filter-buttons {
-    display: flex;
-    gap: 5px;
+  display: flex;
+  gap: 5px;
 }
 
 .filter-button {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    padding: 5px 10px;
-    font-family: var(--terminal-font);
-    cursor: pointer;
-    transition: all 0.2s ease;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  padding: 5px 10px;
+  font-family: var(--terminal-font);
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
-    .filter-button:hover {
-        box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.4);
-    }
+.filter-button:hover {
+  box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.4);
+}
 
-    .filter-button.active {
-        background-color: var(--primary-color);
-        color: var(--bg-color);
-        box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
-    }
+.filter-button.active {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
+}
 
 /* ----- WORKER GRID LAYOUT ----- */
 .worker-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    gap: 10px;
-    margin-top: 10px;
-    margin-bottom: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+  margin-bottom: 20px;
 }
 
 .loading-fade {
-    opacity: 0.6;
-    transition: opacity 0.3s ease;
+  opacity: 0.6;
+  transition: opacity 0.3s ease;
 }
 
 /* ----- WORKER CARD STYLES ----- */
 .worker-card {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
-    position: relative;
-    overflow: hidden;
-    padding: 10px;
-    height: 100%;
-    animation: fadeIn 0.3s ease;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  box-shadow: 0 0 5px rgba(var(--primary-color-rgb), 0.3);
+  position: relative;
+  overflow: hidden;
+  padding: 10px;
+  height: 100%;
+  animation: fadeIn 0.3s ease;
 }
 
-    .worker-card::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background: repeating-linear-gradient( 0deg, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05) 1px, transparent 1px, transparent 2px );
-        pointer-events: none;
-        z-index: 1;
-    }
+.worker-card::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.05),
+    rgba(0, 0, 0, 0.05) 1px,
+    transparent 1px,
+    transparent 2px
+  );
+  pointer-events: none;
+  z-index: 1;
+}
 
 /* Card status modifiers */
 .worker-card-online {
-    border-color: #32CD32;
-    box-shadow: 0 0 8px rgba(50, 205, 50, 0.4);
+  border-color: #32cd32;
+  box-shadow: 0 0 8px rgba(50, 205, 50, 0.4);
 }
 
 .worker-card-offline {
-    border-color: #ff5555;
-    box-shadow: 0 0 8px rgba(255, 85, 85, 0.4);
+  border-color: #ff5555;
+  box-shadow: 0 0 8px rgba(255, 85, 85, 0.4);
 }
 
 /* Card content elements */
 .worker-name {
-    color: var(--primary-color);
-    font-weight: bold;
-    font-size: 1.2rem;
-    margin-bottom: 5px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    z-index: 2;
-    position: relative;
+  color: var(--primary-color);
+  font-weight: bold;
+  font-size: 1.2rem;
+  margin-bottom: 5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  z-index: 2;
+  position: relative;
 }
 
 .worker-stats {
-    margin-top: 8px;
-    font-size: 0.9rem;
-    z-index: 2;
-    position: relative;
+  margin-top: 8px;
+  font-size: 0.9rem;
+  z-index: 2;
+  position: relative;
 }
 
 .worker-stats-row {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 4px;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 4px;
 }
 
 .worker-stats-label {
-    color: #aaa;
+  color: #aaa;
 }
 
 /* Worker type indicator */
 .worker-type {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    font-size: 0.7rem;
-    background-color: rgba(0, 0, 0, 0.6);
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    padding: 1px 5px;
-    z-index: 2;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  font-size: 0.7rem;
+  background-color: rgba(0, 0, 0, 0.6);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  padding: 1px 5px;
+  z-index: 2;
 }
 
 /* ----- STATUS INDICATORS ----- */
 .status-badge {
-    display: inline-block;
-    font-size: 0.8rem;
-    padding: 2px 8px;
-    border-radius: 3px;
-    z-index: 2;
-    position: relative;
-    margin-bottom: 5px;
+  display: inline-block;
+  font-size: 0.8rem;
+  padding: 2px 8px;
+  border-radius: 3px;
+  z-index: 2;
+  position: relative;
+  margin-bottom: 5px;
 }
 
 .status-badge-online {
-    background-color: rgba(50, 205, 50, 0.2);
-    border: 1px solid #32CD32;
-    color: #32CD32;
+  background-color: rgba(50, 205, 50, 0.2);
+  border: 1px solid #32cd32;
+  color: #32cd32;
 }
 
 .status-badge-offline {
-    background-color: rgba(255, 85, 85, 0.2);
-    border: 1px solid #ff5555;
-    color: #ff5555;
+  background-color: rgba(255, 85, 85, 0.2);
+  border: 1px solid #ff5555;
+  color: #ff5555;
 }
 
 /* ----- VISUALIZATION ELEMENTS ----- */
 /* Hashrate bar */
 .hashrate-bar {
-    height: 4px;
-    background: linear-gradient(90deg, #1137F5, #39ff14);
-    margin-top: 4px;
-    margin-bottom: 8px;
-    position: relative;
-    z-index: 2;
+  height: 4px;
+  background: linear-gradient(90deg, #1137f5, #39ff14);
+  margin-top: 4px;
+  margin-bottom: 8px;
+  position: relative;
+  z-index: 2;
 }
 
 /* Stats bars */
 .stats-bar-container {
-    width: 100%;
-    height: 4px;
-    background-color: rgba(255, 255, 255, 0.1);
-    margin-top: 2px;
-    margin-bottom: 5px;
-    position: relative;
-    z-index: 2;
+  width: 100%;
+  height: 4px;
+  background-color: rgba(255, 255, 255, 0.1);
+  margin-top: 2px;
+  margin-bottom: 5px;
+  position: relative;
+  z-index: 2;
 }
 
 .stats-bar {
-    height: 100%;
-    background: linear-gradient(90deg, #ff2d2d, #39ff14);
+  height: 100%;
+  background: linear-gradient(90deg, #ff2d2d, #39ff14);
 }
 
 /* Mini hashrate chart */
 .mini-chart {
-    height: 40px;
-    width: 100%;
-    margin-top: 5px;
-    position: relative;
-    z-index: 2;
+  height: 40px;
+  width: 100%;
+  margin-top: 5px;
+  position: relative;
+  z-index: 2;
 }
 
 /* ----- SUMMARY STATISTICS ----- */
 .summary-stats {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
-    gap: 15px;
-    margin: 15px 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  gap: 15px;
+  margin: 15px 0;
 }
 
 .summary-stat {
-    text-align: center;
-    min-width: 120px;
+  text-align: center;
+  min-width: 120px;
 }
 
 .summary-stat-value {
-    font-size: 1.6rem;
-    margin-bottom: 5px;
+  font-size: 1.6rem;
+  margin-bottom: 5px;
 }
 
 .summary-stat-label {
-    font-size: 0.9rem;
-    color: #aaa;
+  font-size: 0.9rem;
+  color: #aaa;
 }
 
 /* Worker count ring */
 .worker-ring {
-    width: 90px;
-    height: 90px;
-    border-radius: 50%;
-    position: relative;
-    margin: 0 auto;
-    background: conic-gradient( #32CD32 0% calc(var(--online-percent) * 100%), #ff5555 calc(var(--online-percent) * 100%) 100% );
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.3);
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+  position: relative;
+  margin: 0 auto;
+  background: conic-gradient(
+    #32cd32 0% calc(var(--online-percent) * 100%),
+    #ff5555 calc(var(--online-percent) * 100%) 100%
+  );
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.3);
 }
 
 .worker-ring-inner {
-    width: 70px;
-    height: 70px;
-    border-radius: 50%;
-    background-color: var(--bg-color);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2rem;
-    font-weight: bold;
-    color: var(--text-color);
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  background-color: var(--bg-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: var(--text-color);
 }
 
 /* ----- ANIMATIONS ----- */
 @keyframes fadeIn {
-    from {
-        opacity: 0;
-    }
+  from {
+    opacity: 0;
+  }
 
-    to {
-        opacity: 1;
-    }
+  to {
+    opacity: 1;
+  }
 }
 
 /* ----- RESPONSIVE STYLES ----- */
 @media (max-width: 768px) {
-    /* Fix for "Made by" link collision with title */
-    #topRightLink {
-        position: static !important;
-        display: block !important;
-        text-align: right !important;
-        margin-bottom: 0.5rem !important;
-        margin-top: 0 !important;
-        font-size: 0.8rem !important;
-    }
+  /* Fix for "Made by" link collision with title */
+  #topRightLink {
+    position: static !important;
+    display: block !important;
+    text-align: right !important;
+    margin-bottom: 0.5rem !important;
+    margin-top: 0 !important;
+    font-size: 0.8rem !important;
+  }
 
-    /* Adjust heading for better mobile display */
-    h1 {
-        font-size: 20px !important;
-        line-height: 1.2 !important;
-        margin-top: 0.5rem !important;
-        padding-top: 0 !important;
-    }
+  /* Adjust heading for better mobile display */
+  h1 {
+    font-size: 20px !important;
+    line-height: 1.2 !important;
+    margin-top: 0.5rem !important;
+    padding-top: 0 !important;
+  }
 
-    /* Improve container padding for mobile */
-    .container-fluid {
-        padding-left: 0.5rem !important;
-        padding-right: 0.5rem !important;
-    }
+  /* Improve container padding for mobile */
+  .container-fluid {
+    padding-left: 0.5rem !important;
+    padding-right: 0.5rem !important;
+  }
 
-    /* Ensure top section has appropriate spacing */
-    .row.mb-3 {
-        margin-top: 0.5rem !important;
-    }
+  /* Ensure top section has appropriate spacing */
+  .row.mb-3 {
+    margin-top: 0.5rem !important;
+  }
 }
 
 @media (max-width: 576px) {
-    /* Control bar optimization */
-    .controls-bar {
-        flex-direction: column;
-        align-items: stretch;
-    }
+  /* Control bar optimization */
+  .controls-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-    .search-box {
-        width: 100%;
-    }
+  .search-box {
+    width: 100%;
+  }
 
-    .filter-buttons {
-        display: flex;
-        justify-content: space-between;
-    }
+  .filter-buttons {
+    display: flex;
+    justify-content: space-between;
+  }
 
-    /* Single column grid on mobile */
-    .worker-grid {
-        grid-template-columns: 1fr;
-    }
+  /* Single column grid on mobile */
+  .worker-grid {
+    grid-template-columns: 1fr;
+  }
 
-    /* Summary stats on mobile */
-    .summary-stats {
-        flex-direction: column;
-        align-items: center;
-        margin-bottom: 60px;
-    }
+  /* Summary stats on mobile */
+  .summary-stats {
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 60px;
+  }
 
-    .summary-stat {
-        width: 100%;
-    }
+  .summary-stat {
+    width: 100%;
+  }
 }
 
 /* Very small screens */
 @media (max-width: 380px) {
-    #topRightLink {
-        margin-bottom: 0.75rem !important;
-        font-size: 0.7rem !important;
-    }
+  #topRightLink {
+    margin-bottom: 0.75rem !important;
+    font-size: 0.7rem !important;
+  }
 
-    h1 {
-        font-size: 18px !important;
-        margin-bottom: 0.5rem !important;
-    }
+  h1 {
+    font-size: 18px !important;
+    margin-bottom: 0.5rem !important;
+  }
 
-    /* Further reduce container padding */
-    .container-fluid {
-        padding-left: 0.3rem !important;
-        padding-right: 0.3rem !important;
-    }
+  /* Further reduce container padding */
+  .container-fluid {
+    padding-left: 0.3rem !important;
+    padding-right: 0.3rem !important;
+  }
 }
 
 /* ----- PAGINATION STYLES ----- */
 .pagination-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-top: 20px;
-    margin-bottom: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 20px;
+  margin-bottom: 30px;
 }
 
 .pagination {
-    display: flex;
-    gap: 5px;
-    justify-content: center;
-    margin-bottom: 10px;
+  display: flex;
+  gap: 5px;
+  justify-content: center;
+  margin-bottom: 10px;
 }
 
 .pagination-button {
-    background-color: var(--bg-color);
-    border: 1px solid var(--primary-color);
-    color: var(--primary-color);
-    padding: 5px 10px;
-    font-family: var(--terminal-font);
-    cursor: pointer;
-    transition: all 0.2s ease;
-    min-width: 35px;
-    text-align: center;
+  background-color: var(--bg-color);
+  border: 1px solid var(--primary-color);
+  color: var(--primary-color);
+  padding: 5px 10px;
+  font-family: var(--terminal-font);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 35px;
+  text-align: center;
 }
 
-    .pagination-button:hover {
-        box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.4);
-    }
+.pagination-button:hover {
+  box-shadow: 0 0 8px rgba(var(--primary-color-rgb), 0.4);
+}
 
-    .pagination-button.active {
-        background-color: var(--primary-color);
-        color: var(--bg-color);
-        box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
-    }
+.pagination-button.active {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.5);
+}
 
-    .pagination-button.disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-    }
+.pagination-button.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 .pagination-ellipsis {
-    color: var(--text-color);
-    padding: 5px;
-    opacity: 0.7;
+  color: var(--text-color);
+  padding: 5px;
+  opacity: 0.7;
 }
 
 .pagination-info {
-    color: var(--text-color);
-    font-size: 0.9rem;
-    text-align: center;
+  color: var(--text-color);
+  font-size: 0.9rem;
+  text-align: center;
 }
 
 @media (max-width: 576px) {
-    .pagination-container {
-        flex-direction: column;
-    }
+  .pagination-container {
+    flex-direction: column;
+  }
 
-    .pagination {
-        order: 2;
-    }
+  .pagination {
+    order: 2;
+  }
 
-    .pagination-info {
-        order: 1;
-        margin-bottom: 10px;
-    }
+  .pagination-info {
+    order: 1;
+    margin-bottom: 10px;
+  }
 }
 
 /* Power cost styling */
 .power-cost-row {
-    margin-top: 3px;
+  margin-top: 3px;
 }
 
-    .power-cost-row .red-glow {
-        color: #ff6b6b !important;
-        text-shadow: 0 0 5px rgba(255, 107, 107, 0.5);
-    }
+.power-cost-row .red-glow {
+  color: #ff6b6b !important;
+  text-shadow: 0 0 5px rgba(255, 107, 107, 0.5);
+}
 
 /* Add to workers.css */
 .dim-glow {
-    color: #7e7e7e !important;
-    text-shadow: 0 0 3px rgba(126, 126, 126, 0.3);
+  color: #7e7e7e !important;
+  text-shadow: 0 0 3px rgba(126, 126, 126, 0.3);
 }


### PR DESCRIPTION
## Summary
- run Prettier on all CSS files under `static/css`

## Testing
- `npx --yes prettier static/css/*.css --check`
- `python3 -m pytest -q` *(fails: `No module named pytest`)*