### PR TITLE
Fix timestamp parsing bug

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -125,21 +125,21 @@ class NotificationService:
             return datetime.now()
     
     def _parse_timestamp(self, timestamp_str: str) -> datetime:
-        """Parse an ISO format timestamp string into a timezone-aware datetime."""
+        """Parse an ISO timestamp string into a timezone-aware datetime."""
         try:
-            # Parse the naive datetime from the string
-            dt = datetime.fromisoformat(timestamp_str)
-            
-            # If it's already timezone-aware, return it
+            # Handle ``Z`` suffix by converting to ``+00:00`` for ``fromisoformat``
+            ts = timestamp_str.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(ts)
+
+            # If timestamp already has timezone info, return as-is
             if dt.tzinfo is not None:
                 return dt
-                
-            # Otherwise, make it timezone-aware
+
+            # Otherwise, localize to configured timezone
             tz = pytz.timezone(get_timezone())
             return tz.localize(dt)
         except Exception as e:
             logging.error(f"[NotificationService] Error parsing timestamp: {e}")
-            # Return current time as fallback
             return self._get_current_time()
     
     def _get_redis_value(self, key: str, default: Any = None) -> Any:

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -95,5 +95,11 @@ class NotificationCurrencyTest(unittest.TestCase):
         self.assertAlmostEqual(notif['data']['daily_profit_usd'], 10.0)
         self.assertIn('$', notif['message'])
 
+    def test_parse_timestamp_with_z_suffix(self):
+        ts = "2023-01-01T12:34:56Z"
+        parsed = self.service._parse_timestamp(ts)
+        self.assertIsNotNone(parsed.tzinfo)
+        self.assertEqual(parsed.year, 2023)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- handle ISO timestamps with `Z` suffix in `NotificationService`
- add regression test for parsing timestamps ending in `Z`

## Testing
- `ruff check notification_service.py tests/test_notification_service.py`
- `PYTHONPATH=$PWD pytest -q`