### PR TITLE
Refactor test dependency stubs

### DIFF
--- a/tests/test_currency_conversion.py
+++ b/tests/test_currency_conversion.py
@@ -1,42 +1,10 @@
-import sys
-import types
+import pytest
 
-if "pytz" not in sys.modules:
-    tz_module = types.ModuleType("pytz")
+from tests.test_stubs import install_dummy_pytz, install_dummy_requests, install_dummy_bs4
 
-    class DummyTZInfo:
-        def utcoffset(self, dt):
-            return None
-
-        def dst(self, dt):
-            return None
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def localize(self, dt_obj):
-            return dt_obj.replace(tzinfo=self)
-
-    tz_module.timezone = lambda name: DummyTZInfo()
-    sys.modules["pytz"] = tz_module
-if "requests" not in sys.modules:
-    req_module = types.ModuleType("requests")
-
-    class DummySession:
-        def get(self, *args, **kwargs):
-            raise NotImplementedError
-
-    req_module.Session = DummySession
-    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
-    sys.modules["requests"] = req_module
-if "bs4" not in sys.modules:
-    bs4_module = types.ModuleType("bs4")
-
-    class DummySoup:
-        pass
-
-    bs4_module.BeautifulSoup = DummySoup
-    sys.modules["bs4"] = bs4_module
+install_dummy_pytz()
+install_dummy_requests()
+install_dummy_bs4()
 
 import unittest
 from unittest.mock import patch

--- a/tests/test_notification_generation.py
+++ b/tests/test_notification_generation.py
@@ -1,49 +1,11 @@
 import unittest
 from unittest.mock import patch
-import sys
-import types
 
-# Provide a lightweight pytz substitute if pytz is unavailable
-if "pytz" not in sys.modules:
-    tz_module = types.ModuleType("pytz")
+from tests.test_stubs import install_dummy_pytz, install_dummy_requests, install_dummy_bs4
 
-    class DummyTZInfo:
-        def utcoffset(self, dt):
-            return None
-
-        def dst(self, dt):
-            return None
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def localize(self, dt_obj):
-            return dt_obj.replace(tzinfo=self)
-
-    tz_module.timezone = lambda name: DummyTZInfo()
-    sys.modules["pytz"] = tz_module
-
-# Stub requests module if not available
-if "requests" not in sys.modules:
-    req_module = types.ModuleType("requests")
-
-    class DummySession:
-        def get(self, *args, **kwargs):
-            raise NotImplementedError
-
-    req_module.Session = DummySession
-    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
-    sys.modules["requests"] = req_module
-
-# Stub bs4 module if not available
-if "bs4" not in sys.modules:
-    bs4_module = types.ModuleType("bs4")
-
-    class DummySoup:
-        pass
-
-    bs4_module.BeautifulSoup = DummySoup
-    sys.modules["bs4"] = bs4_module
+install_dummy_pytz()
+install_dummy_requests()
+install_dummy_bs4()
 
 from notification_service import NotificationService
 

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -1,49 +1,11 @@
 import unittest
 from unittest.mock import patch
-import sys
-import types
 
-# Provide a lightweight pytz substitute if pytz is unavailable
-if "pytz" not in sys.modules:
-    tz_module = types.ModuleType("pytz")
+from tests.test_stubs import install_dummy_pytz, install_dummy_requests, install_dummy_bs4
 
-    class DummyTZInfo:
-        def utcoffset(self, dt):
-            return None
-
-        def dst(self, dt):
-            return None
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def localize(self, dt_obj):
-            return dt_obj.replace(tzinfo=self)
-
-    tz_module.timezone = lambda name: DummyTZInfo()
-    sys.modules["pytz"] = tz_module
-
-# Stub requests module if not available
-if "requests" not in sys.modules:
-    req_module = types.ModuleType("requests")
-
-    class DummySession:
-        def get(self, *args, **kwargs):
-            raise NotImplementedError
-
-    req_module.Session = DummySession
-    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
-    sys.modules["requests"] = req_module
-
-# Stub bs4 module if not available
-if "bs4" not in sys.modules:
-    bs4_module = types.ModuleType("bs4")
-
-    class DummySoup:
-        pass
-
-    bs4_module.BeautifulSoup = DummySoup
-    sys.modules["bs4"] = bs4_module
+install_dummy_pytz()
+install_dummy_requests()
+install_dummy_bs4()
 
 from notification_service import NotificationService
 

--- a/tests/test_parse_numeric_value.py
+++ b/tests/test_parse_numeric_value.py
@@ -1,46 +1,10 @@
-import sys
-import types
 import pytest
 
-# Provide lightweight stubs if dependencies are missing
-if "pytz" not in sys.modules:
-    tz_module = types.ModuleType("pytz")
+from tests.test_stubs import install_dummy_pytz, install_dummy_requests, install_dummy_bs4
 
-    class DummyTZInfo:
-        def utcoffset(self, dt):
-            return None
-
-        def dst(self, dt):
-            return None
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def localize(self, dt_obj):
-            return dt_obj.replace(tzinfo=self)
-
-    tz_module.timezone = lambda name: DummyTZInfo()
-    sys.modules["pytz"] = tz_module
-
-if "requests" not in sys.modules:
-    req_module = types.ModuleType("requests")
-
-    class DummySession:
-        def get(self, *args, **kwargs):
-            raise NotImplementedError
-
-    req_module.Session = DummySession
-    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
-    sys.modules["requests"] = req_module
-
-if "bs4" not in sys.modules:
-    bs4_module = types.ModuleType("bs4")
-
-    class DummySoup:
-        pass
-
-    bs4_module.BeautifulSoup = DummySoup
-    sys.modules["bs4"] = bs4_module
+install_dummy_pytz()
+install_dummy_requests()
+install_dummy_bs4()
 
 from notification_service import NotificationService
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,50 +1,16 @@
 from unittest.mock import MagicMock
 from datetime import datetime
 from zoneinfo import ZoneInfo
