### PR TITLE
Update payout parsing for nested result

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -605,7 +605,8 @@ class MiningDashboardService:
                 return None
 
             data = resp.json()
-            payouts = data.get("payouts", [])
+            result_obj = data.get("result", {})
+            payouts = result_obj.get("payouts", [])
 
             for item in payouts:
                 ts = item.get("ts")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,4 +1,41 @@
 from unittest.mock import MagicMock
+from datetime import datetime
+from zoneinfo import ZoneInfo
+import sys
+import types
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+if 'pytz' not in sys.modules:
+    tz_module = types.ModuleType('pytz')
+    class DummyTZInfo:
+        def utcoffset(self, dt):
+            return None
+        def dst(self, dt):
+            return None
+        def tzname(self, dt):
+            return 'UTC'
+        def localize(self, dt_obj):
+            return dt_obj.replace(tzinfo=self)
+    tz_module.timezone = lambda name: DummyTZInfo()
+    sys.modules['pytz'] = tz_module
+
+if 'requests' not in sys.modules:
+    req_module = types.ModuleType('requests')
+    class DummySession:
+        def get(self, *args, **kwargs):
+            raise NotImplementedError
+    req_module.Session = DummySession
+    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
+    sys.modules['requests'] = req_module
+
+if 'bs4' not in sys.modules:
+    bs4_module = types.ModuleType('bs4')
+    class DummySoup:
+        pass
+    bs4_module.BeautifulSoup = DummySoup
+    sys.modules['bs4'] = bs4_module
 
 from worker_service import WorkerService
 from data_service import MiningDashboardService
@@ -88,4 +125,76 @@ def test_exchange_rate_caching(monkeypatch):
     rates3 = svc.fetch_exchange_rates()
     assert rates3 == rates1
     assert call_count['count'] == 2
+
+
+def test_get_payment_history_api_nested_result(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+
+    sample = {
+        'result': {
+            'payouts': [
+                {
+                    'ts': 1700000000,
+                    'on_chain_txid': 'abcd',
+                    'total_satoshis_net_paid': 100
+                }
+            ]
+        }
+    }
+
+    def fake_get(url, timeout=10):
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = sample
+        return resp
+
+    monkeypatch.setattr(svc.session, 'get', fake_get)
+    monkeypatch.setattr('data_service.get_timezone', lambda: 'UTC')
+
+    payments = svc.get_payment_history_api(days=1, btc_price=20000)
+
+    assert len(payments) == 1
+    p = payments[0]
+    assert p['txid'] == 'abcd'
+    assert p['amount_sats'] == 100
+    assert abs(p['amount_btc'] - 100 / svc.sats_per_btc) < 1e-9
+    assert p['fiat_value'] == (100 / svc.sats_per_btc) * 20000
+    expected_dt = datetime.fromtimestamp(1700000000, tz=ZoneInfo('UTC'))
+    assert p['date_iso'] == expected_dt.isoformat()
+    assert p['date'] == expected_dt.strftime('%Y-%m-%d %H:%M')
+
+
+def test_get_earnings_data_with_nested_result(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+
+    sample = {
+        'result': {
+            'payouts': [
+                {
+                    'ts': 1700000000,
+                    'on_chain_txid': 'abcd',
+                    'total_satoshis_net_paid': 100
+                }
+            ]
+        }
+    }
+
+    def fake_get(url, timeout=10):
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = sample
+        return resp
+
+    monkeypatch.setattr(svc.session, 'get', fake_get)
+    monkeypatch.setattr('data_service.get_timezone', lambda: 'UTC')
+    monkeypatch.setattr('config.get_currency', lambda: 'USD')
+    monkeypatch.setattr(svc, 'get_ocean_data', lambda: data_service.OceanData())
+    monkeypatch.setattr(svc, 'get_bitcoin_stats', lambda: (0, 0, 20000, 0))
+
+    data = svc.get_earnings_data()
+
+    assert len(data['payments']) == 1
+    assert data['payments'][0]['txid'] == 'abcd'
+    assert data['total_paid_btc'] == 100 / svc.sats_per_btc
+
 


### PR DESCRIPTION
## Summary
- handle nested `result` object in `get_payment_history_api`
- expand `test_services` to verify parsing of new payout JSON and earnings aggregation

## Testing
- `python -m tests.test_currency_conversion`
- `python -m tests.test_notification_service`
