### PR TITLE
Show when power cost is estimated

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -140,11 +140,13 @@ class MiningDashboardService:
 
             power_usage_for_calc = self.power_usage
             power_cost_for_calc = self.power_cost
+            power_usage_estimated = False
 
             if power_usage_for_calc is None or power_usage_for_calc <= 0:
                 estimated_power = self.estimate_total_power()
                 if estimated_power:
                     power_usage_for_calc = estimated_power
+                    power_usage_estimated = True
                     if power_cost_for_calc is None or power_cost_for_calc <= 0:
                         power_cost_for_calc = 0.07
 
@@ -188,6 +190,7 @@ class MiningDashboardService:
                 'daily_power_cost': daily_power_cost,
                 'daily_profit_usd': daily_profit_usd,
                 'monthly_profit_usd': monthly_profit_usd,
+                'power_usage_estimated': power_usage_estimated,
                 'daily_mined_sats': daily_mined_sats,
                 'monthly_mined_sats': monthly_mined_sats,
                 'estimated_earnings_next_block': estimated_earnings_next_block,

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2866,20 +2866,20 @@ function updateUI() {
             data.exchange_rates[currency] : 1.0;
 
         // Update only the currency earnings header, not SATOSHI EARNINGS
-        function updateDashboardHeaders(currency) {
+        function updateDashboardHeaders(currency, powerEstimated) {
             // Find card headers but exclude "SATOSHI EARNINGS"
             const earningsHeaders = document.querySelectorAll('.card-header');
             earningsHeaders.forEach(header => {
                 // Check if it's a currency header (contains EARNINGS but isn't SATOSHI EARNINGS)
                 if (header.textContent.includes('EARNINGS') &&
                     !header.textContent.includes('SATOSHI EARNINGS')) {
-                    header.textContent = `${currency} EARNINGS`;
+                    header.textContent = `${powerEstimated ? 'Est. ' : ''}${currency} EARNINGS`;
                 }
             });
         }
 
         // Call this inside the updateUI function where currency is processed
-        updateDashboardHeaders(currency);
+        updateDashboardHeaders(currency, data.power_usage_estimated);
 
         // If this is the initial load, force a reset of all arrows
         if (initialLoad) {
@@ -3756,10 +3756,10 @@ function formatCurrencyValue(value, currency) {
 }
 
 // Update the BTC price and earnings card header with the selected currency
-function updateCurrencyLabels(currency) {
+function updateCurrencyLabels(currency, powerEstimated) {
     const earningsHeader = document.querySelector('.card-header:contains("USD EARNINGS")');
     if (earningsHeader) {
-        earningsHeader.textContent = `${currency} EARNINGS`;
+        earningsHeader.textContent = `${powerEstimated ? 'Est. ' : ''}${currency} EARNINGS`;
     }
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -342,7 +342,7 @@
 
     <div class="col-md-6">
         <div class="card">
-            <div class="card-header" id="currency-earnings-header">{{ user_currency|default('') }} EARNINGS</div>
+            <div class="card-header" id="currency-earnings-header">{% if metrics and metrics.power_usage_estimated %}Est. {% endif %}{{ user_currency|default('') }} EARNINGS</div>
             <div class="card-body">
                 <p>
                     <strong>Daily Revenue:</strong>

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -283,5 +283,22 @@ def test_fetch_metrics_estimates_power(monkeypatch):
     metrics = svc.fetch_metrics()
 
     assert metrics['daily_power_cost'] == 4.2
+    assert metrics['power_usage_estimated'] is True
+
+
+def test_fetch_metrics_power_configured(monkeypatch):
+    class DummyWS:
+        def get_workers_data(self, cached_metrics, force_refresh=False):
+            return {"workers": [{"power_consumption": 1000}]}
+
+    svc = MiningDashboardService(0, 2000, 'w', worker_service=DummyWS())
+
+    monkeypatch.setattr('data_service.get_timezone', lambda: 'UTC')
+    monkeypatch.setattr(svc, 'get_ocean_data', lambda: data_service.OceanData(hashrate_3hr=100, hashrate_3hr_unit='TH/s', pool_fees_percentage=0.0))
+    monkeypatch.setattr(svc, 'get_bitcoin_stats', lambda: (0, 100e18, 50000, 0))
+
+    metrics = svc.fetch_metrics()
+
+    assert metrics['power_usage_estimated'] is False
 
 


### PR DESCRIPTION
## Summary
- flag when power usage is estimated from workers
- display `Est.` before currency on the earnings card header when estimated
- update dashboard script to toggle the indicator
- test estimation flag logic

## Testing
- `pytest -q`
