### PR TITLE
Integrate additional Ocean API endpoints

### DIFF
--- a/docs/ocean-api-integration.md
+++ b/docs/ocean-api-integration.md
@@ -16,7 +16,7 @@ https://api.ocean.xyz/v1/user_hashrate/3QomtEj5nfzEkxPXoVD3hvxgJDzA6M6evt
 |----------|-------------|-----------|---------|
 | /ping | Server status test | None | "PONG" |
 | /statsnap/{username} | Latest TIDES snapshot for a user or worker | username[.workername] | Hashrate, shares, earnings estimation |
-| /pool_stat | Pool-wide TIDES stats | None | Stats snapshot of active users, workers, difficulty, and rewards |
+| /pool_stat | Pool-wide stats (hashrate, workers, blocks) | None | Stats snapshot of active users, workers, and blocks found |
 | /pool_hashrate | Pool-wide hashrate info | None | Hashrate averages over 60s and 300s |
 | /userinfo_full/{username} | statsnap for all of a user’s workers | username | Array of statsnap results per worker |
 | /multitemplate_stats | Multitemplate share breakdown | None | Array of shares per mining template |

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -225,3 +225,44 @@ def test_get_worker_data_api(monkeypatch):
     assert 'rig1' in names and 'rig2' in names
 
 
+def test_get_pool_stat_api(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+
+    sample = {
+        'hashrate_60s': 1000,
+        'workers': 5,
+        'blocks': 10
+    }
+
+    def fake_get(url, timeout=10):
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = sample
+        return resp
+
+    monkeypatch.setattr(svc.session, 'get', fake_get)
+    data = svc.get_pool_stat_api()
+
+    assert data['workers_hashing'] == 5
+    assert data['blocks_found'] == 10
+    assert data['pool_total_hashrate'] == 1000
+
+
+def test_get_blocks_api(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+
+    sample = {'blocks': [{'height': 100, 'time': 1700000000}]}
+
+    def fake_get(url, timeout=10):
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = sample
+        return resp
+
+    monkeypatch.setattr(svc.session, 'get', fake_get)
+    blocks = svc.get_blocks_api()
+
+    assert isinstance(blocks, list)
+    assert blocks[0]['height'] == 100
+
+


### PR DESCRIPTION
## Summary
- use `/pool_stat` and `/blocks` endpoints to supply extra pool and block data
- document new endpoints in API integration guide
- test `get_pool_stat_api` and `get_blocks_api`

## Testing
- `pytest -q` *(fails: command not found)*