### PR TITLE
Fix Makefile rule syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,18 @@
 PYTHON=python3
 
 setup:
-$(PYTHON) setup.py
+	$(PYTHON) setup.py
 
 minify:
-$(PYTHON) minify.py --all
+	$(PYTHON) minify.py --all
 
 minify-js:
-$(PYTHON) minify.py --js
+	$(PYTHON) minify.py --js
 
 minify-css:
-$(PYTHON) minify.py --css
+	$(PYTHON) minify.py --css
 
 minify-html:
-$(PYTHON) minify.py --html
+	$(PYTHON) minify.py --html
 
 .PHONY: setup minify minify-js minify-css minify-html


### PR DESCRIPTION
## Summary
- ensure Makefile uses tabs so rules execute correctly

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`