### PR TITLE
Improve earnings page resiliency and visuals

### DIFF
--- a/static/css/earnings.css
+++ b/static/css/earnings.css
@@ -94,6 +94,17 @@ html.deepsea-theme {
   z-index: -1;
 }
 
+/* Notice banner for API errors */
+.error-banner {
+  background-color: rgba(255, 0, 0, 0.7);
+  color: #fff;
+  text-align: center;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  font-weight: bold;
+  animation: pulse-highlight 2s infinite;
+}
+
 /* ----- CARD STYLING ----- */
 .stat-card {
   color: white;
@@ -103,6 +114,12 @@ html.deepsea-theme {
   position: relative;
   background-color: var(--bg-color);
   overflow: hidden;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 15px rgba(var(--primary-color-rgb), 0.5);
 }
 
 .stat-card::after {
@@ -357,34 +374,7 @@ html.deepsea-theme {
   color: var(--accent-color);
 }
 
-/* ----- CHARTS & VISUALIZATIONS ----- */
-.chart-container {
-  background-color: var(--bg-color);
-  padding: 0.5rem;
-  margin-bottom: 1rem;
-  height: 230px;
-  border: 1px solid var(--primary-color);
-  box-shadow: 0 0 10px rgba(var(--primary-color-rgb), 0.2);
-  position: relative;
-}
 
-.chart-container::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: repeating-linear-gradient(
-    0deg,
-    rgba(0, 0, 0, 0.1),
-    rgba(0, 0, 0, 0.1) 1px,
-    transparent 1px,
-    transparent 2px
-  );
-  pointer-events: none;
-  z-index: 1;
-}
 
 /* ----- ANIMATIONS ----- */
 @keyframes bounceUp {

--- a/templates/earnings.html
+++ b/templates/earnings.html
@@ -14,11 +14,14 @@
 
 {% block content %}
 <div class="dashboard-container">
+    {% if error_message %}
+    <div class="error-banner">{{ error_message }}</div>
+    {% endif %}
 
     <!-- Summary Cards Section -->
     <div class="stats-grid">
         <div class="stat-card">
-            <h2>Unpaid Earnings</h2>
+            <h2><i class="fa-solid fa-coins"></i> Unpaid Earnings</h2>
             <div class="stat-value">
                 <span id="unpaid-sats">{{ earnings.unpaid_earnings_sats|default(0)|int|commafy }}</span>
                 <span class="stat-unit">sats</span>
@@ -30,7 +33,7 @@
         </div>
 
         <div class="stat-card">
-            <h2>Total Paid</h2>
+            <h2><i class="fa-solid fa-wallet"></i> Total Paid</h2>
             <div class="stat-value">
                 <span id="total-paid-sats">{{ earnings.total_paid_sats|default(0)|int|commafy }}</span>
                 <span class="stat-unit">sats</span>
@@ -44,7 +47,7 @@
         </div>
 
         <div class="stat-card">
-            <h2>Total Payments</h2>
+            <h2><i class="fa-solid fa-file-invoice-dollar"></i> Total Payments</h2>
             <div class="stat-value">
                 <span id="payment-count">{{ earnings.total_payments|default(0) }}</span>
             </div>


### PR DESCRIPTION
## Summary
- cache latest earnings in `StateManager`
- use cached data on errors and show banner in UI
- auto refresh earnings data periodically
- update styling and icons for consistency
- remove the unused Chart.js earnings chart

## Testing
- `python -m py_compile App.py state_manager.py`
- `pytest -q` *(fails: command not found)*