### PR TITLE
Add theme-based audio controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ informed with minimal fuss.
 - **Boot Sequence Animation**: Engaging initialization sequence on startup
 - **System Monitor**: Floating status display with uptime and refresh information
 - **Responsive Interface**: Adapts to desktop and mobile devices
-- **Ambient Ocean Audio**: Soft ocean sounds play in the background with a mute control. Place your 10 minute MP3 at `static/audio/ocean.mp3`.
+- **Ambient Ocean Audio**: Soft ocean sounds play in the background with a mute control. The audio loops while the DeepSea theme is active and automatically mutes when the Bitcoin theme is selected. Place your 10 minute MP3 at `static/audio/ocean.mp3`.
   The Docker configuration mounts this directory automatically.
 
 ### DeepSea Theme

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -1,33 +1,62 @@
 // Background audio controls
 
 (function() {
-    document.addEventListener('DOMContentLoaded', function() {
-        const audio = document.getElementById('backgroundAudio');
-        const control = document.getElementById('audioControl');
-        const icon = document.getElementById('audioIcon');
-        if (!audio) { return; }
-        audio.volume = 1.00;
-        const play = () => {
-            const promise = audio.play();
-            if (promise !== undefined) {
-                promise.catch(() => {});
+    let audio;
+    let control;
+    let icon;
+
+    function play() {
+        const promise = audio.play();
+        if (promise !== undefined) {
+            promise.catch(() => {});
+        }
+    }
+
+    function apply_audio_theme(useDeepSea) {
+        if (!audio) {
+            return;
+        }
+        if (useDeepSea) {
+            audio.muted = false;
+            play();
+            if (icon) {
+                icon.classList.remove('fa-volume-mute');
+                icon.classList.add('fa-volume-up');
             }
-        };
-        play();
+        } else {
+            audio.muted = true;
+            audio.pause();
+            if (icon) {
+                icon.classList.remove('fa-volume-up');
+                icon.classList.add('fa-volume-mute');
+            }
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        audio = document.getElementById('backgroundAudio');
+        control = document.getElementById('audioControl');
+        icon = document.getElementById('audioIcon');
+
+        if (!audio) {
+            return;
+        }
+
+        audio.volume = 1.00;
+
+        const useDeepSea = localStorage.getItem('useDeepSeaTheme') === 'true';
+        apply_audio_theme(useDeepSea);
+
         if (control) {
             control.addEventListener('click', function() {
                 if (audio.muted || audio.paused) {
-                    audio.muted = false;
-                    play();
-                    icon.classList.remove('fa-volume-mute');
-                    icon.classList.add('fa-volume-up');
+                    apply_audio_theme(true);
                 } else {
-                    audio.muted = true;
-                    audio.pause();
-                    icon.classList.remove('fa-volume-up');
-                    icon.classList.add('fa-volume-mute');
+                    apply_audio_theme(false);
                 }
             });
         }
+
+        window.applyAudioTheme = apply_audio_theme;
     });
 })();

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -406,6 +406,10 @@ window.applyDeepSeaTheme = applyDeepSeaTheme;
 function toggleTheme() {
     const useDeepSea = localStorage.getItem('useDeepSeaTheme') !== 'true';
 
+    if (typeof window.applyAudioTheme === 'function') {
+        window.applyAudioTheme(useDeepSea);
+    }
+
     // Update the data-text attribute based on the new theme
     updateDashboardDataText(useDeepSea);
 


### PR DESCRIPTION
## Summary
- loop ocean.mp3 only for DeepSea theme and mute when switching to Bitcoin theme
- expose `applyAudioTheme` for theme.js to call
- mention automatic mute behavior in README

## Testing
- `python3 minify.py --all`
- `PYTHONPATH=$PWD pytest -q`