### PR TITLE
Add payout interval averaging

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1012,6 +1012,9 @@ function trackPayoutPerformance(data) {
                     lastPayoutTracking.payoutHistory.pop();
                 }
 
+                // Update average payout interval
+                updateAvgDaysFromHistory();
+
                 // Save to local storage for persistence
                 try {
                     localStorage.setItem('payoutHistory', JSON.stringify(lastPayoutTracking.payoutHistory));
@@ -1214,6 +1217,30 @@ function loadLocalHistory() {
     } catch (e) {
         console.error("Error loading payout history from localStorage:", e);
     }
+}
+
+// Calculate the average number of days between consecutive payouts
+function updateAvgDaysFromHistory() {
+    const history = lastPayoutTracking.payoutHistory;
+    if (!Array.isArray(history) || history.length < 2) {
+        lastPayoutTracking.avgDays = null;
+        return;
+    }
+
+    let totalDays = 0;
+    let intervals = 0;
+
+    for (let i = 0; i < history.length - 1; i++) {
+        const current = new Date(history[i].timestamp);
+        const next = new Date(history[i + 1].timestamp);
+        const diff = current - next;
+        if (!isNaN(diff) && diff >= 0) {
+            totalDays += diff / (24 * 60 * 60 * 1000);
+            intervals++;
+        }
+    }
+
+    lastPayoutTracking.avgDays = intervals > 0 ? totalDays / intervals : null;
 }
 
 // Update the init function to add the summary display
@@ -1666,6 +1693,9 @@ function verifyPayoutsAgainstOfficial() {
             if (lastPayoutTracking.payoutHistory.length > 30) {
                 lastPayoutTracking.payoutHistory = lastPayoutTracking.payoutHistory.slice(0, 30);
             }
+
+            // Recalculate average payout interval
+            updateAvgDaysFromHistory();
 
             // Update the display with enriched data if it's visible
             if ($("#payout-history-container").is(":visible")) {


### PR DESCRIPTION
## Summary
- compute average days between payouts
- recalc average after new payout and after verifying history

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*