### PR TITLE
Add estimated power consumption indicator

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -140,11 +140,13 @@ class MiningDashboardService:
 
             power_usage_for_calc = self.power_usage
             power_cost_for_calc = self.power_cost
+            power_usage_estimated = False
 
             if power_usage_for_calc is None or power_usage_for_calc <= 0:
                 estimated_power = self.estimate_total_power()
                 if estimated_power:
                     power_usage_for_calc = estimated_power
+                    power_usage_estimated = True
                     if power_cost_for_calc is None or power_cost_for_calc <= 0:
                         power_cost_for_calc = 0.07
 
@@ -188,6 +190,7 @@ class MiningDashboardService:
                 'daily_power_cost': daily_power_cost,
                 'daily_profit_usd': daily_profit_usd,
                 'monthly_profit_usd': monthly_profit_usd,
+                'power_usage_estimated': power_usage_estimated,
                 'daily_mined_sats': daily_mined_sats,
                 'monthly_mined_sats': monthly_mined_sats,
                 'estimated_earnings_next_block': estimated_earnings_next_block,

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -837,6 +837,53 @@ html.deepsea-theme h1::after {
   color: #ff2d95 !important;
 }
 
+/* ----- TOOLTIP STYLING ----- */
+.tooltip {
+  position: relative;
+  display: inline-block;
+  margin-left: 5px;
+  width: 14px;
+  height: 14px;
+  background-color: #333;
+  color: var(--text-color);
+  border-radius: 50%;
+  text-align: center;
+  line-height: 14px;
+  font-size: 10px;
+  cursor: help;
+}
+
+.tooltip .tooltip-text {
+  visibility: hidden;
+  width: 200px;
+  background-color: #000;
+  color: var(--text-color);
+  text-align: center;
+  border-radius: 3px;
+  padding: 5px;
+  position: absolute;
+  z-index: 1;
+  bottom: 125%;
+  left: 50%;
+  margin-left: -100px;
+  opacity: 0;
+  transition: opacity 0.3s;
+  font-size: 14px;
+  border: 1px solid var(--primary-color);
+}
+
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
+/* Icon shown when power usage is estimated */
+.estimated-icon {
+  color: #ffd700;
+  font-weight: bold;
+  margin-left: 4px;
+}
+
 /* ----- FOOTER ----- */
 .footer {
   padding: 10px 0;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3260,6 +3260,14 @@ function updateUI() {
             updateElementText("daily_power_cost", formatCurrencyValue(0, currency));
         }
 
+        // Show or hide estimated power indicator
+        if (data.power_usage_estimated !== undefined) {
+            const icon = document.getElementById("power-estimated-icon");
+            if (icon) {
+                icon.style.display = data.power_usage_estimated ? "inline-block" : "none";
+            }
+        }
+
         // Daily profit with currency conversion and color
         if (data.daily_profit_usd != null) {
             const dailyProfit = data.daily_profit_usd;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -357,6 +357,15 @@
                 </p>
                 <p>
                     <strong>Daily Power Cost:</strong>
+                    {% if metrics and metrics.power_usage_estimated %}
+                    <span id="power-estimated-icon" class="tooltip estimated-icon">*
+                        <span class="tooltip-text">Using estimated power consumption</span>
+                    </span>
+                    {% else %}
+                    <span id="power-estimated-icon" class="tooltip estimated-icon" style="display:none;">*
+                        <span class="tooltip-text">Using estimated power consumption</span>
+                    </span>
+                    {% endif %}
                     <span id="daily_power_cost" class="metric-value red">
                         {% if metrics and metrics.daily_power_cost is defined and metrics.daily_power_cost is not none %}
                         ${{ "%.2f"|format(metrics.daily_power_cost) }}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -283,5 +283,6 @@ def test_fetch_metrics_estimates_power(monkeypatch):
     metrics = svc.fetch_metrics()
 
     assert metrics['daily_power_cost'] == 4.2
+    assert metrics['power_usage_estimated'] is True
 
 


### PR DESCRIPTION
## Summary
- track when power usage is estimated in `MiningDashboardService`
- include `power_usage_estimated` flag in metrics
- display tooltip icon on dashboard when power is estimated
- style tooltip and icon in common CSS
- toggle icon via JavaScript updates
- test new metrics flag

## Testing
- `pytest -q`