### PR TITLE
Fix crossfade stop bug

### DIFF
--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -3,7 +3,7 @@
 (function () {
     document.addEventListener('DOMContentLoaded', function () {
         let audio = document.getElementById('backgroundAudio');
-        const nextAudio = new Audio();
+        let nextAudio = new Audio();
         const control = document.getElementById('audioControl');
         const icon = document.getElementById('audioIcon');
         const volumeSlider = document.getElementById('volumeSlider');


### PR DESCRIPTION
## Summary
- fix crossfade transition halting audio by allowing `nextAudio` to be reassigned

## Testing
- `python3 minify.py --js`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`