### PR TITLE
Enhance system monitor memory display

### DIFF
--- a/App.py
+++ b/App.py
@@ -934,10 +934,12 @@ def health_check():
         mem_info = process.memory_info()
         memory_usage_mb = mem_info.rss / 1024 / 1024
         memory_percent = process.memory_percent()
+        memory_total_mb = psutil.virtual_memory().total / 1024 / 1024
     except Exception as e:
         logging.error(f"Error getting memory usage: {e}")
         memory_usage_mb = 0
         memory_percent = 0
+        memory_total_mb = 0
     
     # Check data freshness
     data_age = 0
@@ -963,7 +965,8 @@ def health_check():
         "connections": active_sse_connections,
         "memory": {
             "usage_mb": round(memory_usage_mb, 2),
-            "percent": round(memory_percent, 2)
+            "percent": round(memory_percent, 2),
+            "total_mb": round(memory_total_mb, 2)
         },
         "data": {
             "last_update": cached_metrics.get("server_timestamp") if cached_metrics else None,

--- a/static/js/BitcoinProgressBar.js
+++ b/static/js/BitcoinProgressBar.js
@@ -1247,6 +1247,7 @@ const BitcoinMinuteRefresh = (function () {
         font-size: 0.8rem;
         font-weight: bold;
         margin-bottom: 4px;
+        color: var(--primary-color, ${theme.color});
       }
 
       .page-controls {
@@ -1283,6 +1284,7 @@ const BitcoinMinuteRefresh = (function () {
       .data-age {
         font-size: 0.9rem;
         margin-top: 4px;
+        color: #ffffff;
       }
       
       /* CRT scanline effect */
@@ -1569,7 +1571,11 @@ const BitcoinMinuteRefresh = (function () {
         if (memFill && data.memory && data.memory.percent != null) {
             const pct = Math.round(data.memory.percent);
             memFill.style.width = pct + '%';
-            if (memText) memText.textContent = pct + '%';
+            if (memText) {
+                const used = Math.round(data.memory.usage_mb);
+                const total = data.memory.total_mb ? Math.round(data.memory.total_mb) : 0;
+                memText.textContent = `${used}MB / ${total}MB (${pct}%)`;
+            }
         }
 
         const connText = document.getElementById(DOM_IDS.CONN_TEXT);


### PR DESCRIPTION
## Summary
- expose total memory in `/api/health`
- show memory usage numbers in floating system monitor
- style monitor page titles using theme color and display values in white

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*