### PR TITLE
Add payout history API with Redis storage

### DIFF
--- a/static/js/blocks.js
+++ b/static/js/blocks.js
@@ -215,6 +215,7 @@ function resetWalletAddress() {
                     localStorage.removeItem('payoutHistory');
                     lastPayoutTracking.payoutHistory = [];
                     console.log("Payout history cleared for wallet change");
+                    fetch('/api/payout-history', { method: 'DELETE' });
 
                     // Remove any visible payout comparison elements
                     $("#payout-comparison").remove();
@@ -270,6 +271,7 @@ function resetWalletAddressOnly() {
         localStorage.removeItem('payoutHistory');
         lastPayoutTracking.payoutHistory = [];
         console.log("Payout history cleared for wallet change");
+        fetch('/api/payout-history', { method: 'DELETE' });
 
         // Remove any visible payout comparison elements
         $("#payout-comparison").remove();

--- a/static/js/earnings.js
+++ b/static/js/earnings.js
@@ -228,6 +228,7 @@ function resetWalletAddress() {
                     localStorage.removeItem('payoutHistory');
                     lastPayoutTracking.payoutHistory = [];
                     console.log("Payout history cleared for wallet change");
+                    fetch('/api/payout-history', { method: 'DELETE' });
 
                     // Remove any visible payout comparison elements
                     $("#payout-comparison").remove();
@@ -283,6 +284,7 @@ function resetWalletAddressOnly() {
         localStorage.removeItem('payoutHistory');
         lastPayoutTracking.payoutHistory = [];
         console.log("Payout history cleared for wallet change");
+        fetch('/api/payout-history', { method: 'DELETE' });
 
         // Remove any visible payout comparison elements
         $("#payout-comparison").remove();

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -535,6 +535,7 @@ function resetWalletAddress() {
                     localStorage.removeItem('payoutHistory');
                     lastPayoutTracking.payoutHistory = [];
                     console.log("Payout history cleared for wallet change");
+                    fetch('/api/payout-history', { method: 'DELETE' });
 
                     // Remove any visible payout comparison elements
                     $("#payout-comparison").remove();
@@ -590,6 +591,7 @@ function resetWalletAddressOnly() {
         localStorage.removeItem('payoutHistory');
         lastPayoutTracking.payoutHistory = [];
         console.log("Payout history cleared for wallet change");
+        fetch('/api/payout-history', { method: 'DELETE' });
 
         // Remove any visible payout comparison elements
         $("#payout-comparison").remove();

--- a/static/js/workers.js
+++ b/static/js/workers.js
@@ -402,6 +402,7 @@ function resetWalletAddress() {
                     localStorage.removeItem('payoutHistory');
                     lastPayoutTracking.payoutHistory = [];
                     console.log("Payout history cleared for wallet change");
+                    fetch('/api/payout-history', { method: 'DELETE' });
 
                     // Remove any visible payout comparison elements
                     $("#payout-comparison").remove();
@@ -457,6 +458,7 @@ function resetWalletAddressOnly() {
         localStorage.removeItem('payoutHistory');
         lastPayoutTracking.payoutHistory = [];
         console.log("Payout history cleared for wallet change");
+        fetch('/api/payout-history', { method: 'DELETE' });
 
         // Remove any visible payout comparison elements
         $("#payout-comparison").remove();

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,3 +40,24 @@ def test_update_config_endpoint(client):
     assert resp.status_code == 200
     assert data["status"] == "success"
 
+
+def test_payout_history_endpoint(client):
+    resp = client.get("/api/payout-history")
+    assert resp.status_code == 200
+    assert resp.get_json()["payout_history"] == []
+
+    record = {"timestamp": "2023-01-01T00:00:00Z", "amountBTC": "0.1"}
+    resp = client.post("/api/payout-history", json={"record": record})
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "success"
+
+    resp = client.get("/api/payout-history")
+    data = resp.get_json()
+    assert len(data["payout_history"]) == 1
+    assert data["payout_history"][0]["amountBTC"] == "0.1"
+
+    resp = client.delete("/api/payout-history")
+    assert resp.status_code == 200
+    resp = client.get("/api/payout-history")
+    assert resp.get_json()["payout_history"] == []
+


### PR DESCRIPTION
## Summary
- store payout history in StateManager
- add `/api/payout-history` endpoint for retrieving and updating payout records
- sync payout history from client via new API and keep localStorage as fallback
- clear payout history on wallet resets
- test payout history API

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*