### PR TITLE
Fix timezone fallback in notification service

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -128,11 +128,10 @@ class NotificationService:
         """Get current datetime with the configured timezone."""
         try:
             tz = pytz.timezone(get_timezone())
-            return datetime.now(tz)
         except Exception as e:
             logging.error(f"[NotificationService] Error getting timezone: {e}")
-            # Fallback to naive datetime if timezone fails
-            return datetime.now()
+            tz = pytz.utc
+        return datetime.now(tz)
 
     def _parse_timestamp(self, timestamp_str: str) -> datetime:
         """Parse an ISO timestamp string into a timezone-aware datetime."""

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -126,6 +126,12 @@ class NotificationCurrencyTest(unittest.TestCase):
         self.assertEqual(dt.year, 2024)
         self.assertEqual(dt.minute, 4)
 
+    def test_get_current_time_fallback_tz(self):
+        svc = NotificationService(DummyStateManager())
+        with patch("notification_service.pytz.timezone", side_effect=Exception("bad")):
+            dt = svc._get_current_time()
+        self.assertIsNotNone(dt.tzinfo)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure `_get_current_time` always returns timezone-aware datetimes
- test fallback timezone handling

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`