### PR TITLE
Switch history structures to deque

### DIFF
--- a/App.py
+++ b/App.py
@@ -6,6 +6,7 @@ import logging
 import time
 import gc
 import psutil
+from collections import deque
 import signal
 import sys
 import threading
@@ -97,7 +98,7 @@ def log_memory_usage():
         
         # Log the size of key data structures
         logging.info(
-            f"Arrow history entries: {sum(len(v) for v in state_manager.get_history().values() if isinstance(v, list))}"
+            f"Arrow history entries: {sum(len(v) for v in state_manager.get_history().values() if isinstance(v, (list, deque)))}"
         )
         logging.info(f"Metrics log entries: {len(state_manager.get_metrics_log())}")
         logging.info(f"Active SSE connections: {active_sse_connections}")
@@ -225,7 +226,7 @@ def record_memory_metrics():
             "vms_mb": memory_info.vms / 1024 / 1024,
             "percent": process.memory_percent(),
             "arrow_history_entries": sum(
-                len(v) for v in state_manager.get_history().values() if isinstance(v, list)
+                len(v) for v in state_manager.get_history().values() if isinstance(v, (list, deque))
             ),
             "metrics_log_entries": len(state_manager.get_metrics_log()),
             "sse_connections": active_sse_connections
@@ -1050,7 +1051,7 @@ def memory_profile():
                 "data_structures": {
                     "arrow_history": {
                         "entries": sum(
-                            len(v) for v in state_manager.get_history().values() if isinstance(v, list)
+                            len(v) for v in state_manager.get_history().values() if isinstance(v, (list, deque))
                         ),
                         "keys": list(state_manager.get_history().keys())
                     },

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -14,6 +14,7 @@ if 'redis' not in sys.modules:
     redis_mod.Redis = DummyRedisModule
     sys.modules['redis'] = redis_mod
 
+from collections import deque
 from state_manager import StateManager
 
 class DummyRedis:
@@ -29,9 +30,9 @@ class DummyRedis:
 def test_save_and_load_graph_state_gzip():
     mgr = StateManager()
     mgr.redis_client = DummyRedis()
-    mgr.arrow_history = {"hashrate_60sec": [{"time": "00:00:01", "value": 1, "arrow": "", "unit": "th/s"}]}
+    mgr.arrow_history = {"hashrate_60sec": deque([{"time": "00:00:01", "value": 1, "arrow": "", "unit": "th/s"}], maxlen=180)}
     mgr.hashrate_history = [1]
-    mgr.metrics_log = [{"timestamp": "t", "metrics": {"hashrate_60sec": 1, "hashrate_60sec_unit": "th/s"}}]
+    mgr.metrics_log = deque([{"timestamp": "t", "metrics": {"hashrate_60sec": 1, "hashrate_60sec_unit": "th/s"}}], maxlen=180)
 
     mgr.save_graph_state()
     raw = mgr.redis_client.get(mgr.STATE_KEY)


### PR DESCRIPTION
## Summary
- use `collections.deque` for `metrics_log`
- load and save arrow history and metrics log using deques
- adjust prune and update logic for deque objects
- update log helpers in `App.py`
- adapt state manager tests

## Testing
- `python3 -m tests.test_state_manager`
- `for f in tests/*.py; do echo "Running $f"; python3 -m tests.$(basename $f .py); done`
