### PR TITLE
Maintain executor across service calls

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -35,6 +35,8 @@ class MiningDashboardService:
         self.sats_per_btc = 100_000_000
         self.previous_values = {}
         self.session = requests.Session()
+        # Persistent executor for concurrent tasks
+        self.executor = ThreadPoolExecutor(max_workers=6)
         # Cache for storing fetched currency exchange rates
         self.exchange_rates_cache = {"rates": {}, "timestamp": 0.0}
         # Time-to-live (TTL) for exchange rate cache in seconds (~2 hours)
@@ -44,6 +46,7 @@ class MiningDashboardService:
         """Close any open network resources."""
         try:
             self.session.close()
+            self.executor.shutdown(wait=False)
         except Exception as e:
             logging.error(f"Error closing session: {e}")
 
@@ -58,15 +61,14 @@ class MiningDashboardService:
         start_time = time.time()
     
         try:
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                future_ocean = executor.submit(self.get_ocean_data)
-                future_btc = executor.submit(self.get_bitcoin_stats)
-                try:
-                    ocean_data = future_ocean.result(timeout=15)
-                    btc_stats = future_btc.result(timeout=15)
-                except Exception as e:
-                    logging.error(f"Error fetching metrics concurrently: {e}")
-                    return None
+            future_ocean = self.executor.submit(self.get_ocean_data)
+            future_btc = self.executor.submit(self.get_bitcoin_stats)
+            try:
+                ocean_data = future_ocean.result(timeout=15)
+                btc_stats = future_btc.result(timeout=15)
+            except Exception as e:
+                logging.error(f"Error fetching metrics concurrently: {e}")
+                return None
 
             if ocean_data is None:
                 logging.error("Failed to retrieve Ocean data")
@@ -835,113 +837,111 @@ class MiningDashboardService:
         block_count = self.cache.get("block_count")
 
         try:
-            with ThreadPoolExecutor(max_workers=6) as executor:
-                # Add all API endpoints to futures
-                futures = {}
-        
-                # Add blockchain.info endpoints
-                for key, url in blockchain_info_urls.items():
-                    futures[key] = executor.submit(self.fetch_url, url)
-            
-                # Add mempool.guide endpoints
-                for key, url in mempool_urls.items():
-                    futures[f"mempool_{key}"] = executor.submit(self.fetch_url, url)
-        
-                # Get all responses
-                responses = {key: futures[key].result(timeout=5) for key in futures}
-        
-        
-                # Process mempool.guide price data (primary source)
-                price_data = {}
-                mempool_price_response = responses.get("mempool_prices")
-                if mempool_price_response and mempool_price_response.ok:
-                    try:
-                        price_data = mempool_price_response.json()
-                        if "USD" in price_data:
-                            btc_price = float(price_data.get("USD"))
-                            self.cache["btc_price"] = btc_price
-                            self.cache["btc_price_USD"] = btc_price
-                            logging.info(f"Successfully fetched USD price from mempool.guide: {btc_price}")
-                        for curr, value in price_data.items():
-                            if curr != "time":
-                                self.cache[f"btc_price_{curr}"] = float(value)
-                        
-                    except (ValueError, TypeError, json.JSONDecodeError) as e:
-                        logging.error(f"Error parsing mempool.guide price data: {e}")
-                else:
-                    logging.warning("Could not fetch price data from mempool.guide, falling back to blockchain.info")
-            
-                # Fall back to blockchain.info for price if mempool.guide failed or currency not available
-                if btc_price is None and responses["ticker"] and responses["ticker"].ok:
-                    try:
-                        ticker_data = responses["ticker"].json()
-                        btc_price = float(ticker_data.get("USD", {}).get("last", 0))
+            # Add all API endpoints to futures using the shared executor
+            futures = {}
+
+            # Add blockchain.info endpoints
+            for key, url in blockchain_info_urls.items():
+                futures[key] = self.executor.submit(self.fetch_url, url)
+
+            # Add mempool.guide endpoints
+            for key, url in mempool_urls.items():
+                futures[f"mempool_{key}"] = self.executor.submit(self.fetch_url, url)
+
+            # Get all responses
+            responses = {key: futures[key].result(timeout=5) for key in futures}
+
+            # Process mempool.guide price data (primary source)
+            price_data = {}
+            mempool_price_response = responses.get("mempool_prices")
+            if mempool_price_response and mempool_price_response.ok:
+                try:
+                    price_data = mempool_price_response.json()
+                    if "USD" in price_data:
+                        btc_price = float(price_data.get("USD"))
                         self.cache["btc_price"] = btc_price
                         self.cache["btc_price_USD"] = btc_price
