### PR TITLE
Improve blocks page chart

### DIFF
--- a/static/css/blocks.css
+++ b/static/css/blocks.css
@@ -90,7 +90,7 @@
 
 /* Miner distribution chart */
 #minerChart {
-  max-width: 500px;
+  max-width: 700px;
   width: 100%;
   height: auto;
   margin: 0 auto;

--- a/static/js/blocks.js
+++ b/static/js/blocks.js
@@ -873,7 +873,7 @@ function updateMinerDistributionChart(blocks) {
         animation: { duration: 500 },
         plugins: {
             legend: {
-                position: 'bottom',
+                position: 'left',
                 labels: { color: theme.PRIMARY }
             },
             tooltip: {

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -21,7 +21,7 @@
         <div class="card">
             <div class="card-header">MINER DISTRIBUTION (LAST 25 BLOCKS)</div>
             <div class="card-body text-center">
-                <canvas id="minerChart" height="120"></canvas>
+                <canvas id="minerChart" height="240"></canvas>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- enlarge the miner distribution chart
- move chart legend to the left

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*