### PR TITLE
Add payout scraping fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This open-source dashboard provides real-time monitoring for Ocean.xyz pool mine
 - **Payout Monitoring**: View unpaid balance and estimated time to next payout
 - **Pool Fee Analysis**: Monitor pool fee percentages with visual indicator when optimal rates (0.9-1.3%) are detected
 - **Official Ocean API**: Supplement scraping with data from the official Ocean.xyz API for greater accuracy
+- **Scraping Fallback**: If the API does not provide payout history, the dashboard scrapes the stats page to fill in missing records
 
 ### Multi-Currency Support
 - **Flexible Currency Configuration**: Set your preferred fiat currency for displaying Bitcoin value and earnings

--- a/data_service.py
+++ b/data_service.py
@@ -738,6 +738,65 @@ class MiningDashboardService:
             logging.error(f"Error fetching payment history from API: {e}")
             return None
 
+    def get_payment_history_scrape(self, btc_price=None):
+        """Scrape payout history from the stats page as a fallback."""
+        base_url = "https://ocean.xyz"
+        url = f"{base_url}/stats/{self.wallet}"
+        headers = {
+            "User-Agent": "Mozilla/5.0",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Cache-Control": "no-cache"
+        }
+        payments = []
+        try:
+            resp = self.session.get(url, headers=headers, timeout=10)
+            if not resp.ok:
+                logging.error(f"Error fetching payout page: {resp.status_code}")
+                return None
+            soup = BeautifulSoup(resp.text, "html.parser")
+            table = (soup.find("tbody", id="payouts-tablerows") or soup.find("tbody", id="payout-tablerows"))
+            if not table:
+                logging.error("Payout table not found")
+                return None
+            for row in table.find_all("tr", class_="table-row"):
+                cells = row.find_all("td")
+                if len(cells) < 3:
+                    continue
+                date_text = cells[0].get_text(strip=True)
+                txid = cells[1].get_text(strip=True)
+                amount_text = cells[-1].get_text(strip=True)
+                amount_clean = amount_text.replace("BTC", "").replace(",", "").strip()
+                try:
+                    amount_btc = float(amount_clean)
+                except Exception:
+                    continue
+                sats = int(round(amount_btc * self.sats_per_btc))
+                date_iso = None
+                date_str = date_text
+                try:
+                    dt = datetime.strptime(date_text, "%Y-%m-%d %H:%M")
+                    dt = dt.replace(tzinfo=ZoneInfo("UTC")).astimezone(ZoneInfo(get_timezone()))
+                    date_iso = dt.isoformat()
+                    date_str = dt.strftime("%Y-%m-%d %H:%M")
+                except Exception:
+                    pass
+                payment = {
+                    "date": date_str,
+                    "txid": txid,
+                    "amount_btc": amount_btc,
+                    "amount_sats": sats,
+                    "status": "confirmed",
+                    "date_iso": date_iso,
+                }
+                if btc_price is not None:
+                    payment["rate"] = btc_price
+                    payment["fiat_value"] = amount_btc * btc_price
+                payments.append(payment)
+            return payments
+        except Exception as e:
+            logging.error(f"Error scraping payment history: {e}")
+            return None
+
     def get_earnings_data(self):
         """
         Get comprehensive earnings data from Ocean.xyz with improved error handling.
@@ -757,8 +816,9 @@ class MiningDashboardService:
 
             # Prefer the official API for payout history
             payments = self.get_payment_history_api(days=360, btc_price=btc_price)
-            if payments is None:
-                payments = []
+            if not payments:
+                logging.info("Falling back to scraping payout history")
+                payments = self.get_payment_history_scrape(btc_price=btc_price) or []
     
             # Get basic Ocean data for summary metrics (with timeout handling)
             try:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -198,6 +198,63 @@ def test_get_earnings_data_with_nested_result(monkeypatch):
     assert data['total_paid_btc'] == 100 / svc.sats_per_btc
 
 
+def test_get_payment_history_scrape(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+
+    html = """
+    <table><tbody id='payouts-tablerows'>
+    <tr class='table-row'>
+        <td class='table-cell'>2025-05-01 00:00</td>
+        <td class='table-cell'>abcd</td>
+        <td class='table-cell'>0.00000100 BTC</td>
+    </tr>
+    </tbody></table>
+    """
+
+    def fake_get(url, headers=None, timeout=10):
+        resp = MagicMock()
+        resp.ok = True
+        resp.text = html
+        return resp
+
+    monkeypatch.setattr(svc.session, 'get', fake_get)
+    monkeypatch.setattr('data_service.get_timezone', lambda: 'UTC')
+    import importlib, sys
+    sys.modules.pop('bs4', None)
+    real_bs4 = importlib.import_module('bs4')
+    monkeypatch.setattr(data_service, 'BeautifulSoup', real_bs4.BeautifulSoup)
+
+    payments = svc.get_payment_history_scrape(btc_price=20000)
+    assert len(payments) == 1
+    p = payments[0]
+    assert p['txid'] == 'abcd'
+    assert p['amount_sats'] == 100
+    assert p['fiat_value'] == (100 / svc.sats_per_btc) * 20000
+
+
+def test_get_earnings_data_fallback_to_scrape(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+
+    monkeypatch.setattr(svc, 'get_payment_history_api', lambda days=360, btc_price=None: [])
+    sample = [{
+        'date': '2025-05-01 00:00',
+        'txid': 'abcd',
+        'amount_btc': 0.000001,
+        'amount_sats': 100,
+        'status': 'confirmed',
+        'date_iso': '2025-05-01T00:00:00+00:00'
+    }]
+    monkeypatch.setattr(svc, 'get_payment_history_scrape', lambda btc_price=None: sample)
+    monkeypatch.setattr('data_service.get_timezone', lambda: 'UTC')
+    monkeypatch.setattr('config.get_currency', lambda: 'USD')
+    monkeypatch.setattr(svc, 'get_ocean_data', lambda: data_service.OceanData())
+    monkeypatch.setattr(svc, 'get_bitcoin_stats', lambda: (0, 0, 20000, 0))
+
+    data = svc.get_earnings_data()
+    assert len(data['payments']) == 1
+    assert data['payments'][0]['txid'] == 'abcd'
+
+
 def test_get_worker_data_api(monkeypatch):
     svc = MiningDashboardService(0, 0, 'w')
 


### PR DESCRIPTION
## Summary
- fallback to scraping payout data when the earnpay API returns nothing
- document the scraping fallback
- add tests for scraping fallback

## Testing
- `pytest -q`