### PR TITLE
Add centralized Flask error handlers

### DIFF
--- a/App.py
+++ b/App.py
@@ -27,6 +27,7 @@ from data_service import MiningDashboardService
 from worker_service import WorkerService
 from state_manager import StateManager, MAX_HISTORY_ENTRIES
 from config import get_timezone
+from error_handlers import register_error_handlers
 
 # Memory management configuration
 MEMORY_CONFIG = {
@@ -47,6 +48,7 @@ object_counts_history = {}
 
 # Initialize Flask app
 app = Flask(__name__)
+register_error_handlers(app)
 
 
 @app.context_processor
@@ -1295,17 +1297,6 @@ def notifications_page():
     return render_template("notifications.html", current_time=current_time)
 
 
-@app.errorhandler(404)
-def page_not_found(e):
-    """Error handler for 404 errors."""
-    return render_template("error.html", message="Page not found."), 404
-
-
-@app.errorhandler(500)
-def internal_server_error(e):
-    """Error handler for 500 errors."""
-    logging.error("Internal server error: %s", e)
-    return render_template("error.html", message="Internal server error."), 500
 
 
 class RobustMiddleware:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ informed with minimal fuss.
 - **API Worker Fallback**: Uses the Ocean.xyz API for worker lists when HTML parsing fails
 - **Cross-Tab Synchronization**: Data consistency across multiple browser tabs
 - **Server Health Monitoring**: Built-in watchdog processes ensure reliability
-- **Error Handling**: Displays a user-friendly error page (`error.html`) for unexpected issues.
+- **Error Handling**: Centralized error handlers return a user-friendly page (`error.html`) for unexpected issues.
 
 ### Distinctive Design Elements
 - **Retro Terminal Aesthetic**: Nostalgic interface with modern functionality

--- a/error_handlers.py
+++ b/error_handlers.py
@@ -1,0 +1,19 @@
+import logging
+from flask import Blueprint, render_template
+
+errors = Blueprint('errors', __name__)
+
+@errors.app_errorhandler(404)
+def page_not_found(error):
+    """Return a friendly 404 error page."""
+    return render_template("error.html", message="Page not found."), 404
+
+@errors.app_errorhandler(500)
+def internal_server_error(error):
+    """Return a friendly 500 error page and log the exception."""
+    logging.error("Internal server error: %s", error)
+    return render_template("error.html", message="Internal server error."), 500
+
+def register_error_handlers(app):
+    """Register error handlers with the given Flask app."""
+    app.register_blueprint(errors)

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+import types
+
+if "pytest" not in sys.modules:
+    pytest = types.ModuleType("pytest")
+
+    def fixture(func=None, **kwargs):
+        if func is None:
+            return lambda f: f
+        return func
+
+    pytest.fixture = fixture
+    sys.modules["pytest"] = pytest
+else:
+    import pytest
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import apscheduler.schedulers.background as bg
+    monkeypatch.setattr(bg.BackgroundScheduler, "start", lambda self: None)
+    App = importlib.reload(importlib.import_module("App"))
+    monkeypatch.setattr(App, "update_metrics_job", lambda force=False: None)
+    monkeypatch.setattr(App, "MiningDashboardService", lambda *a, **k: object())
+    monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
+    sample_cfg = {"wallet": "w"}
+    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+    return App.app.test_client()
+
+
+def test_404_handler(client):
+    resp = client.get("/nonexistent")
+    assert resp.status_code == 404
+    assert b"Page not found." in resp.data
+
+
+def test_500_handler(client):
+    import App
+    @App.app.route("/error")
+    def raise_error():
+        raise Exception("boom")
+    resp = client.get("/error")
+    assert resp.status_code == 500
+    assert b"Internal server error." in resp.data


### PR DESCRIPTION
## Summary
- centralize error handling in new `error_handlers` blueprint
- register error handlers in `App.py`
- document centralized error handling in README
- test 404 and 500 error responses

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`