### PR TITLE
Fix numeric parsing with commas

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -521,18 +521,18 @@ class NotificationService:
             return None
     
     def _parse_numeric_value(self, value_str: Any) -> float:
-        """Parse numeric values from strings that may include units."""
+        """Parse numeric values from strings that may include units or commas."""
         if isinstance(value_str, (int, float)):
             return float(value_str)
-            
+
         if isinstance(value_str, str):
-            # Extract just the numeric part
-            parts = value_str.split()
+            # Extract the first token and remove common thousands separators
+            numeric_part = value_str.split()[0].replace(",", "")
             try:
-                return float(parts[0])
+                return float(numeric_part)
             except (ValueError, IndexError):
                 pass
-        
+
         return 0.0
     
     def _check_hashrate_change(self, current: Dict[str, Any], previous: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/tests/test_parse_numeric_value.py
+++ b/tests/test_parse_numeric_value.py
@@ -1,0 +1,48 @@
+import sys
+import types
+import pytest
+
+# Provide lightweight stubs if dependencies are missing
+if 'pytz' not in sys.modules:
+    tz_module = types.ModuleType('pytz')
+    class DummyTZInfo:
+        def utcoffset(self, dt):
+            return None
+        def dst(self, dt):
+            return None
+        def tzname(self, dt):
+            return 'UTC'
+        def localize(self, dt_obj):
+            return dt_obj.replace(tzinfo=self)
+    tz_module.timezone = lambda name: DummyTZInfo()
+    sys.modules['pytz'] = tz_module
+
+if 'requests' not in sys.modules:
+    req_module = types.ModuleType('requests')
+    class DummySession:
+        def get(self, *args, **kwargs):
+            raise NotImplementedError
+    req_module.Session = DummySession
+    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
+    sys.modules['requests'] = req_module
+
+if 'bs4' not in sys.modules:
+    bs4_module = types.ModuleType('bs4')
+    class DummySoup:
+        pass
+    bs4_module.BeautifulSoup = DummySoup
+    sys.modules['bs4'] = bs4_module
+
+from notification_service import NotificationService
+
+class DummyState:
+    def get_notifications(self):
+        return []
+    def save_notifications(self, notifications):
+        pass
+
+
+def test_parse_numeric_value_with_commas():
+    svc = NotificationService(DummyState())
+    assert svc._parse_numeric_value("1,234") == pytest.approx(1234)
+    assert svc._parse_numeric_value("-2,000.5 TH/s") == pytest.approx(-2000.5)


### PR DESCRIPTION
## Summary
- handle comma separators in `_parse_numeric_value`
- add unit test for numeric parsing with commas

## Testing
- `ruff .`
- `PYTHONPATH=$PWD pytest -q`