### PR TITLE
Preserve chart point preference on SSE reconnect

### DIFF
--- a/App.py
+++ b/App.py
@@ -590,7 +590,7 @@ def stream():
         start_event_id = 0
 
     try:
-        num_points = int(request.args.get("points", 30))
+        num_points = int(request.args.get("points", 180))
         if num_points not in [30, 60, 180]:
             num_points = 180
     except Exception:

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1404,6 +1404,19 @@ function setupEventSource() {
         window.eventSource = null;
     }
 
+    // Reload chart points preference in case the variable was reset
+    try {
+        const storedPreference = localStorage.getItem('chartPointsPreference');
+        if (storedPreference) {
+            const points = parseInt(storedPreference, 10);
+            if ([30, 60, 180].includes(points)) {
+                chartPoints = points;
+            }
+        }
+    } catch (e) {
+        console.error("Error loading chart points preference", e);
+    }
+
     // Always use absolute URL with origin to ensure it works from any path
     const baseUrl = window.location.origin;
     // Include points parameter in the stream URL


### PR DESCRIPTION
## Summary
- default `/stream` endpoint to 180 data points when query param is missing
- reload `chartPointsPreference` before every SSE reconnection to ensure the correct value is used

## Testing
- `pytest -q` *(fails: command not found)*