### PR TITLE
Improve earnings page resiliency and visuals

### DIFF
--- a/static/css/earnings.css
+++ b/static/css/earnings.css
@@ -94,6 +94,17 @@ html.deepsea-theme {
   z-index: -1;
 }
 
+/* Notice banner for API errors */
+.error-banner {
+  background-color: rgba(255, 0, 0, 0.7);
+  color: #fff;
+  text-align: center;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  font-weight: bold;
+  animation: pulse-highlight 2s infinite;
+}
+
 /* ----- CARD STYLING ----- */
 .stat-card {
   color: white;
@@ -103,6 +114,12 @@ html.deepsea-theme {
   position: relative;
   background-color: var(--bg-color);
   overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.5);
 }
 
 .stat-card::after {

--- a/static/js/earnings.js
+++ b/static/js/earnings.js
@@ -1,18 +1,15 @@
 // earnings.js
+let earningsChart = null;
+
 document.addEventListener('DOMContentLoaded', function () {
     console.log('Earnings page loaded');
 
-    // Add refresh functionality if needed
     setupAutoRefresh();
-
-    // Format all currency values with commas
     formatCurrencyValues();
-
-    // Apply user timezone formatting to all dates
     applyUserTimezoneFormatting();
-
-    // Initialize the system monitor
     initializeSystemMonitor();
+    initEarningsChart();
+    fetchEarningsData();
 });
 
 // Initialize the BitcoinMinuteRefresh system monitor
@@ -20,7 +17,7 @@ function initializeSystemMonitor() {
     // Define refresh function for the system monitor
     window.manualRefresh = function () {
         console.log("Manual refresh triggered by system monitor");
-        location.reload();
+        fetchEarningsData();
     };
 
     // Initialize system monitor if it's available
@@ -123,10 +120,10 @@ function setupAutoRefresh() {
     // Check if refresh is enabled in the UI
     const refreshToggle = document.getElementById('refresh-toggle');
     if (refreshToggle && refreshToggle.checked) {
-        // Set a refresh interval (e.g., every 5 minutes)
+        // Periodically fetch new data
         setInterval(function () {
-            location.reload();
-        }, 5 * 60 * 1000);
+            fetchEarningsData();
+        }, 3 * 60 * 1000);
     }
 }
 
@@ -152,6 +149,77 @@ function applyUserTimezoneFormatting() {
 
     // This function would format dates according to user timezone preference
     // when dates are dynamically loaded or updated via JavaScript
+}
+
+// Fetch latest earnings data from the API and update the UI
+function fetchEarningsData() {
+    fetch('/api/earnings')
+        .then(response => response.json())
+        .then(data => {
+            if (data.error) {
+                showErrorBanner('Failed to fetch earnings');
+                return;
+            }
+            hideErrorBanner();
+            updateEarningsUI(data);
+        })
+        .catch(() => showErrorBanner('Failed to fetch earnings'));
+}
+
+// Update DOM elements with latest earnings data
+function updateEarningsUI(data) {
+    if (!data) return;
+    document.getElementById('unpaid-sats').textContent = formatSats(data.unpaid_earnings_sats);
+    document.getElementById('unpaid-btc').textContent = formatBTC(data.unpaid_earnings);
+    document.getElementById('est-time-payout').textContent = data.est_time_to_payout || 'Unknown';
+    document.getElementById('total-paid-sats').textContent = formatSats(data.total_paid_sats);
+    document.getElementById('total-paid-btc').textContent = formatBTC(data.total_paid_btc);
+    if (data.total_paid_fiat !== undefined) {
+        document.getElementById('total-paid-fiat').innerHTML = `<span id="total-paid-currency-symbol">${currencySymbol}</span>${formatCurrency(parseFloat(data.total_paid_fiat).toFixed(2))}`;
+    }
+    document.getElementById('payment-count').textContent = formatCurrency(data.total_payments);
+    if (data.payments && data.payments.length > 0) {
+        document.getElementById('latest-payment').textContent = 'Latest: ' + formatDateToUserTimezone(data.payments[0].date);
+    }
+    if (earningsChart) {
+        updateEarningsChart(data.monthly_summaries || []);
+    }
+}
+
+// Initialize Chart.js bar chart for monthly totals
+function initEarningsChart() {
+    if (!window.Chart) return;
+    const canvas = document.getElementById('earningsChart');
+    if (!canvas) return;
+    const labels = monthlySummaries.map(m => m.month_name);
+    const values = monthlySummaries.map(m => m.total_fiat || m.total_usd || m.total_btc);
+    const theme = getCurrentTheme();
+    const ctx = canvas.getContext('2d');
+    earningsChart = new Chart(ctx, {
+        type: 'bar',
+        data: { labels: labels, datasets: [{ data: values, backgroundColor: theme.PRIMARY }] },
+        options: { responsive: true, plugins: { legend: { display: false } } }
+    });
+}
+
+function updateEarningsChart(summaries) {
+    if (!earningsChart) return;
+    earningsChart.data.labels = summaries.map(m => m.month_name);
+    earningsChart.data.datasets[0].data = summaries.map(m => m.total_fiat || m.total_usd || m.total_btc);
+    earningsChart.update();
+}
+
+function showErrorBanner(msg) {
+    const banner = document.querySelector('.error-banner');
+    if (banner) {
+        banner.textContent = msg;
+        banner.style.display = 'block';
+    }
+}
+
+function hideErrorBanner() {
+    const banner = document.querySelector('.error-banner');
+    if (banner) banner.style.display = 'none';
 }
 
 // Function to format a timestamp based on user timezone

