### PR TITLE
Add caching utilities for expensive operations

### DIFF
--- a/cache_utils.py
+++ b/cache_utils.py
@@ -1,0 +1,39 @@
+"""Utility helpers for caching expensive operations."""
+
+import time
+from functools import wraps
+
+
+def ttl_cache(ttl_seconds=60):
+    """Simple decorator providing a time based cache."""
+
+    def decorator(func):
+        cache = {}
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if args and hasattr(args[0], "__dict__"):
+                key_prefix = id(args[0])
+                key_args = args[1:]
+            else:
+                key_prefix = None
+                key_args = args
+            key = (key_prefix, key_args, tuple(sorted(kwargs.items())))
+            now = time.time()
+            cached = cache.get(key)
+            if cached and now - cached[1] < ttl_seconds:
+                return cached[0]
+            result = func(*args, **kwargs)
+            if result is not None:
+                cache[key] = (result, now)
+            return result
+
+        def cache_clear():
+            cache.clear()
+
+        wrapper.cache_clear = cache_clear
+        return wrapper
+
+    return decorator
+
+__all__ = ["ttl_cache"]

--- a/data_service.py
+++ b/data_service.py
@@ -14,6 +14,7 @@ from bs4 import BeautifulSoup
 
 from models import OceanData, convert_to_ths
 from config import get_timezone
+from cache_utils import ttl_cache
 from miner_specs import parse_worker_name
 
 
@@ -629,6 +630,7 @@ class MiningDashboardService:
         except Exception as e:
             logging.error(f"Error dumping table structure: {e}")
 
+    @ttl_cache(ttl_seconds=30)
     def fetch_url(self, url: str, timeout: int = 5):
         """
         Fetch URL with error handling.
@@ -1162,6 +1164,7 @@ class MiningDashboardService:
 
         return difficulty, network_hashrate, btc_price, block_count
 
+    @ttl_cache(ttl_seconds=60)
     def get_all_worker_rows(self):
         """
         Iterate through wpage parameter values to collect all worker table rows.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -33,3 +33,9 @@ The default configuration file contains the following keys:
 | `PORT` | Application port | `5000` |
 
 Refer to [INSTALL.md](INSTALL.md) and [DEPLOYMENT.md](DEPLOYMENT.md) for instructions on how these variables are used during setup and deployment.
+
+## Caching
+
+Expensive operations such as network requests, complex calculations and Redis queries are cached to reduce
+load on external services. Results are retained for up to 60 seconds before being refreshed. The built-in
+cache requires no configuration.

--- a/models.py
+++ b/models.py
@@ -4,6 +4,7 @@ Data models for the Bitcoin Mining Dashboard.
 
 from dataclasses import dataclass
 from typing import Dict, Any
+from functools import lru_cache
 import logging
 import re
 
@@ -152,6 +153,7 @@ class HashRateConversionError(Exception):
     pass
 
 
+@lru_cache(maxsize=128)
 def convert_to_ths(value, unit):
     """
     Convert any hashrate unit to TH/s equivalent.

--- a/state_manager.py
+++ b/state_manager.py
@@ -13,6 +13,7 @@ import gc
 import threading
 import gzip
 import redis
+from cache_utils import ttl_cache
 from collections import deque
 from datetime import datetime
 from config import get_timezone
@@ -92,6 +93,7 @@ class StateManager:
                     logging.error(f"Could not connect to Redis after {max_retries} attempts: {e}")
                     return None
 
+    @ttl_cache(ttl_seconds=60)
     def load_graph_state(self):
         """Load graph state from Redis with support for the optimized format."""
 
@@ -190,6 +192,7 @@ class StateManager:
         except Exception as e:
             logging.error(f"Error loading graph state from Redis: {e}")
 
+    @ttl_cache(ttl_seconds=60)
     def load_payout_history(self):
         """Load payout history list from Redis."""
         if not self.redis_client:
@@ -662,6 +665,7 @@ class StateManager:
     # ------------------------------------------------------------------
     # Last earnings caching
     # ------------------------------------------------------------------
+    @ttl_cache(ttl_seconds=60)
     def load_last_earnings(self):
         """Load last successful earnings data from Redis."""
         if not self.redis_client:

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,33 @@
+import types
+import sys
+
+# Ensure time module is available
+import time
+
+if "cache_utils" not in sys.modules:
+    pass
+
+from cache_utils import ttl_cache
+
+
+def test_ttl_cache(monkeypatch):
+    fake_time = [0]
+    monkeypatch.setattr(time, "time", lambda: fake_time[0])
+
+    call_count = {"count": 0}
+
+    @ttl_cache(ttl_seconds=5)
+    def add(a, b):
+        call_count["count"] += 1
+        return a + b
+
+    assert add(1, 2) == 3
+    assert call_count["count"] == 1
+
+    fake_time[0] += 2
+    assert add(1, 2) == 3
+    assert call_count["count"] == 1
+
+    fake_time[0] += 5
+    assert add(1, 2) == 3
+    assert call_count["count"] == 2


### PR DESCRIPTION
## Summary
- add generic `ttl_cache` decorator for simple time-based caching
- cache network fetches and worker row parsing in `MiningDashboardService`
- cache Redis loading helpers in `StateManager`
- memoize `convert_to_ths` conversions
- document caching behavior in configuration docs
- add unit test for caching decorator

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`