-                        logging.info(f"Using blockchain.info price: {btc_price}")
-                    except (ValueError, TypeError, json.JSONDecodeError) as e:
-                        logging.error(f"Error parsing blockchain.info price: {e}")
-                block_height_response = responses.get("mempool_block_height")
-                if block_height_response and block_height_response.ok:
-                    try:
-                        # The API returns just the block height as a simple integer value
-                        block_count = int(block_height_response.text)
-                        self.cache["block_count"] = block_count
-                        logging.info(f"Successfully fetched latest block height from mempool.guide: {block_count}")
-                    except (ValueError, TypeError) as e:
-                        logging.error(f"Error parsing block height from mempool.guide: {e}")
-                        # Will fall back to blockchain.info below if this fails
-                else:
-                    logging.warning("Could not fetch block height from mempool.guide, falling back to blockchain.info")
-            
-                # Process mempool.guide hashrate data (primary source)
-                mempool_hashrate_response = responses.get("mempool_hashrate")
-                if mempool_hashrate_response and mempool_hashrate_response.ok:
-                    try:
-                        hashrate_data = mempool_hashrate_response.json()
-                        # Use currentHashrate from the API (already in H/s)
-                        network_hashrate = hashrate_data.get("currentHashrate")
-            
-                        # Also update difficulty if available in the response
-                        if "currentDifficulty" in hashrate_data:
-                            difficulty = hashrate_data.get("currentDifficulty")
-            
-                        # Cache the updated values
-                        self.cache["network_hashrate"] = network_hashrate
-                        self.cache["difficulty"] = difficulty
-            
-                        logging.info(f"Successfully fetched network hashrate from mempool.guide: {network_hashrate/1e18:.2f} EH/s")
-                    except (ValueError, TypeError, json.JSONDecodeError) as e:
-                        logging.error(f"Error parsing mempool.guide hashrate data: {e}")
-                else:
-                    logging.warning("Could not fetch hashrate from mempool.guide, falling back to blockchain.info")
+                        logging.info(f"Successfully fetched USD price from mempool.guide: {btc_price}")
+                    for curr, value in price_data.items():
+                        if curr != "time":
+                            self.cache[f"btc_price_{curr}"] = float(value)
+
+                except (ValueError, TypeError, json.JSONDecodeError) as e:
+                    logging.error(f"Error parsing mempool.guide price data: {e}")
+            else:
+                logging.warning("Could not fetch price data from mempool.guide, falling back to blockchain.info")
+
+            # Fall back to blockchain.info for price if mempool.guide failed or currency not available
+            if btc_price is None and responses["ticker"] and responses["ticker"].ok:
+                try:
+                    ticker_data = responses["ticker"].json()
+                    btc_price = float(ticker_data.get("USD", {}).get("last", 0))
+                    self.cache["btc_price"] = btc_price
+                    self.cache["btc_price_USD"] = btc_price
+                    logging.info(f"Using blockchain.info price: {btc_price}")
+                except (ValueError, TypeError, json.JSONDecodeError) as e:
+                    logging.error(f"Error parsing blockchain.info price: {e}")
+            block_height_response = responses.get("mempool_block_height")
+            if block_height_response and block_height_response.ok:
+                try:
+                    # The API returns just the block height as a simple integer value
+                    block_count = int(block_height_response.text)
+                    self.cache["block_count"] = block_count
+                    logging.info(f"Successfully fetched latest block height from mempool.guide: {block_count}")
+                except (ValueError, TypeError) as e:
+                    logging.error(f"Error parsing block height from mempool.guide: {e}")
+                    # Will fall back to blockchain.info below if this fails
+            else:
+                logging.warning("Could not fetch block height from mempool.guide, falling back to blockchain.info")
+
+            # Process mempool.guide hashrate data (primary source)
+            mempool_hashrate_response = responses.get("mempool_hashrate")
+            if mempool_hashrate_response and mempool_hashrate_response.ok:
+                try:
+                    hashrate_data = mempool_hashrate_response.json()
+                    # Use currentHashrate from the API (already in H/s)
+                    network_hashrate = hashrate_data.get("currentHashrate")
+
+                    # Also update difficulty if available in the response
+                    if "currentDifficulty" in hashrate_data:
+                        difficulty = hashrate_data.get("currentDifficulty")
+
+                    # Cache the updated values
+                    self.cache["network_hashrate"] = network_hashrate
+                    self.cache["difficulty"] = difficulty
+
+                    logging.info(f"Successfully fetched network hashrate from mempool.guide: {network_hashrate/1e18:.2f} EH/s")
+                except (ValueError, TypeError, json.JSONDecodeError) as e:
+                    logging.error(f"Error parsing mempool.guide hashrate data: {e}")
+            else:
+                logging.warning("Could not fetch hashrate from mempool.guide, falling back to blockchain.info")
     
                 # Process blockchain.info hashrate as fallback
