### PR TITLE
Fix ruff E501 violations

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -1198,11 +1198,15 @@ class MiningDashboardService:
             page_num += 1
 
         if page_num >= max_pages:
-            logging.info(f"Reached maximum page limit ({max_pages}). Collected {len(all_rows)} worker rows total.")
-        else:
             logging.info(
-                f"Completed fetching all available worker data. Collected {len(all_rows)} worker rows from {page_num} pages."
+                f"Reached maximum page limit ({max_pages}). Collected {len(all_rows)} worker rows total."
             )
+        else:
+            msg = (
+                "Completed fetching all available worker data. Collected "
+                f"{len(all_rows)} worker rows from {page_num} pages."
+            )
+            logging.info(msg)
 
         return all_rows
 

--- a/notification_service.py
+++ b/notification_service.py
@@ -503,7 +503,10 @@ class NotificationService:
             formatted_profit = format_currency_value(daily_profit_usd, user_currency, exchange_rates)
 
             # Build message
-            message = f"Daily Mining Summary: {hashrate_24hr} {hashrate_unit} average hashrate, {daily_mined_sats} SATS mined ({formatted_profit})"
+            message = (
+                f"Daily Mining Summary: {hashrate_24hr} {hashrate_unit} average hashrate, "
+                f"{daily_mined_sats} SATS mined ({formatted_profit})"
+            )
 
             # Add notification
             logging.info(f"[NotificationService] Generating daily stats notification: {message}")
@@ -530,9 +533,11 @@ class NotificationService:
             last_block_height = metrics.get("last_block_height", "Unknown")
             last_block_earnings = metrics.get("last_block_earnings", "0")
 
-            logging.info(
-                f"[NotificationService] Generating block notification: height={last_block_height}, earnings={last_block_earnings}"
+            log_msg = (
+                "[NotificationService] Generating block notification: "
+                f"height={last_block_height}, earnings={last_block_earnings}"
             )
+            logging.info(log_msg)
 
             message = f"New block found by the pool! Block #{last_block_height}, earnings: {last_block_earnings} SATS"
 
@@ -605,9 +610,11 @@ class NotificationService:
             previous_hashrate = previous.get(previous_hashrate_key, 0)
 
             # Log what we're comparing
-            logging.debug(
-                f"[NotificationService] Comparing {timeframe} hashrates - current: {current_hashrate}, previous: {previous_hashrate}"
+            log_msg = (
+                f"[NotificationService] Comparing {timeframe} hashrates - "
+                f"current: {current_hashrate}, previous: {previous_hashrate}"
             )
+            logging.debug(log_msg)
 
             # Skip if values are missing
             if not current_hashrate or not previous_hashrate:
@@ -618,9 +625,11 @@ class NotificationService:
             current_value = self._parse_numeric_value(current_hashrate)
             previous_value = self._parse_numeric_value(previous_hashrate)
 
-            logging.debug(
-                f"[NotificationService] Converted {timeframe} hashrates - current: {current_value}, previous: {previous_value}"
+            conv_msg = (
+                f"[NotificationService] Converted {timeframe} hashrates - "
+                f"current: {current_value}, previous: {previous_value}"
             )
+            logging.debug(conv_msg)
 
             # Skip if previous was zero (prevents division by zero)
             if previous_value == 0:
@@ -678,7 +687,8 @@ class NotificationService:
             current_wallet = str(current.get("wallet", ""))
             if current_wallet == "yourwallethere":
                 logging.info(
-                    "[NotificationService] Detected wallet reset to default (likely Alt+W) - skipping payout notification"
+                    "[NotificationService] Detected wallet reset to default "
+                    "(likely Alt+W) - skipping payout notification"
                 )
                 return None
 

--- a/worker_service.py
+++ b/worker_service.py
@@ -121,7 +121,8 @@ class WorkerService:
                         return real_worker_data
                     else:
                         logging.warning(
-                            "Real worker data had invalid names (like 'online'/'offline'), falling back to simulated data"
+                            "Real worker data had invalid names (like 'online'/'offline'), "
+                            "falling back to simulated data"
                         )
                 else:
                     logging.warning("Real worker data fetch returned no workers, falling back to simulated data")
@@ -203,9 +204,11 @@ class WorkerService:
                 worker_data["workers_online"] = new_online_count
                 worker_data["workers_offline"] = new_offline_count
 
-                logging.info(
-                    f"Updated worker counts - Total: {dashboard_worker_count}, Online: {new_online_count}, Offline: {new_offline_count}"
+                msg = (
+                    f"Updated worker counts - Total: {dashboard_worker_count}, "
+                    f"Online: {new_online_count}, Offline: {new_offline_count}"
                 )
+                logging.info(msg)
 
                 # If we have worker instances, try to adjust them as well
                 if "workers" in worker_data and isinstance(worker_data["workers"], list):


### PR DESCRIPTION
## Summary
- wrap long f-strings in data service and notification service
- split long log strings in worker service
- satisfy ruff line length limits

## Testing
- `ruff check --select E501`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`