### PR TITLE
Add Lightning transaction links

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -700,6 +700,7 @@ class MiningDashboardService:
             for item in payouts:
                 ts = item.get("ts")
                 txid = item.get("on_chain_txid", "")
+                lightning_txid = item.get("lightning_txid", "")
                 sats = item.get("total_satoshis_net_paid", 0) or 0
                 amount_btc = sats / self.sats_per_btc
 
@@ -720,6 +721,7 @@ class MiningDashboardService:
                 payment = {
                     "date": date_str,
                     "txid": txid,
+                    "lightning_txid": lightning_txid,
                     "amount_btc": amount_btc,
                     "amount_sats": int(sats),
                     "status": "confirmed",
@@ -795,6 +797,7 @@ class MiningDashboardService:
                     payment = {
                         "date": date_str,
                         "txid": txid,
+                        "lightning_txid": "",
                         "amount_btc": amount_btc,
                         "amount_sats": sats,
                         "status": "confirmed",

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -911,7 +911,8 @@ function trackPayoutPerformance(data) {
             timestamp: actualPayoutTime,
             amountBTC: (lastPayoutTracking.lastUnpaidEarnings - currentUnpaidEarnings).toFixed(8),
             verified: false,
-            status: 'pending'
+            status: 'pending',
+            lightningId: ''
         };
 
         lastPayoutTracking.payoutHistory.unshift(payoutRecord);
@@ -1143,16 +1144,27 @@ function displayPayoutSummary() {
     let statusDisplay = lastPayout.status || "pending";
     const statusClass = lastPayout.verified ? "text-success" : "text-warning";
 
-    // Build HTML for the transaction link
+    // Build HTML for the transaction links
     let txLink = '';
     if (lastPayout.officialId) {
-        txLink = `
-            <a href="https://mempool.guide/tx/${lastPayout.officialId}" 
-               target="_blank" 
+        txLink += `
+            <a href="https://mempool.guide/tx/${lastPayout.officialId}"
+               target="_blank"
                class="btn btn-sm btn-secondary ms-2"
                style="font-size: 12px; width: 90px;"
                title="View transaction on mempool.guide">
                 <i class="fa-solid fa-external-link-alt"></i> View TX
+            </a>`;
+    }
+
+    if (lastPayout.lightningId) {
+        txLink += `
+            <a href="https://ocean.xyz/info/tx/lightning/${lastPayout.lightningId}"
+               target="_blank"
+               class="btn btn-sm btn-secondary ms-2"
+               style="font-size: 12px; width: 90px;"
+               title="View Lightning transaction">
+                <i class="fa-solid fa-bolt"></i> LN TX
             </a>`;
     }
 
@@ -1310,6 +1322,7 @@ function verifyPayoutsAgainstOfficial() {
                 if (matchingPayment) {
                     detectedPayout.verified = true;
                     detectedPayout.officialId = matchingPayment.txid || '';
+                    detectedPayout.lightningId = matchingPayment.lightning_txid || '';
                     detectedPayout.status = matchingPayment.status || 'confirmed';
 
                     if (matchingPayment.rate) {
@@ -1347,6 +1360,7 @@ function verifyPayoutsAgainstOfficial() {
                         amountBTC: payment.amount_btc,
                         verified: true,
                         officialId: payment.txid || '',
+                        lightningId: payment.lightning_txid || '',
                         status: payment.status || 'confirmed',
                         officialRecordOnly: true
                     };

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -136,6 +136,7 @@ def test_get_payment_history_api_nested_result(monkeypatch):
                 {
                     'ts': 1700000000,
                     'on_chain_txid': 'abcd',
+                    'lightning_txid': 'ln1',
                     'total_satoshis_net_paid': 100
                 }
             ]
@@ -156,6 +157,7 @@ def test_get_payment_history_api_nested_result(monkeypatch):
     assert len(payments) == 1
     p = payments[0]
     assert p['txid'] == 'abcd'
+    assert p['lightning_txid'] == 'ln1'
     assert p['amount_sats'] == 100
     assert abs(p['amount_btc'] - 100 / svc.sats_per_btc) < 1e-9
     assert p['fiat_value'] == (100 / svc.sats_per_btc) * 20000
@@ -173,6 +175,7 @@ def test_get_earnings_data_with_nested_result(monkeypatch):
                 {
                     'ts': 1700000000,
                     'on_chain_txid': 'abcd',
+                    'lightning_txid': 'ln1',
                     'total_satoshis_net_paid': 100
                 }
             ]
@@ -195,6 +198,7 @@ def test_get_earnings_data_with_nested_result(monkeypatch):
 
     assert len(data['payments']) == 1
     assert data['payments'][0]['txid'] == 'abcd'
+    assert data['payments'][0]['lightning_txid'] == 'ln1'
     assert data['total_paid_btc'] == 100 / svc.sats_per_btc
 
 


### PR DESCRIPTION
## Summary
- parse `lightning_txid` from payouts
- surface `lightning_txid` in API payments
- track `lightningId` in payout history
- show link to Lightning transaction in payout summary
- test lightning transaction parsing

## Testing
- `pytest -q`