-                if network_hashrate is None and responses["hashrate"] and responses["hashrate"].ok:
-                    try:
-                        # blockchain.info returns hashrate in GH/s, convert to H/s for consistency
-                        network_hashrate = float(responses["hashrate"].text) * 1e9
-                        self.cache["network_hashrate"] = network_hashrate
-                        logging.info(f"Using blockchain.info network hashrate: {network_hashrate/1e18:.2f} EH/s")
-                    except (ValueError, TypeError) as e:
-                        logging.error(f"Error parsing network hashrate from blockchain.info: {e}")
-    
-                # Handle difficulty (if not already set by mempool.guide)
-                if difficulty is None and responses["difficulty"] and responses["difficulty"].ok:
-                    try:
-                        difficulty = float(responses["difficulty"].text)
-                        self.cache["difficulty"] = difficulty
-                    except (ValueError, TypeError) as e:
-                        logging.error(f"Error parsing difficulty: {e}")
-            
-                # Handle blockchain.info block count as fallback if mempool.guide failed
-                if block_count is None and responses["blockcount"] and responses["blockcount"].ok:
-                    try:
-                        block_count = int(responses["blockcount"].text)
-                        self.cache["block_count"] = block_count
-                        logging.info(f"Using blockchain.info block height: {block_count}")
-                    except (ValueError, TypeError) as e:
-                        logging.error(f"Error parsing block count: {e}")
+            if network_hashrate is None and responses["hashrate"] and responses["hashrate"].ok:
+                try:
+                    # blockchain.info returns hashrate in GH/s, convert to H/s for consistency
+                    network_hashrate = float(responses["hashrate"].text) * 1e9
+                    self.cache["network_hashrate"] = network_hashrate
+                    logging.info(f"Using blockchain.info network hashrate: {network_hashrate/1e18:.2f} EH/s")
+                except (ValueError, TypeError) as e:
+                    logging.error(f"Error parsing network hashrate from blockchain.info: {e}")
+
+            # Handle difficulty (if not already set by mempool.guide)
+            if difficulty is None and responses["difficulty"] and responses["difficulty"].ok:
+                try:
+                    difficulty = float(responses["difficulty"].text)
+                    self.cache["difficulty"] = difficulty
+                except (ValueError, TypeError) as e:
+                    logging.error(f"Error parsing difficulty: {e}")
+
+            # Handle blockchain.info block count as fallback if mempool.guide failed
+            if block_count is None and responses["blockcount"] and responses["blockcount"].ok:
+                try:
+                    block_count = int(responses["blockcount"].text)
+                    self.cache["block_count"] = block_count
+                    logging.info(f"Using blockchain.info block height: {block_count}")
+                except (ValueError, TypeError) as e:
+                    logging.error(f"Error parsing block count: {e}")
             
         except Exception as e:
             logging.error(f"Error fetching Bitcoin stats: {e}")


### PR DESCRIPTION
## Summary
- reuse a single `ThreadPoolExecutor` for all requests
- shut down the executor when closing the service

## Testing
- `python3 -m py_compile data_service.py` *(passes)*
- `python3 -m pytest -q` *(fails: No module named pytest)*