### PR TITLE
Add 3hr variance for network hashrate

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -525,6 +525,7 @@ class StateManager:
                 "estimated_earnings_per_day_sats",
                 "estimated_earnings_next_block_sats",
                 "estimated_rewards_in_window_sats",
+                "network_hashrate",
             ]
             now = datetime.now(ZoneInfo(get_timezone()))
             window_start = now - timedelta(hours=3)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2801,7 +2801,7 @@ function updateUI() {
     }
 
     // Helper to attach a 3hr variance divider to a metric row
-    function updateVarianceDivider(metricId, varianceId, varianceValue) {
+    function updateVarianceDivider(metricId, varianceId, varianceValue, formatFn) {
         const para = document.getElementById(metricId).parentNode;
         ensureElementStyles();
 
@@ -2843,6 +2843,8 @@ function updateUI() {
         const needsData = varianceValue === null || varianceValue === undefined;
         if (needsData) {
             formatted = 'Loading...';
+        } else if (typeof formatFn === 'function') {
+            formatted = formatFn(varianceValue);
         } else {
             formatted = (varianceValue >= 0 ? '+' : '') +
                 numberWithCommas(Math.round(varianceValue)) + ' SATS';
@@ -3266,6 +3268,22 @@ function updateUI() {
             // Use regular EH/s formatting
             updateElementText("network_hashrate",
                 numberWithCommas(Math.round(data.network_hashrate)) + " EH/s");
+        }
+
+        if (data.network_hashrate_variance_3hr !== undefined) {
+            updateVarianceDivider(
+                "network_hashrate",
+                "variance_network_hashrate",
+                data.network_hashrate_variance_3hr,
+                function(v) {
+                    const sign = v >= 0 ? '+' : '';
+                    const abs = Math.abs(v);
+                    if (abs >= 1000) {
+                        return sign + (abs / 1000).toFixed(2) + ' ZH/s';
+                    }
+                    return sign + numberWithCommas(Math.round(abs)) + ' EH/s';
+                }
+            );
         }
         updateElementText("difficulty", numberWithCommas(Math.round(data.difficulty)));
 

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -113,6 +113,24 @@ def test_variance_history_calculation(monkeypatch):
     assert second["estimated_rewards_in_window_sats_variance_3hr"] == 10
 
 
+def test_network_hashrate_variance_calculation(monkeypatch):
+    mgr = StateManager()
+    monkeypatch.setattr("state_manager.get_timezone", lambda: "UTC")
+
+    first = {"network_hashrate": 400}
+    mgr.update_metrics_history(first)
+    assert first["network_hashrate_variance_3hr"] is None
+
+    history = mgr.variance_history["network_hashrate"]
+    for _ in range(MAX_VARIANCE_HISTORY_ENTRIES - 1):
+        history.append({"time": history[0]["time"], "value": first["network_hashrate"]})
+
+    second = {"network_hashrate": 450}
+    mgr.update_metrics_history(second)
+
+    assert second["network_hashrate_variance_3hr"] == 50
+
+
 def test_variance_history_persistence(monkeypatch):
     mgr = StateManager()
     mgr.redis_client = DummyRedis()


### PR DESCRIPTION
## Summary
- compute network hashrate variance over a 3hr window
- display that variance on the Network Stats card
- extend `updateVarianceDivider` to support custom formatting
- test new variance calculation

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`