### PR TITLE
Fix NaN on earnings page when values missing

### DIFF
--- a/static/js/earnings.js
+++ b/static/js/earnings.js
@@ -71,7 +71,11 @@ function fetchServerTimeAndInitializeMonitor() {
 
 // Function to format currency values with commas
 function formatCurrency(amount) {
-    return amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    const num = Number(amount);
+    if (num == null || isNaN(num)) {
+        return '0';
+    }
+    return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
 // Format all currency values on the page
@@ -126,17 +130,29 @@ function setupAutoRefresh() {
 
 // Function to format BTC values
 function formatBTC(btcValue) {
-    return parseFloat(btcValue).toFixed(8);
+    const num = parseFloat(btcValue);
+    if (isNaN(num)) {
+        return '0.00000000';
+    }
+    return num.toFixed(8);
 }
 
 // Function to format sats with commas
 function formatSats(satsValue) {
-    return formatCurrency(parseInt(satsValue));
+    const num = parseInt(satsValue);
+    if (isNaN(num)) {
+        return '0';
+    }
+    return formatCurrency(num);
 }
 
 // Function to format USD values with commas
 function formatUSD(usdValue) {
-    return formatCurrency(parseFloat(usdValue).toFixed(2));
+    const num = parseFloat(usdValue);
+    if (isNaN(num)) {
+        return '0.00';
+    }
+    return formatCurrency(num.toFixed(2));
 }
 
 // Function to apply user timezone formatting to dates


### PR DESCRIPTION
## Summary
- guard against missing or non-numeric values in earnings.js helpers
- regenerate minified assets

## Testing
- `python3 minify.py --all`
- `PYTHONPATH=$PWD pytest`