### PR TITLE
Fix Docker build missing routes package

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -16,6 +16,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY *.py .
 COPY config.json .
 COPY setup.py .
+COPY routes/ routes/
 
 # Create all necessary directories in one command
 RUN mkdir -p static/css static/js static/favicon templates logs /app/logs


### PR DESCRIPTION
## Summary
- include the `routes` package in Docker build to avoid `ModuleNotFoundError`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`