--- a/templates/earnings.html
+++ b/templates/earnings.html
@@ -14,11 +14,14 @@
 
 {% block content %}
 <div class="dashboard-container">
+    {% if error_message %}
+    <div class="error-banner">{{ error_message }}</div>
+    {% endif %}
 
     <!-- Summary Cards Section -->
     <div class="stats-grid">
         <div class="stat-card">
-            <h2>Unpaid Earnings</h2>
+            <h2><i class="fa-solid fa-coins"></i> Unpaid Earnings</h2>
             <div class="stat-value">
                 <span id="unpaid-sats">{{ earnings.unpaid_earnings_sats|default(0)|int|commafy }}</span>
                 <span class="stat-unit">sats</span>
@@ -30,7 +33,7 @@
         </div>
 
         <div class="stat-card">
-            <h2>Total Paid</h2>
+            <h2><i class="fa-solid fa-wallet"></i> Total Paid</h2>
             <div class="stat-value">
                 <span id="total-paid-sats">{{ earnings.total_paid_sats|default(0)|int|commafy }}</span>
                 <span class="stat-unit">sats</span>
@@ -44,7 +47,7 @@
         </div>
 
         <div class="stat-card">
-            <h2>Total Payments</h2>
+            <h2><i class="fa-solid fa-file-invoice-dollar"></i> Total Payments</h2>
             <div class="stat-value">
                 <span id="payment-count">{{ earnings.total_payments|default(0) }}</span>
             </div>
@@ -65,6 +68,9 @@
     <!-- Monthly Summaries Section -->
     <div class="earnings-section">
         <h2>Monthly Summary</h2>
+        <div class="chart-container">
+            <canvas id="earningsChart"></canvas>
+        </div>
         <div class="table-container">
             <table class="earnings-table">
                 <thead>
@@ -144,6 +150,7 @@
     const userCurrency = "{{ user_currency }}";
     const userTimezone = "{{ user_timezone }}";
     const currencySymbol = "{{ currency_symbols[user_currency] }}";
+    const monthlySummaries = {{ earnings.monthly_summaries | tojson | safe }};
 </script>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- cache latest earnings in `StateManager`
- use cached data on errors and show banner in UI
- add bar chart of monthly totals
- auto refresh earnings data periodically
- update styling and icons for consistency

## Testing
- `python -m py_compile App.py state_manager.py`
- `pytest -q` *(fails: command not found)*