### PR TITLE
Add Lightning transaction links

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -700,6 +700,7 @@ class MiningDashboardService:
             for item in payouts:
                 ts = item.get("ts")
                 txid = item.get("on_chain_txid", "")
+                lightning_txid = item.get("lightning_txid", "")
                 sats = item.get("total_satoshis_net_paid", 0) or 0
                 amount_btc = sats / self.sats_per_btc
 
@@ -720,6 +721,7 @@ class MiningDashboardService:
                 payment = {
                     "date": date_str,
                     "txid": txid,
+                    "lightning_txid": lightning_txid,
                     "amount_btc": amount_btc,
                     "amount_sats": int(sats),
                     "status": "confirmed",
@@ -775,7 +777,16 @@ class MiningDashboardService:
                     if len(cells) < 3:
                         continue
                     date_text = cells[0].get_text(strip=True)
+                    link = cells[1].find('a')
                     txid = cells[1].get_text(strip=True)
+                    lightning_txid = ""
+                    if link and link.get('href'):
+                        href = link['href']
+                        if 'lightning' in href:
+                            lightning_txid = href.rstrip('/').split('/')[-1]
+                            txid = ""
+                        else:
+                            txid = href.rstrip('/').split('/')[-1]
                     amount_text = cells[-1].get_text(strip=True)
                     amount_clean = amount_text.replace("BTC", "").replace(",", "").strip()
                     try:
@@ -795,6 +806,7 @@ class MiningDashboardService:
                     payment = {
                         "date": date_str,
                         "txid": txid,
+                        "lightning_txid": lightning_txid,
                         "amount_btc": amount_btc,
                         "amount_sats": sats,
                         "status": "confirmed",

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -911,7 +911,8 @@ function trackPayoutPerformance(data) {
             timestamp: actualPayoutTime,
             amountBTC: (lastPayoutTracking.lastUnpaidEarnings - currentUnpaidEarnings).toFixed(8),
             verified: false,
-            status: 'pending'
+            status: 'pending',
+            lightningId: ''
         };
 
         lastPayoutTracking.payoutHistory.unshift(payoutRecord);
@@ -1143,16 +1144,27 @@ function displayPayoutSummary() {
     let statusDisplay = lastPayout.status || "pending";
     const statusClass = lastPayout.verified ? "text-success" : "text-warning";
 
-    // Build HTML for the transaction link
+    // Build HTML for the transaction links
     let txLink = '';
     if (lastPayout.officialId) {
-        txLink = `
-            <a href="https://mempool.guide/tx/${lastPayout.officialId}" 
-               target="_blank" 
+        txLink += `
+            <a href="https://mempool.guide/tx/${lastPayout.officialId}"
+               target="_blank"
                class="btn btn-sm btn-secondary ms-2"
                style="font-size: 12px; width: 90px;"
                title="View transaction on mempool.guide">
                 <i class="fa-solid fa-external-link-alt"></i> View TX
+            </a>`;
+    }
+
+    if (lastPayout.lightningId) {
+        txLink += `
+            <a href="https://ocean.xyz/info/tx/lightning/${lastPayout.lightningId}"
+               target="_blank"
+               class="btn btn-sm btn-secondary ms-2"
+               style="font-size: 12px; width: 90px;"
+               title="View Lightning transaction">
+                <i class="fa-solid fa-bolt"></i> LN TX
             </a>`;
     }
 
@@ -1310,6 +1322,7 @@ function verifyPayoutsAgainstOfficial() {
                 if (matchingPayment) {
                     detectedPayout.verified = true;
                     detectedPayout.officialId = matchingPayment.txid || '';
+                    detectedPayout.lightningId = matchingPayment.lightning_txid || '';
                     detectedPayout.status = matchingPayment.status || 'confirmed';
 
                     if (matchingPayment.rate) {
@@ -1347,6 +1360,7 @@ function verifyPayoutsAgainstOfficial() {
                         amountBTC: payment.amount_btc,
                         verified: true,
                         officialId: payment.txid || '',
+                        lightningId: payment.lightning_txid || '',
                         status: payment.status || 'confirmed',
                         officialRecordOnly: true
                     };


### PR DESCRIPTION
## Summary
- parse lightning links when scraping payout history
- test lightning link scraping

## Testing
- `pytest -q`
