### PR TITLE
Update docs on route organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ DeepSea-Dashboard/
 ├── requirements.txt            # Python dependencies
 ├── Dockerfile                  # Docker configuration
 ├── docker-compose.yml          # Docker Compose configuration
+├── routes/                  # Flask route modules (main_routes.py, memory_routes.py, notification_routes.py)
 DeepSea-Dashboard/
 │
 ├── templates/                  # HTML templates
@@ -281,6 +282,7 @@ DeepSea-Dashboard/
 ├── LICENSE.md                  # License information
 └── logs/                       # Application logs (generated at runtime)
 ```
+Most Flask routes are defined in `routes/main_routes.py`. `App.py` registers them during startup.
 
 For more details on the architecture and component interactions,
 see [project_structure.md](project_structure.md).

--- a/project_structure.md
+++ b/project_structure.md
@@ -20,6 +20,7 @@ DeepSea-Dashboard/
 ├── requirements.txt            # Python dependencies
 ├── Dockerfile                  # Docker configuration
 ├── docker-compose.yml          # Docker Compose configuration
+├── routes/                  # Flask route modules (main_routes.py, memory_routes.py, notification_routes.py)
 │
 ├── templates/                  # HTML templates
 │   ├── base.html              # Base template with common elements
@@ -64,7 +65,7 @@ DeepSea-Dashboard/
 #### App.py
 The main Flask application that serves as the entry point. It:
 - Initializes the application and its components
-- Configures routes and middleware
+- Registers routes from `routes/main_routes.py` (where most route handlers reside) and configures middleware
 - Sets up the background scheduler for data updates
 - Manages Server-Sent Events (SSE) connections
 - Handles error recovery and graceful shutdown


### PR DESCRIPTION
## Summary
- document `routes/` folder in project structure
- mention that `App.py` registers routes from `routes/main_routes.py`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`