### PR TITLE
Add break-even electricity price metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ informed with minimal fuss.
 - **Live Hashrate Tracking**: Monitor 60-second, 10-minute, 3-hour, and 24-hour average hashrates
 - **Profitability Analysis**: View daily and monthly earnings in both BTC and USD
 - **Financial Calculations**: Automatically calculate revenue, power costs, and net profit
+- **Break-Even Electricity Price**: Shows the maximum power rate that still yields profit
 - **Network Statistics**: Track current Bitcoin price, difficulty, and network hashrate
 - **Payout Monitoring**: View unpaid balance and estimated time to next payout
 - **Pool Fee Analysis**: Monitor pool fee percentages with visual indicator when optimal rates (0.9-1.3%) are detected

--- a/data_service.py
+++ b/data_service.py
@@ -154,6 +154,12 @@ class MiningDashboardService:
             daily_profit_usd = round(daily_revenue - daily_power_cost, 2) if daily_revenue is not None else None
             monthly_profit_usd = round(daily_profit_usd * 30, 2) if daily_profit_usd is not None else None
 
+            # Calculate break-even electricity price in $/kWh
+            daily_energy_kwh = (power_usage_for_calc / 1000) * 24
+            break_even_electricity_price = round(
+                daily_revenue / daily_energy_kwh, 4
+            ) if daily_energy_kwh > 0 else None
+
             daily_mined_sats = int(round(daily_btc_net * self.sats_per_btc))
             monthly_mined_sats = daily_mined_sats * 30
 
@@ -190,6 +196,7 @@ class MiningDashboardService:
                 'daily_power_cost': daily_power_cost,
                 'daily_profit_usd': daily_profit_usd,
                 'monthly_profit_usd': monthly_profit_usd,
+                'break_even_electricity_price': break_even_electricity_price,
                 'power_usage_estimated': power_usage_estimated,
                 'daily_mined_sats': daily_mined_sats,
                 'monthly_mined_sats': monthly_mined_sats,
@@ -227,6 +234,10 @@ class MiningDashboardService:
                 metrics["daily_power_cost"] = round(metrics["daily_power_cost"] * rate, 2)
                 metrics["daily_profit_usd"] = round(metrics["daily_profit_usd"] * rate, 2)
                 metrics["monthly_profit_usd"] = round(metrics["monthly_profit_usd"] * rate, 2)
+                if metrics["break_even_electricity_price"] is not None:
+                    metrics["break_even_electricity_price"] = round(
+                        metrics["break_even_electricity_price"] * rate, 4
+                    )
                 metrics["exchange_rates"] = exchange_rates
             else:
                 metrics["exchange_rates"] = {}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3285,6 +3285,52 @@ function updateUI() {
             updateElementText("daily_power_cost", formatCurrencyValue(0, currency));
         }
 
+        // Break-even electricity price divider
+        const bePrice = data.break_even_electricity_price;
+        const formattedBe = bePrice != null
+            ? formatCurrencyValue(bePrice, currency) + '/kWh'
+            : formatCurrencyValue(0, currency) + '/kWh';
+
+        const powerCostPara = document.getElementById('daily_power_cost').parentNode;
+        ensureElementStyles();
+        if (!powerCostPara.querySelector('.main-metric')) {
+            const metricEl = document.getElementById('daily_power_cost');
+            const indicatorEl = document.getElementById('indicator_daily_power_cost');
+            const mainMetric = document.createElement('span');
+            mainMetric.className = 'main-metric';
+            if (metricEl && indicatorEl) {
+                let node = metricEl.nextSibling;
+                while (node && node !== indicatorEl) {
+                    const nextNode = node.nextSibling;
+                    if (node.nodeType === 3) {
+                        powerCostPara.removeChild(node);
+                    }
+                    node = nextNode;
+                }
+                metricEl.parentNode.insertBefore(mainMetric, metricEl);
+                mainMetric.appendChild(metricEl);
+                mainMetric.appendChild(indicatorEl);
+            }
+            const dividerContainer = document.createElement('span');
+            dividerContainer.className = 'metric-divider-container';
+            powerCostPara.appendChild(dividerContainer);
+        }
+
+        let beContainer = powerCostPara.querySelector('.metric-divider-container');
+        if (!beContainer) {
+            beContainer = document.createElement('span');
+            beContainer.className = 'metric-divider-container';
+            powerCostPara.appendChild(beContainer);
+        }
+
+        const existingBe = document.getElementById('break_even_price');
+        if (existingBe) {
+            existingBe.textContent = formattedBe;
+        } else {
+            const beDiv = createDivider('break_even_price', formattedBe, '[Break-Even]');
+            beContainer.appendChild(beDiv);
+        }
+
         // Daily profit with currency conversion and color
         if (data.daily_profit_usd != null) {
             const dailyProfit = data.daily_profit_usd;

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -458,6 +458,7 @@ def test_fetch_metrics_estimates_power(monkeypatch):
 
     assert metrics['daily_power_cost'] == 4.2
     assert metrics['power_usage_estimated'] is True
+    assert abs(metrics['break_even_electricity_price'] - 0.375) < 1e-6
 
 
 def test_fetch_metrics_power_configured(monkeypatch):
@@ -474,5 +475,6 @@ def test_fetch_metrics_power_configured(monkeypatch):
     metrics = svc.fetch_metrics()
 
     assert metrics['power_usage_estimated'] is False
+    assert abs(metrics['break_even_electricity_price'] - 0.46875) < 1e-4
 
 


### PR DESCRIPTION
## Summary
- compute `break_even_electricity_price` in `fetch_metrics`
- expose the value through the API and convert with currency rates
- display break-even electricity price on the dashboard next to power cost
- document the feature
- test new metric in service tests

## Testing
- `python minify.py --all`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`