### PR TITLE
Improve miner distribution chart

### DIFF
--- a/static/css/blocks.css
+++ b/static/css/blocks.css
@@ -91,6 +91,8 @@
 /* Miner distribution chart */
 #minerChart {
   max-width: 500px;
+  width: 100%;
+  height: auto;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
## Summary
- show block count and percentage in doughnut chart tooltips
- group small pools into an "Other" slice with default color
- enable animation and responsive behaviour for miner chart
- make the chart canvas responsive via CSS

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*