### PR TITLE
Update volume slider for desktop only

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -46,7 +46,7 @@ html.deepsea-theme {
   width: 100vw;
   height: 100vh;
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   justify-content: center;
   align-items: center;
   z-index: 9999;
@@ -1239,7 +1239,7 @@ html.deepsea-theme #congratsMessage {
   color: var(--primary-color);
   z-index: 1010;
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   align-items: center;
 }
 
@@ -1255,11 +1255,17 @@ html.deepsea-theme #congratsMessage {
   display: none;
   width: 4px;
   height: 100px;
-  margin-top: 4px;
+  margin-bottom: 4px;
   writing-mode: bt-lr;
   -webkit-appearance: slider-vertical;
 }
 
 .audio-controls:hover .volume-slider {
   display: block;
+}
+
+@media (max-width: 599px) {
+  .audio-controls:hover .volume-slider {
+    display: none;
+  }
 }

--- a/tests/test_volume_slider.py
+++ b/tests/test_volume_slider.py
@@ -6,3 +6,11 @@ def test_volume_slider_vertical():
     content = css_path.read_text()
     assert "slider-vertical" in content
     assert "writing-mode: bt-lr" in content
+
+
+def test_volume_slider_desktop_only_and_position():
+    """Ensure the volume slider styles are correct for desktop only and above the icon."""
+    css_path = Path("static/css/common.css")
+    content = css_path.read_text()
+    assert "flex-direction: column-reverse" in content
+    assert "@media (max-width: 599px)" in content


### PR DESCRIPTION
## Summary
- hide volume slider on mobile and position above speaker icon
- test CSS to ensure desktop-only behavior

## Testing
- `python3 minify.py --all`
- `PYTHONPATH=$PWD pytest -q`