### PR TITLE
Add power estimate indicator

### DIFF
--- a/App.py
+++ b/App.py
@@ -750,6 +750,7 @@ def dashboard():
                 "monthly_profit_usd": 0,
                 "daily_mined_sats": 0,
                 "monthly_mined_sats": 0,
+                "power_estimated": False,
                 "unpaid_earnings": "0",
                 "est_time_to_payout": None,
                 "last_block_height": None,

--- a/data_service.py
+++ b/data_service.py
@@ -140,11 +140,13 @@ class MiningDashboardService:
 
             power_usage_for_calc = self.power_usage
             power_cost_for_calc = self.power_cost
+            power_estimated = False
 
             if power_usage_for_calc is None or power_usage_for_calc <= 0:
                 estimated_power = self.estimate_total_power()
                 if estimated_power:
                     power_usage_for_calc = estimated_power
+                    power_estimated = True
                     if power_cost_for_calc is None or power_cost_for_calc <= 0:
                         power_cost_for_calc = 0.07
 
@@ -190,6 +192,7 @@ class MiningDashboardService:
                 'monthly_profit_usd': monthly_profit_usd,
                 'daily_mined_sats': daily_mined_sats,
                 'monthly_mined_sats': monthly_mined_sats,
+                'power_estimated': power_estimated,
                 'estimated_earnings_next_block': estimated_earnings_next_block,
                 'estimated_rewards_in_window': estimated_rewards_in_window,
                 'unpaid_earnings': ocean_data.unpaid_earnings,

--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -579,6 +579,13 @@ html.deepsea-theme .satellite-dish-connected {
     0 0 3px #32cd32;
 }
 
+/* ----- POWER ESTIMATE ICON ----- */
+#power-estimate-icon {
+  color: #ffa500;
+  margin-left: 4px;
+  font-size: 0.85rem;
+}
+
 @keyframes pulse-satellite {
   0%,
   100% {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3292,6 +3292,16 @@ function updateUI() {
             }
         }
 
+        // Show indicator if power usage was estimated
+        const powerIcon = document.getElementById("power-estimate-icon");
+        if (powerIcon) {
+            if (data.power_estimated) {
+                powerIcon.style.display = "inline-block";
+            } else {
+                powerIcon.style.display = "none";
+            }
+        }
+
         updateElementText("daily_mined_sats", numberWithCommas(data.daily_mined_sats) + " SATS");
         updateElementText("monthly_mined_sats", numberWithCommas(data.monthly_mined_sats) + " SATS");
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -342,7 +342,13 @@
 
     <div class="col-md-6">
         <div class="card">
-            <div class="card-header" id="currency-earnings-header">{{ user_currency|default('') }} EARNINGS</div>
+            <div class="card-header" id="currency-earnings-header">
+                {{ user_currency|default('') }} EARNINGS
+                <span id="power-estimate-icon" class="tooltip" style="display:{% if metrics and metrics.power_estimated %}inline-block{% else %}none{% endif %}; margin-left:4px;">
+                    <i class="fa-solid fa-bolt"></i>
+                    <span class="tooltip-text">Power usage estimated from hashrate</span>
+                </span>
+            </div>
             <div class="card-body">
                 <p>
                     <strong>Daily Revenue:</strong>

--- a/tests/test_currency_conversion.py
+++ b/tests/test_currency_conversion.py
@@ -43,6 +43,7 @@ class MetricsConversionTest(unittest.TestCase):
         self.assertAlmostEqual(metrics['daily_revenue'], 2.25)
         self.assertAlmostEqual(metrics['daily_profit_usd'], 2.25)
         self.assertEqual(metrics['currency'], 'EUR')
+        self.assertFalse(metrics['power_estimated'])
 
 class EarningsConversionTest(unittest.TestCase):
     @patch('config.get_currency', return_value='EUR')

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -283,5 +283,6 @@ def test_fetch_metrics_estimates_power(monkeypatch):
     metrics = svc.fetch_metrics()
 
     assert metrics['daily_power_cost'] == 4.2
+    assert metrics['power_estimated'] is True
 
 


### PR DESCRIPTION
## Summary
- mark when power usage is estimated when fetching metrics
- expose `power_estimated` through API and dashboard
- show bolt icon in earnings card when power is estimated
- style the indicator and update on UI refresh
- update unit tests for new field

## Testing
- `pytest -q`