### PR TITLE
Fix annotation plugin loading

### DIFF
--- a/static/js/chartjs-plugin-annotation-lite.js
+++ b/static/js/chartjs-plugin-annotation-lite.js
@@ -1,0 +1,59 @@
+(function() {
+  const simpleAnnotationPlugin = {
+    id: 'simple-annotation',
+    afterDraw(chart) {
+      const anns = chart.options.plugins && chart.options.plugins.annotation && chart.options.plugins.annotation.annotations;
+      if (!anns) return;
+      const ctx = chart.ctx;
+      const chartArea = chart.chartArea;
+      const xScale = chart.scales.x;
+      const yScale = chart.scales.y;
+      Object.keys(anns).forEach(key => {
+        const ann = anns[key];
+        if (ann.type !== 'line') return;
+        const color = ann.borderColor || 'rgba(0,0,0,0.5)';
+        const width = ann.borderWidth || 1;
+        const dash = ann.borderDash || [];
+        ctx.save();
+        ctx.strokeStyle = color;
+        ctx.lineWidth = width;
+        ctx.setLineDash(dash);
+        if (ann.xMin !== undefined) {
+          const x = xScale.getPixelForValue(ann.xMin);
+          ctx.beginPath();
+          ctx.moveTo(x, chartArea.top);
+          ctx.lineTo(x, chartArea.bottom);
+          ctx.stroke();
+        } else if (ann.yMin !== undefined) {
+          const y = yScale.getPixelForValue(ann.yMin);
+          ctx.beginPath();
+          ctx.moveTo(chartArea.left, y);
+          ctx.lineTo(chartArea.right, y);
+          ctx.stroke();
+        }
+        if (ann.label && ann.label.enabled && ann.label.content) {
+          const font = ann.label.font || {};
+          ctx.fillStyle = ann.label.color || color;
+          ctx.font = `${font.weight || ''} ${font.size || 12}px ${font.family || 'Arial'}`;
+          ctx.textBaseline = 'bottom';
+          const padding = ann.label.padding || {};
+          const text = ann.label.content;
+          let lx = chartArea.left + (padding.left || 0);
+          let ly = chartArea.top + (padding.top || 0);
+          if (ann.xMin !== undefined) {
+            lx = xScale.getPixelForValue(ann.xMin) + (padding.left || 0);
+          }
+          if (ann.yMin !== undefined) {
+            ly = yScale.getPixelForValue(ann.yMin) - (padding.bottom || 0);
+          }
+          ctx.fillText(text, lx, ly);
+        }
+        ctx.restore();
+      });
+    }
+  };
+  if (window.Chart) {
+    Chart.register(simpleAnnotationPlugin);
+  }
+  window.simpleAnnotationPlugin = simpleAnnotationPlugin;
+})();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -348,9 +348,9 @@ let lastPayoutTracking = {
 let serverTimeOffset = 0;
 let serverStartTime = null;
 
-// Register Chart.js annotation plugin if available
-if (window['chartjs-plugin-annotation']) {
-    Chart.register(window['chartjs-plugin-annotation']);
+// Register local annotation plugin if available
+if (window.simpleAnnotationPlugin) {
+    Chart.register(window.simpleAnnotationPlugin);
 }
 
 function loadBlockAnnotations() {
@@ -1812,8 +1812,8 @@ function initializeChart() {
         // Get the current theme colors
         const theme = getCurrentTheme();
 
-        // Check if Chart.js plugin is available
-        const hasAnnotationPlugin = window['chartjs-plugin-annotation'] !== undefined;
+        // Check if annotation plugin is available
+        const hasAnnotationPlugin = window.simpleAnnotationPlugin !== undefined;
 
         return new Chart(ctx, {
             type: 'line',
@@ -3866,8 +3866,8 @@ $(document).ready(function () {
             // Get the current theme colors
             const theme = getCurrentTheme();
 
-            // Check if Chart.js plugin is available
-            const hasAnnotationPlugin = window['chartjs-plugin-annotation'] !== undefined;
+            // Check if annotation plugin is available
+            const hasAnnotationPlugin = window.simpleAnnotationPlugin !== undefined;
 
             const chart = new Chart(ctx, {
                 type: 'line',

--- a/templates/base.html
+++ b/templates/base.html
@@ -238,8 +238,9 @@
 
     <!-- External JavaScript libraries -->
     <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@1.1.0"></script>
+    <!-- Pin Chart.js version and load local annotation plugin for offline support -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+    <script src="{{ url_for('static', filename='js/chartjs-plugin-annotation-lite.js') }}"></script>
 
     <!-- Theme toggle initialization -->
     <script>


### PR DESCRIPTION
## Summary
- bundle a lite Chart.js annotation plugin for offline use
- load the annotation plugin locally in `base.html`
- register the plugin if present in `main.js`
- check plugin availability via `simpleAnnotationPlugin`

## Testing
- `pytest -q` *(fails: command not found)*