### PR TITLE
Fix negative hashrate conversion

### DIFF
--- a/models.py
+++ b/models.py
@@ -154,7 +154,7 @@ def convert_to_ths(value, unit):
     Returns:
         float: The hashrate value in TH/s
     """
-    if value is None or value == 0:
+    if value is None or value <= 0:
         return 0
         
     try:

--- a/tests/test_convert_to_ths.py
+++ b/tests/test_convert_to_ths.py
@@ -20,3 +20,8 @@ def test_unexpected_unit_returns_original_and_logs_warning(caplog):
         result = convert_to_ths(7.5, "unknown")
     assert result == 7.5
     assert any("Unexpected hashrate unit" in rec.message for rec in caplog.records)
+
+
+def test_negative_or_none_returns_zero():
+    assert convert_to_ths(-5, "TH/s") == 0
+    assert convert_to_ths(None, "TH/s") == 0


### PR DESCRIPTION
## Summary
- prevent negative values in `convert_to_ths`
- add tests for negative and None input

## Testing
- `PYTHONPATH=$PWD pytest -q`