### PR TITLE
Fix numeric parsing for strings without unit space

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -526,12 +526,15 @@ class NotificationService:
             return float(value_str)
 
         if isinstance(value_str, str):
-            # Extract the first token and remove common thousands separators
-            numeric_part = value_str.split()[0].replace(",", "")
-            try:
-                return float(numeric_part)
-            except (ValueError, IndexError):
-                pass
+            # Remove commas and extract leading numeric portion to handle
+            # values like "1,234.5TH/s" without a space before the unit.
+            cleaned = value_str.replace(",", "").strip()
+            match = re.match(r"[-+]?\d*\.?\d+", cleaned)
+            if match:
+                try:
+                    return float(match.group(0))
+                except ValueError:
+                    pass
 
         return 0.0
     

--- a/tests/test_parse_numeric_value.py
+++ b/tests/test_parse_numeric_value.py
@@ -46,3 +46,8 @@ def test_parse_numeric_value_with_commas():
     svc = NotificationService(DummyState())
     assert svc._parse_numeric_value("1,234") == pytest.approx(1234)
     assert svc._parse_numeric_value("-2,000.5 TH/s") == pytest.approx(-2000.5)
+
+
+def test_parse_numeric_value_without_space():
+    svc = NotificationService(DummyState())
+    assert svc._parse_numeric_value("1,234.56TH/s") == pytest.approx(1234.56)


### PR DESCRIPTION
## Summary
- handle numeric strings that have no space before the unit
- test parsing for the new case

## Testing
- `ruff .`
- `PYTHONPATH=$PWD pytest -q`