### PR TITLE
Add theme-aware cursor burst

### DIFF
--- a/static/css/easter-egg.css
+++ b/static/css/easter-egg.css
@@ -72,21 +72,23 @@
     }
   }
 
-body.easterEggActive p::after,
-body.easterEggActive h1::after,
-body.easterEggActive h2::after,
-body.easterEggActive h3::after,
-body.easterEggActive h4::after,
-body.easterEggActive h5::after,
-body.easterEggActive h6::after,
-body.easterEggActive li::after,
-body.easterEggActive a::after,
-body.easterEggActive span::after,
-body.easterEggActive td::after,
-body.easterEggActive th::after {
-  content: var(--egg-emoji);
-  margin-left: 4px;
-  opacity: 0.9;
-  color: #f7931a;
-  font-size: 1.3em;
+
+.cursor-whale {
+  position: fixed;
+  z-index: 10000;
+  pointer-events: none;
+  font-size: 1.5rem;
+  color: var(--primary-color);
+  animation: whaleBurst 0.7s forwards;
+}
+
+@keyframes whaleBurst {
+  from {
+    transform: translate(0, 0);
+    opacity: 1;
+  }
+  to {
+    transform: translate(var(--x), var(--y)) scale(0.8);
+    opacity: 0;
+  }
 }

--- a/static/js/easterEgg.js
+++ b/static/js/easterEgg.js
@@ -10,16 +10,65 @@
     'Whales can hold their breath for more than an hour!'
   ];
 
+  let lastWhaleTime = 0;
+
+  function spawnWhales(x, y) {
+    const count = 8;
+    const useDeepSea = document.documentElement.classList.contains('deepsea-theme');
+    const symbol = useDeepSea ? '🐳' : '₿';
+    for (let i = 0; i < count; i++) {
+      const emoji = document.createElement('span');
+      emoji.className = 'cursor-whale';
+      emoji.textContent = symbol;
+      const angle = Math.random() * Math.PI * 2;
+      const distance = 60 + Math.random() * 40;
+      const xMove = Math.cos(angle) * distance;
+      const yMove = Math.sin(angle) * distance;
+      emoji.style.left = x + 'px';
+      emoji.style.top = y + 'px';
+      emoji.style.setProperty('--x', xMove + 'px');
+      emoji.style.setProperty('--y', yMove + 'px');
+      if (!useDeepSea) {
+        emoji.style.color = '#f7931a';
+      }
+      document.body.appendChild(emoji);
+      emoji.addEventListener('animationend', () => emoji.remove());
+    }
+  }
+
+  function handleMove(e) {
+    const now = Date.now();
+    if (now - lastWhaleTime > 50) {
+      lastWhaleTime = now;
+      spawnWhales(e.clientX, e.clientY);
+    }
+  }
+
+  function handleTouch(e) {
+    const t = e.touches[0];
+    if (t) {
+      spawnWhales(t.clientX, t.clientY);
+    }
+  }
+
+  function addWhaleListeners() {
+    window.addEventListener('mousemove', handleMove);
+    window.addEventListener('touchstart', handleTouch);
+  }
+
+  function removeWhaleListeners() {
+    window.removeEventListener('mousemove', handleMove);
+    window.removeEventListener('touchstart', handleTouch);
+  }
+
   function applyEmojiMode() {
-    const useDeepSea = localStorage.getItem('useDeepSeaTheme') === 'true';
-    const emoji = useDeepSea ? '🐳' : '₿';
     document.body.classList.add('easterEggActive');
-    document.body.style.setProperty('--egg-emoji', '"' + emoji + '"');
+    addWhaleListeners();
   }
 
   function removeEmojiMode() {
     document.body.classList.remove('easterEggActive');
-    document.body.style.removeProperty('--egg-emoji');
+    removeWhaleListeners();
   }
 
   function handleKey(e) {


### PR DESCRIPTION
## Summary
- make cursor burst color follow theme primary color
- spawn whales on DeepSea theme and orange ₿ bursts on Bitcoin theme

## Testing
- `pytest -q` *(fails: command not found)*