### PR TITLE
Add page loader overlay

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -1229,3 +1229,39 @@ html.deepsea-theme #congratsMessage {
     border-right: 3px solid var(--primary-color);
   }
 }
+
+/* ----- PAGE LOADER ----- */
+#page-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 9998;
+  font-family: var(--terminal-font);
+}
+
+html.bitcoin-theme #page-loader {
+  background-color: #111111;
+  color: #f2a900;
+}
+
+html.deepsea-theme #page-loader {
+  background-color: #0c141a;
+  color: #0088cc;
+}
+
+#page-loader-icon {
+  font-size: 48px;
+  margin-bottom: 20px;
+  animation: spin 2s infinite linear;
+}
+
+#page-loader-text {
+  font-size: 24px;
+  text-transform: uppercase;
+}

--- a/static/js/earnings.js
+++ b/static/js/earnings.js
@@ -1,5 +1,8 @@
 // earnings.js
 document.addEventListener('DOMContentLoaded', function () {
+    if (window.PageLoader) {
+        PageLoader.show('Loading earnings...');
+    }
     console.log('Earnings page loaded');
 
     // Add refresh functionality if needed
@@ -13,6 +16,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Initialize the system monitor
     initializeSystemMonitor();
+    if (window.PageLoader) {
+        PageLoader.hide();
+    }
 });
 
 // Initialize the BitcoinMinuteRefresh system monitor

--- a/static/js/page-loader.js
+++ b/static/js/page-loader.js
@@ -1,0 +1,40 @@
+// page-loader.js
+(function(global){
+    function getEmoji() {
+        var useDeepSea = localStorage.getItem('useDeepSeaTheme') === 'true';
+        return useDeepSea ? '🌊' : '₿';
+    }
+
+    function ensureLoader() {
+        var loader = document.getElementById('page-loader');
+        if (!loader) {
+            loader = document.createElement('div');
+            loader.id = 'page-loader';
+
+            var icon = document.createElement('div');
+            icon.id = 'page-loader-icon';
+            loader.appendChild(icon);
+
+            var text = document.createElement('div');
+            text.id = 'page-loader-text';
+            loader.appendChild(text);
+
+            document.body.appendChild(loader);
+        }
+        return loader;
+    }
+
+    function show(message) {
+        var loader = ensureLoader();
+        loader.querySelector('#page-loader-icon').innerHTML = getEmoji();
+        loader.querySelector('#page-loader-text').textContent = message || 'Loading...';
+        loader.style.display = 'flex';
+    }
+
+    function hide() {
+        var loader = document.getElementById('page-loader');
+        if (loader) loader.style.display = 'none';
+    }
+
+    global.PageLoader = { show: show, hide: hide };
+})(window);

--- a/static/js/workers.js
+++ b/static/js/workers.js
@@ -538,10 +538,16 @@ function updateServerTime() {
 // Utility functions to show/hide loader
 function showLoader() {
     $("#loader").show();
+    if (window.PageLoader) {
+        PageLoader.show('Loading workers...');
+    }
 }
 
 function hideLoader() {
     $("#loader").hide();
+    if (window.PageLoader) {
+        PageLoader.hide();
+    }
 }
 
 // Modified to properly fetch and store currency data 

--- a/templates/base.html
+++ b/templates/base.html
@@ -244,6 +244,8 @@
     <!-- Pin Chart.js version and load local annotation plugin for offline support -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
     <script src="{{ url_for('static', filename='js/chartjs-plugin-annotation-lite.js') }}"></script>
+    <!-- Global page loader utilities -->
+    <script src="{{ url_for('static', filename='js/page-loader.js') }}"></script>
 
     <!-- Theme toggle initialization -->
     <script>


### PR DESCRIPTION
## Summary
- show a global page loader so slow pages display a friendly spinner
- integrate the loader with the workers and earnings pages

## Testing
- `pytest -q` *(fails: command not found)*