### PR TITLE
Persist audio playback position

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ informed with minimal fuss.
 - **Boot Sequence Animation**: Engaging initialization sequence on startup
 - **System Monitor**: Floating status display with uptime and refresh information
 - **Responsive Interface**: Adapts to desktop and mobile devices
-- **Ambient Ocean Audio**: Soft ocean sounds play in the background with a mute control. Place your 10 minute MP3 at `static/audio/ocean.mp3`.
+- **Ambient Ocean Audio**: Soft ocean sounds play in the background with a mute control. Playback position now
+  persists between page loads for uninterrupted listening. Place your 10 minute MP3 at `static/audio/ocean.mp3`.
   The Docker configuration mounts this directory automatically.
 
 ### DeepSea Theme

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -1,21 +1,58 @@
 // Background audio controls
 
-(function() {
-    document.addEventListener('DOMContentLoaded', function() {
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
         const audio = document.getElementById('backgroundAudio');
         const control = document.getElementById('audioControl');
         const icon = document.getElementById('audioIcon');
         if (!audio) { return; }
+
         audio.volume = 1.00;
+
+        const setPosition = () => {
+            const storedTime = parseFloat(localStorage.getItem('audioPlaybackTime'));
+            if (!Number.isNaN(storedTime)) {
+                audio.currentTime = storedTime;
+            }
+        };
+
+        if (audio.readyState > 0) {
+            setPosition();
+        } else {
+            audio.addEventListener('loadedmetadata', setPosition);
+        }
+
+        const storedMuted = localStorage.getItem('audioMuted') === 'true';
+        const wasPaused = localStorage.getItem('audioPaused') === 'true';
+        audio.muted = storedMuted;
+        if (icon) {
+            icon.classList.toggle('fa-volume-mute', storedMuted);
+            icon.classList.toggle('fa-volume-up', !storedMuted);
+        }
+
         const play = () => {
             const promise = audio.play();
             if (promise !== undefined) {
-                promise.catch(() => {});
+                promise.catch(() => { });
             }
         };
-        play();
+
+        if (!wasPaused && !storedMuted) {
+            play();
+        }
+
+        audio.addEventListener('timeupdate', () => {
+            localStorage.setItem('audioPlaybackTime', audio.currentTime);
+        });
+
+        window.addEventListener('beforeunload', () => {
+            localStorage.setItem('audioPlaybackTime', audio.currentTime);
+            localStorage.setItem('audioMuted', audio.muted.toString());
+            localStorage.setItem('audioPaused', audio.paused.toString());
+        });
+
         if (control) {
-            control.addEventListener('click', function() {
+            control.addEventListener('click', function () {
                 if (audio.muted || audio.paused) {
                     audio.muted = false;
                     play();
@@ -27,6 +64,8 @@
                     icon.classList.remove('fa-volume-up');
                     icon.classList.add('fa-volume-mute');
                 }
+                localStorage.setItem('audioMuted', audio.muted.toString());
+                localStorage.setItem('audioPaused', audio.paused.toString());
             });
         }
     });


### PR DESCRIPTION
## Summary
- persist playback time in `audio.js`
- resume muted/paused state across page loads
- document the new audio continuity feature in README

## Testing
- `python3 minify.py --all`
- `PYTHONPATH=$PWD pytest`