### PR TITLE
Add 3hr variance for earnings metrics

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2785,6 +2785,57 @@ function updateUI() {
         return dividerContainer;
     }
 
+    // Helper to attach a 3hr variance divider to a metric row
+    function updateVarianceDivider(metricId, varianceId, varianceValue) {
+        const para = document.getElementById(metricId).parentNode;
+        ensureElementStyles();
+
+        if (!para.querySelector('.main-metric')) {
+            const metricEl = document.getElementById(metricId);
+            const indicatorEl = document.getElementById(`indicator_${metricId}`);
+
+            const mainMetric = document.createElement('span');
+            mainMetric.className = 'main-metric';
+
+            if (metricEl && indicatorEl) {
+                let node = metricEl.nextSibling;
+                while (node && node !== indicatorEl) {
+                    const nextNode = node.nextSibling;
+                    if (node.nodeType === 3) {
+                        para.removeChild(node);
+                    }
+                    node = nextNode;
+                }
+
+                metricEl.parentNode.insertBefore(mainMetric, metricEl);
+                mainMetric.appendChild(metricEl);
+                mainMetric.appendChild(indicatorEl);
+            }
+
+            const dividerContainer = document.createElement('span');
+            dividerContainer.className = 'metric-divider-container';
+            para.appendChild(dividerContainer);
+        }
+
+        let container = para.querySelector('.metric-divider-container');
+        if (!container) {
+            container = document.createElement('span');
+            container.className = 'metric-divider-container';
+            para.appendChild(container);
+        }
+
+        const formatted = (varianceValue >= 0 ? '+' : '') +
+            numberWithCommas(Math.round(varianceValue)) + ' SATS';
+
+        const existing = document.getElementById(varianceId);
+        if (existing) {
+            existing.textContent = formatted;
+        } else {
+            const div = createDivider(varianceId, formatted, '[3hr \u0394]');
+            container.appendChild(div);
+        }
+    }
+
     if (!latestMetrics) {
         console.warn("No metrics data available");
         return;
@@ -3284,6 +3335,29 @@ function updateUI() {
         updateElementText("estimated_earnings_per_day_sats", numberWithCommas(data.estimated_earnings_per_day_sats) + " SATS");
         updateElementText("estimated_earnings_next_block_sats", numberWithCommas(data.estimated_earnings_next_block_sats) + " SATS");
         updateElementText("estimated_rewards_in_window_sats", numberWithCommas(data.estimated_rewards_in_window_sats) + " SATS");
+
+        // Add 3hr variance dividers for estimated earnings metrics
+        if (data.estimated_earnings_per_day_sats_variance_3hr !== undefined) {
+            updateVarianceDivider(
+                "estimated_earnings_per_day_sats",
+                "variance_earnings_day",
+                data.estimated_earnings_per_day_sats_variance_3hr
+            );
+        }
+        if (data.estimated_earnings_next_block_sats_variance_3hr !== undefined) {
+            updateVarianceDivider(
+                "estimated_earnings_next_block_sats",
+                "variance_earnings_block",
+                data.estimated_earnings_next_block_sats_variance_3hr
+            );
+        }
+        if (data.estimated_rewards_in_window_sats_variance_3hr !== undefined) {
+            updateVarianceDivider(
+                "estimated_rewards_in_window_sats",
+                "variance_rewards_window",
+                data.estimated_rewards_in_window_sats_variance_3hr
+            );
+        }
 
         // Update last updated timestamp
         try {

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -16,6 +16,7 @@ if 'redis' not in sys.modules:
 
 from collections import deque
 from state_manager import StateManager
+from datetime import timedelta
 
 class DummyRedis:
     def __init__(self):
@@ -45,3 +46,36 @@ def test_save_and_load_graph_state_gzip():
     new_mgr.load_graph_state()
     assert new_mgr.arrow_history == mgr.arrow_history
     assert new_mgr.metrics_log[0]["metrics"]["hashrate_60sec"] == 1
+
+
+def test_variance_history_calculation(monkeypatch):
+    mgr = StateManager()
+    monkeypatch.setattr('state_manager.get_timezone', lambda: 'UTC')
+
+    first = {
+        "estimated_earnings_per_day_sats": 100,
+        "estimated_earnings_next_block_sats": 50,
+        "estimated_rewards_in_window_sats": 10,
+    }
+    mgr.update_metrics_history(first)
+    assert first["estimated_earnings_per_day_sats_variance_3hr"] == 0
+
+    # Move the stored entry 3 hours back to simulate passage of time
+    for key in [
+        "estimated_earnings_per_day_sats",
+        "estimated_earnings_next_block_sats",
+        "estimated_rewards_in_window_sats",
+    ]:
+        history = mgr.variance_history[key]
+        history[0]["time"] -= timedelta(hours=3) - timedelta(seconds=1)
+
+    second = {
+        "estimated_earnings_per_day_sats": 120,
+        "estimated_earnings_next_block_sats": 60,
+        "estimated_rewards_in_window_sats": 20,
+    }
+    mgr.update_metrics_history(second)
+
+    assert second["estimated_earnings_per_day_sats_variance_3hr"] == 20
+    assert second["estimated_earnings_next_block_sats_variance_3hr"] == 10
+    assert second["estimated_rewards_in_window_sats_variance_3hr"] == 10


### PR DESCRIPTION
## Summary
- record short-term history for variance tracking
- compute 3hr variance for estimated earnings metrics
- show 3hr variance inline in the SATOSHI card
- add unit test verifying variance calculation

## Testing
- `pytest -q`