### PR TITLE
Fix block annotations timeframe

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -370,7 +370,6 @@ function loadBlockAnnotations() {
     // Fetch past block events from the server and merge with stored annotations
     // Limit events to the last 180 minutes
     fetch('/api/block-events?minutes=180')
-    fetch('/api/block-events')
         .then(resp => resp.json())
         .then(data => {
             if (data && Array.isArray(data.events)) {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -76,7 +76,6 @@ def test_payout_history_endpoint(client):
 
 def test_block_events_endpoint(client):
     resp = client.get("/api/block-events?minutes=180")
-    resp = client.get("/api/block-events")
     assert resp.status_code == 200
     data = resp.get_json()
     assert "events" in data


### PR DESCRIPTION
## Summary
- only fetch block events from the last 180 minutes for block annotation lines
- adjust block events API test to hit the endpoint with minutes parameter

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*