### PR TITLE
Enhance Bitcoin theme Easter egg visuals

### DIFF
--- a/static/css/easter-egg.css
+++ b/static/css/easter-egg.css
@@ -36,6 +36,7 @@
   font-size: 3rem;
   animation: spin-move 12s linear infinite;
   pointer-events: none;
+  color: #f7931a;
 }
 
 @keyframes swim {
@@ -77,4 +78,6 @@ body.easterEggActive th::after {
   content: var(--egg-emoji);
   margin-left: 4px;
   opacity: 0.9;
+  color: #f7931a;
+  font-size: 1.3em;
 }

--- a/static/js/easterEgg.js
+++ b/static/js/easterEgg.js
@@ -61,7 +61,12 @@
       icon.style.left = '-150px';
       icon.style.animationDuration = 8 + Math.random() * 4 + 's';
       icon.style.animationDelay = Math.random() * 6 + 's';
-      icon.style.fontSize = 2 + Math.random() * 2 + 'rem';
+      if (useDeepSea) {
+        icon.style.fontSize = 2 + Math.random() * 2 + 'rem';
+      } else {
+        icon.style.fontSize = 4 + Math.random() * 2 + 'rem';
+        icon.style.color = '#f7931a';
+      }
       overlay.appendChild(icon);
     }
 


### PR DESCRIPTION
## Summary
- adjust easter egg icon generation for larger bitcoin symbols and orange color
- style bitcoin icons and emoji overlays to use bitcoin orange and larger font size

## Testing
- `pytest -q` *(fails: command not found)*