### PR TITLE
Fix currency update without exchange rate

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -795,6 +795,11 @@ class NotificationService:
             # zero-argument callable.  Call it without arguments to avoid
             # issues when such a patch is in place.
             exchange_rates = get_exchange_rates()
+            if new_currency not in exchange_rates:
+                logging.warning(
+                    f"[NotificationService] Missing exchange rate for {new_currency}, skipping update"
+                )
+                return 0
 
             updated = 0
             for notif in self.notifications:

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -108,6 +108,16 @@ class NotificationCurrencyTest(unittest.TestCase):
         self.assertAlmostEqual(notif["data"]["daily_profit_usd"], 10.0)
         self.assertIn("$", notif["message"])
 
+    def test_update_notification_currency_missing_rate(self):
+        """Ensure notifications remain unchanged when a rate is missing."""
+        with patch("notification_service.get_exchange_rates", return_value={"EUR": 0.5}):
+            updated = self.service.update_notification_currency("JPY")
+
+        self.assertEqual(updated, 0)
+        notif = self.service.notifications[0]
+        self.assertEqual(notif["data"]["currency"], "USD")
+        self.assertAlmostEqual(notif["data"]["daily_profit"], 10.0)
+
     def test_parse_timestamp_with_z_suffix(self):
         with patch("notification_service.get_timezone", return_value="UTC"):
             svc = NotificationService(DummyStateManager())


### PR DESCRIPTION
## Summary
- avoid updating notifications when the chosen currency doesn't have an exchange rate
- test notification currency update with missing rate

## Testing
- `ruff .`
- `PYTHONPATH=$PWD pytest`