### PR TITLE
Toggleable emoji easter egg

### DIFF
--- a/static/css/easter-egg.css
+++ b/static/css/easter-egg.css
@@ -61,3 +61,20 @@
       font-size: 2rem;
     }
   }
+
+body.easterEggActive p::after,
+body.easterEggActive h1::after,
+body.easterEggActive h2::after,
+body.easterEggActive h3::after,
+body.easterEggActive h4::after,
+body.easterEggActive h5::after,
+body.easterEggActive h6::after,
+body.easterEggActive li::after,
+body.easterEggActive a::after,
+body.easterEggActive span::after,
+body.easterEggActive td::after,
+body.easterEggActive th::after {
+  content: var(--egg-emoji);
+  margin-left: 4px;
+  opacity: 0.9;
+}

--- a/static/js/easterEgg.js
+++ b/static/js/easterEgg.js
@@ -3,6 +3,18 @@
   let index = 0;
   let cursorClicks = [];
 
+  function applyEmojiMode() {
+    const useDeepSea = localStorage.getItem('useDeepSeaTheme') === 'true';
+    const emoji = useDeepSea ? '🐳' : '₿';
+    document.body.classList.add('easterEggActive');
+    document.body.style.setProperty('--egg-emoji', '"' + emoji + '"');
+  }
+
+  function removeEmojiMode() {
+    document.body.classList.remove('easterEggActive');
+    document.body.style.removeProperty('--egg-emoji');
+  }
+
   function handleKey(e) {
     if (e.key === konami[index]) {
       index++;
@@ -28,7 +40,8 @@
     }
 
     const text = document.createElement('div');
-    text.textContent = useDeepSea ? 'DeepSea Discovery!' : 'Bitcoin Surprise!';
+    const active = localStorage.getItem('easterEggActive') === 'true';
+    text.textContent = active ? 'Easter Egg Disabled!' : (useDeepSea ? 'DeepSea Discovery!' : 'Bitcoin Surprise!');
     overlay.appendChild(text);
 
     const iconCount = window.innerWidth < 600
@@ -52,8 +65,16 @@
       overlay.appendChild(icon);
     }
 
+    if (active) {
+      removeEmojiMode();
+      localStorage.setItem('easterEggActive', 'false');
+    } else {
+      applyEmojiMode();
+      localStorage.setItem('easterEggActive', 'true');
+    }
+
     document.body.appendChild(overlay);
-    setTimeout(() => overlay.remove(), 10000);
+    setTimeout(() => overlay.remove(), 3000);
   }
 
   window.addEventListener('keydown', handleKey);
@@ -77,4 +98,8 @@
 
   window.addEventListener('click', cursorListener);
   window.addEventListener('touchstart', cursorListener);
+
+  if (localStorage.getItem('easterEggActive') === 'true') {
+    applyEmojiMode();
+  }
 })();


### PR DESCRIPTION
## Summary
- extend the easter egg script to toggle a persistent emoji mode
- show whales or bitcoin symbols after most text when enabled
- add CSS rules for inserting emojis throughout the page

## Testing
- `pytest -q` *(fails: command not found)*