### PR TITLE
Fix timestamp parsing for Z-suffix

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -129,8 +129,9 @@ class NotificationService:
     def _parse_timestamp(self, timestamp_str: str) -> datetime:
         """Parse an ISO format timestamp string into a timezone-aware datetime."""
         try:
-            # Parse the naive datetime from the string
-            dt = datetime.fromisoformat(timestamp_str)
+            # Support timestamps that end with 'Z' for UTC designator
+            ts = timestamp_str.replace("Z", "+00:00")
+            dt = datetime.fromisoformat(ts)
             
             # If it's already timezone-aware, return it
             if dt.tzinfo is not None:

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -95,5 +95,13 @@ class NotificationCurrencyTest(unittest.TestCase):
         self.assertAlmostEqual(notif['data']['daily_profit_usd'], 10.0)
         self.assertIn('$', notif['message'])
 
+    def test_parse_timestamp_with_z_suffix(self):
+        with patch('notification_service.get_timezone', return_value='UTC'):
+            svc = NotificationService(DummyStateManager())
+            dt = svc._parse_timestamp('2024-01-02T03:04:05Z')
+        self.assertIsNotNone(dt.tzinfo)
+        self.assertEqual(dt.year, 2024)
+        self.assertEqual(dt.minute, 4)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- handle `Z` timestamps in NotificationService
- add test for the new timestamp parsing

## Testing
- `PYTHONPATH=$PWD pytest -q`