### PR TITLE
Fix worker count sync after adjusting workers

### DIFF
--- a/tests/test_worker_service.py
+++ b/tests/test_worker_service.py
@@ -151,3 +151,15 @@ def test_adjust_worker_instances_removes_excess(monkeypatch):
 
     svc.adjust_worker_instances(worker_data, 3)
     assert len(worker_data['workers']) == 3
+
+
+def test_adjust_worker_instances_updates_counts(monkeypatch):
+    monkeypatch.setattr('worker_service.get_timezone', lambda: 'UTC')
+    svc = WorkerService()
+    worker_data = svc.generate_default_workers_data()
+
+    svc.adjust_worker_instances(worker_data, 4)
+
+    assert worker_data['workers_total'] == 4
+    assert worker_data['workers_online'] + worker_data['workers_offline'] == 4
+    assert len(worker_data['workers']) == 4

--- a/worker_service.py
+++ b/worker_service.py
@@ -275,8 +275,15 @@ class WorkerService:
             # Remove workers from the end of the list to preserve earlier ones
             current_workers = current_workers[:target_count]
 
-        # Update the worker data
+        # Update the worker data and counts
         worker_data["workers"] = current_workers
+        worker_data["workers_total"] = len(current_workers)
+        worker_data["workers_online"] = sum(
+            1 for w in current_workers if w.get("status") == "online"
+        )
+        worker_data["workers_offline"] = worker_data["workers_total"] - worker_data[
+            "workers_online"
+        ]
 
     def create_default_worker(self, name, status):
         """


### PR DESCRIPTION
## Summary
- ensure worker counts are updated when adjusting worker instances
- test that `adjust_worker_instances` updates totals

## Testing
- `PYTHONPATH=$PWD pytest -q`