### PR TITLE
Add block event annotations

### DIFF
--- a/App.py
+++ b/App.py
@@ -1291,6 +1291,28 @@ def payout_history():
         logging.error(f"Error handling payout history: {e}")
         return jsonify({"error": str(e)}), 500
 
+# New endpoint to fetch recent block events for chart annotations
+@app.route("/api/block-events")
+def block_events():
+    """Return recent block notifications for chart annotations."""
+    try:
+        limit = request.args.get("limit", 20, type=int)
+        notifications = notification_service.get_notifications(
+            limit=limit,
+            category=NotificationCategory.BLOCK.value
+        )
+        events = []
+        for n in notifications:
+            ts = n.get("timestamp")
+            data = n.get("data") or {}
+            height = data.get("block_height")
+            if ts and height:
+                events.append({"timestamp": ts, "height": height})
+        return jsonify({"events": events})
+    except Exception as e:
+        logging.error(f"Error fetching block events: {e}")
+        return jsonify({"error": str(e)}), 500
+
 # First, register the template filter outside of any route function
 # Add this near the top of your file with other template filters
 @app.template_filter('format_datetime')

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -366,6 +366,38 @@ function loadBlockAnnotations() {
         console.error('Error loading block annotations', e);
         blockAnnotations = [];
     }
+
+    // Fetch past block events from the server and merge with stored annotations
+    fetch('/api/block-events')
+        .then(resp => resp.json())
+        .then(data => {
+            if (data && Array.isArray(data.events)) {
+                const tz = window.dashboardTimezone || DEFAULT_TIMEZONE;
+                const formatter = new Intl.DateTimeFormat('en-US', {
+                    timeZone: tz,
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    hour12: true
+                });
+                data.events.forEach(ev => {
+                    try {
+                        const d = new Date(ev.timestamp);
+                        const label = formatter.format(d).replace(/\s[AP]M$/i, '');
+                        if (!blockAnnotations.includes(label)) {
+                            blockAnnotations.push(label);
+                        }
+                    } catch (err) {
+                        console.error('Error processing block event', err);
+                    }
+                });
+                saveBlockAnnotations();
+                if (trendChart) {
+                    updateBlockAnnotations(trendChart);
+                    trendChart.update('none');
+                }
+            }
+        })
+        .catch(err => console.error('Error fetching block events', err));
 }
 
 function saveBlockAnnotations() {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,3 +73,10 @@ def test_payout_history_endpoint(client):
     resp = client.get("/api/payout-history")
     assert resp.get_json()["payout_history"] == []
 
+
+def test_block_events_endpoint(client):
+    resp = client.get("/api/block-events")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "events" in data
+


### PR DESCRIPTION
## Summary
- add `/api/block-events` endpoint to expose past block notifications
- load past block events on page load so chart shows vertical lines
- test new API endpoint

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*