### PR TITLE
Handle payouts array at top level

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -694,8 +694,14 @@ class MiningDashboardService:
                 return None
 
             data = resp.json()
-            result_obj = data.get("result", {})
-            payouts = result_obj.get("payouts", [])
+            payouts = []
+            result_obj = data.get("result") if isinstance(data.get("result"), dict) else None
+            if result_obj and "payouts" in result_obj:
+                payouts = result_obj.get("payouts", [])
+            elif "payouts" in data:
+                payouts = data.get("payouts", [])
+            else:
+                return []
 
             for item in payouts:
                 ts = item.get("ts")


### PR DESCRIPTION
## Summary
- support payout history responses with `payouts` at the top level
- test payout history API when payouts is a top-level key

## Testing
- `PYTHONPATH=$PWD pytest -q`