-import sys
-import types
 import os
 
+from tests.test_stubs import install_dummy_pytz, install_dummy_requests, install_dummy_bs4
+
+install_dummy_pytz()
+install_dummy_requests()
+install_dummy_bs4()
+
+import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
-if "pytz" not in sys.modules:
-    tz_module = types.ModuleType("pytz")
-
-    class DummyTZInfo:
-        def utcoffset(self, dt):
-            return None
-
-        def dst(self, dt):
-            return None
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def localize(self, dt_obj):
-            return dt_obj.replace(tzinfo=self)
-
-    tz_module.timezone = lambda name: DummyTZInfo()
-    sys.modules["pytz"] = tz_module
-
-if "requests" not in sys.modules:
-    req_module = types.ModuleType("requests")
-
-    class DummySession:
-        def get(self, *args, **kwargs):
-            raise NotImplementedError
-
-    req_module.Session = DummySession
-    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
-    sys.modules["requests"] = req_module
-
-if "bs4" not in sys.modules:
-    bs4_module = types.ModuleType("bs4")
-
-    class DummySoup:
-        pass
-
-    bs4_module.BeautifulSoup = DummySoup
-    sys.modules["bs4"] = bs4_module
 
 from worker_service import WorkerService
 from data_service import MiningDashboardService

--- a/tests/test_stubs.py
+++ b/tests/test_stubs.py
@@ -1,0 +1,88 @@
+import sys
+import types
+import pytest
+
+
+def install_dummy_pytz():
+    """Install a lightweight pytz substitute if missing."""
+    if "pytz" not in sys.modules:
+        tz_module = types.ModuleType("pytz")
+
+        class DummyTZInfo:
+            def utcoffset(self, dt):
+                return None
+
+            def dst(self, dt):
+                return None
+
+            def tzname(self, dt):
+                return "UTC"
+
+            def localize(self, dt_obj):
+                return dt_obj.replace(tzinfo=self)
+
+        tz_module.timezone = lambda name: DummyTZInfo()
+        sys.modules["pytz"] = tz_module
+    return sys.modules["pytz"]
+
+
+def install_dummy_requests():
+    """Install a lightweight requests stub if missing."""
+    if "requests" not in sys.modules:
+        req_module = types.ModuleType("requests")
+
+        class DummySession:
+            def get(self, *args, **kwargs):
+                raise NotImplementedError
+
+        req_module.Session = DummySession
+        req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
+        sys.modules["requests"] = req_module
+    return sys.modules["requests"]
+
+
+def install_dummy_bs4():
+    """Install a lightweight bs4 stub if missing."""
+    if "bs4" not in sys.modules:
+        bs4_module = types.ModuleType("bs4")
+
+        class DummySoup:
+            pass
+
+        bs4_module.BeautifulSoup = DummySoup
+        sys.modules["bs4"] = bs4_module
+    return sys.modules["bs4"]
+
+
+@pytest.fixture
+def dummy_pytz():
+    """Fixture ensuring a pytz stub is available."""
+    return install_dummy_pytz()
+
+
+@pytest.fixture
+def dummy_requests():
+    """Fixture ensuring a requests stub is available."""
+    return install_dummy_requests()
+
+
+@pytest.fixture
+def dummy_bs4():
+    """Fixture ensuring a bs4 stub is available."""
+    return install_dummy_bs4()
+
+
+@pytest.fixture
+def dummy_deps(dummy_pytz, dummy_requests, dummy_bs4):
+    """Fixture installing all dummy dependencies."""
+    return dummy_pytz, dummy_requests, dummy_bs4
+
+__all__ = [
+    "install_dummy_pytz",
+    "install_dummy_requests",
+    "install_dummy_bs4",
+    "dummy_pytz",
+    "dummy_requests",
+    "dummy_bs4",
+    "dummy_deps",
+]

--- a/tests/test_worker_service.py
+++ b/tests/test_worker_service.py
@@ -1,46 +1,10 @@
-import types
-import sys
 import random
 
-# Provide lightweight stubs for external deps if missing
-if "pytz" not in sys.modules:
-    tz_module = types.ModuleType("pytz")
+from tests.test_stubs import install_dummy_pytz, install_dummy_requests, install_dummy_bs4
 
-    class DummyTZInfo:
-        def utcoffset(self, dt):
-            return None
-
-        def dst(self, dt):
-            return None
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def localize(self, dt_obj):
-            return dt_obj.replace(tzinfo=self)
-
-    tz_module.timezone = lambda name: DummyTZInfo()
-    sys.modules["pytz"] = tz_module
-
-if "requests" not in sys.modules:
-    req_module = types.ModuleType("requests")
-
-    class DummySession:
-        def get(self, *args, **kwargs):
-            raise NotImplementedError
-
-    req_module.Session = DummySession
-    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
-    sys.modules["requests"] = req_module
-
-if "bs4" not in sys.modules:
-    bs4_module = types.ModuleType("bs4")
-
-    class DummySoup:
-        pass
-
-    bs4_module.BeautifulSoup = DummySoup
-    sys.modules["bs4"] = bs4_module
+install_dummy_pytz()
+install_dummy_requests()
+install_dummy_bs4()
 
 from worker_service import WorkerService
 


### PR DESCRIPTION
## Summary
- centralize dummy dependency modules under `tests/test_stubs.py`
- update tests to import these stubs instead of redefining them

## Testing
- `PYTHONPATH=$PWD pytest -q`