### PR TITLE
Add estimated power usage fallback

### DIFF
--- a/App.py
+++ b/App.py
@@ -886,12 +886,15 @@ def update_config():
                 new_config.get("power_cost", 0.0),
                 new_config.get("power_usage", 0.0),
                 new_config.get("wallet"),
-                network_fee=new_config.get("network_fee", 0.0)  # Include network fee
+                network_fee=new_config.get("network_fee", 0.0),
+                worker_service=worker_service
             )
             logging.info(f"Dashboard service reinitialized with new wallet: {new_config.get('wallet')}")
 
             # Update worker service to use the new dashboard service (with the updated wallet)
             worker_service.set_dashboard_service(dashboard_service)
+            if hasattr(dashboard_service, 'set_worker_service'):
+                dashboard_service.set_worker_service(worker_service)
             notification_service.dashboard_service = dashboard_service
             logging.info(f"Worker service updated with the new dashboard service")
             
@@ -1565,10 +1568,13 @@ dashboard_service = MiningDashboardService(
     config.get("power_cost", 0.0),
     config.get("power_usage", 0.0),
     config.get("wallet"),
-    network_fee=config.get("network_fee", 0.0)  # Add network fee parameter
+    network_fee=config.get("network_fee", 0.0),
+    worker_service=None
 )
 worker_service = WorkerService()
 # Connect the services
+if hasattr(dashboard_service, 'set_worker_service'):
+    dashboard_service.set_worker_service(worker_service)
 worker_service.set_dashboard_service(dashboard_service)
 notification_service.dashboard_service = dashboard_service
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -266,3 +266,22 @@ def test_get_blocks_api(monkeypatch):
     assert blocks[0]['height'] == 100
 
 
+def test_fetch_metrics_estimates_power(monkeypatch):
+    class DummyWS:
+        def get_workers_data(self, cached_metrics, force_refresh=False):
+            return {"workers": [
+                {"power_consumption": 1000},
+                {"power_consumption": 1500}
+            ]}
+
+    svc = MiningDashboardService(0, 0, 'w', worker_service=DummyWS())
+
+    monkeypatch.setattr('data_service.get_timezone', lambda: 'UTC')
+    monkeypatch.setattr(svc, 'get_ocean_data', lambda: data_service.OceanData(hashrate_3hr=100, hashrate_3hr_unit='TH/s', pool_fees_percentage=0.0))
+    monkeypatch.setattr(svc, 'get_bitcoin_stats', lambda: (0, 100e18, 50000, 0))
+
+    metrics = svc.fetch_metrics()
+
+    assert metrics['daily_power_cost'] == 4.2
+
+


### PR DESCRIPTION
## Summary
- estimate total power from worker data when power usage is blank
- set default power cost of $0.07/kWh when using estimated power
- connect worker service to dashboard service in App
- test new power estimation behavior

## Testing
- `pytest -q`