### PR TITLE
Fix nested block API parsing

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -326,7 +326,13 @@ class MiningDashboardService:
             resp = self.session.get(url, timeout=10)
             if resp.ok:
                 data = resp.json()
-                blocks = data.get("blocks") or data.get("result") or data
+                blocks = data.get("blocks")
+                if blocks is None:
+                    result = data.get("result")
+                    if isinstance(result, dict):
+                        blocks = result.get("blocks")
+                    elif isinstance(result, list):
+                        blocks = result
                 if isinstance(blocks, list):
                     return blocks
         except Exception as e:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -422,6 +422,24 @@ def test_get_blocks_api(monkeypatch):
     assert blocks[0]['height'] == 100
 
 
+def test_get_blocks_api_nested(monkeypatch):
+    svc = MiningDashboardService(0, 0, 'w')
+
+    sample = {'result': {'blocks': [{'height': 101, 'time': 1700000010}]}}
+
+    def fake_get(url, timeout=10):
+        resp = MagicMock()
+        resp.ok = True
+        resp.json.return_value = sample
+        return resp
+
+    monkeypatch.setattr(svc.session, 'get', fake_get)
+    blocks = svc.get_blocks_api()
+
+    assert isinstance(blocks, list)
+    assert blocks[0]['height'] == 101
+
+
 def test_fetch_metrics_estimates_power(monkeypatch):
     class DummyWS:
         def get_workers_data(self, cached_metrics, force_refresh=False):


### PR DESCRIPTION
## Summary
- handle nested `result` structure in `get_blocks_api`
- add test covering nested response from Ocean API

## Testing
- `PYTHONPATH=$PWD pytest -q`