### PR TITLE
Improve block stats visuals and add miner distribution chart

### DIFF
--- a/static/css/blocks.css
+++ b/static/css/blocks.css
@@ -60,11 +60,19 @@
 .stat-item {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
 }
 
 .stat-item strong {
   color: var(--primary-color);
   margin-bottom: 5px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stat-item i {
+  color: var(--primary-color);
 }
 
 /* ----- BLOCKS GRID ----- */
@@ -78,6 +86,12 @@
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 15px;
   margin-top: 15px;
+}
+
+/* Miner distribution chart */
+#minerChart {
+  max-width: 500px;
+  margin: 0 auto;
 }
 
 /* ----- BLOCK CARD ----- */

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -23,34 +23,46 @@
             <div class="card-body">
                 <div class="latest-block-stats">
                     <div class="stat-item">
-                        <strong>BLOCK HEIGHT:</strong>
+                        <strong><i class="fa-solid fa-layer-group"></i> BLOCK HEIGHT:</strong>
                         <span id="latest-height" class="metric-value white">Loading...</span>
                     </div>
                     <div class="stat-item">
-                        <strong>TIME:</strong>
+                        <strong><i class="fa-regular fa-clock"></i> TIME:</strong>
                         <span id="latest-time" class="metric-value blue">Loading...</span>
                     </div>
                     <div class="stat-item">
-                        <strong>TRANSACTIONS:</strong>
+                        <strong><i class="fa-solid fa-receipt"></i> TRANSACTIONS:</strong>
                         <span id="latest-tx-count" class="metric-value white">Loading...</span>
                     </div>
                     <div class="stat-item">
-                        <strong>SIZE:</strong>
+                        <strong><i class="fa-solid fa-database"></i> SIZE:</strong>
                         <span id="latest-size" class="metric-value white">Loading...</span>
                     </div>
                     <div class="stat-item">
-                        <strong>DIFFICULTY:</strong>
+                        <strong><i class="fa-solid fa-gauge-high"></i> DIFFICULTY:</strong>
                         <span id="latest-difficulty" class="metric-value yellow">Loading...</span>
                     </div>
                     <div class="stat-item">
-                        <strong>POOL:</strong>
+                        <strong><i class="fa-solid fa-people-group"></i> POOL:</strong>
                         <span id="latest-pool" class="metric-value green">Loading...</span>
                     </div>
                     <div class="stat-item">
-                        <strong>AVG FEE RATE:</strong>
+                        <strong><i class="fa-solid fa-coins"></i> AVG FEE RATE:</strong>
                         <span id="latest-fee-rate" class="metric-value yellow" style="animation: pulse 1s infinite;">Loading...</span>
                     </div>
                 </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Miner diversity chart -->
+<div class="row mb-2">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">MINER DISTRIBUTION (LAST 25 BLOCKS)</div>
+            <div class="card-body text-center">
+                <canvas id="minerChart" height="120"></canvas>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle latest block stats with icons
- include miner distribution chart for latest blocks
- add styles for new visuals
- compute miner distribution in `blocks.js`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*