### PR TITLE
Add T21 miner specs

### DIFF
--- a/miner_specs.py
+++ b/miner_specs.py
@@ -20,6 +20,7 @@ MODEL_SPECS = [
     (r"s21\s*xp\s*hydro", {"model": "Bitmain Antminer S21 XP Hydro", "type": "ASIC", "hashrate": 300, "efficiency": 12}),
     (r"s21[-_\s]*pro", {"model": "Bitmain Antminer S21 Pro", "type": "ASIC", "hashrate": 234, "efficiency": 15.0}),
     (r"s21\b", {"model": "Bitmain Antminer S21", "type": "ASIC", "hashrate": 200, "efficiency": 17.5}),
+    (r"t21\b", {"model": "Bitmain Antminer T21", "type": "ASIC", "hashrate": 162, "efficiency": 20.2}),
 
     # MicroBT Whatsminer series
     (r"m20s", {"model": "MicroBT Whatsminer M20S", "type": "ASIC", "hashrate": 68, "efficiency": 49.4}),

--- a/tests/test_parse_worker_name.py
+++ b/tests/test_parse_worker_name.py
@@ -9,3 +9,12 @@ def test_parse_worker_name_basic():
     assert specs["efficiency"] == 29.5
     # power approx 110 TH/s * 29.5 J/TH
     assert round(specs["power"]) == 3245
+
+
+def test_parse_worker_name_t21():
+    specs = miner_specs.parse_worker_name("Rig_T21")
+    assert specs is not None
+    assert specs["model"] == "Bitmain Antminer T21"
+    assert specs["type"] == "ASIC"
+    assert specs["efficiency"] == 20.2
+    assert round(specs["power"]) == round(162 * 20.2)


### PR DESCRIPTION
## Summary
- support parsing `T21` workers
- test worker name parsing for the new model

## Testing
- `ruff .`
- `PYTHONPATH=$PWD pytest -q`