### PR TITLE
Add block event filter

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,3 +73,10 @@ def test_payout_history_endpoint(client):
     resp = client.get("/api/payout-history")
     assert resp.get_json()["payout_history"] == []
 
+
+def test_block_events_endpoint(client):
+    resp = client.get("/api/block-events?minutes=180")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "events" in data
+


### PR DESCRIPTION
## Summary
- filter `/api/block-events` results to recent minutes and support query param
- load only last 180 minutes of block events on the client
- update API tests

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*