### PR TITLE
Fix server start time bug

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -46,6 +46,8 @@ class MiningDashboardService:
         self.exchange_rates_cache = {"rates": {}, "timestamp": 0.0}
         # Time-to-live (TTL) for exchange rate cache in seconds (~2 hours)
         self.exchange_rate_ttl = 7200
+        # Record the service start time to report consistent uptime
+        self.server_start_time = datetime.now(ZoneInfo(get_timezone()))
 
     def set_worker_service(self, worker_service):
         """Associate a WorkerService instance for power estimation."""
@@ -231,7 +233,9 @@ class MiningDashboardService:
 
             # --- Add server timestamps to the response in Los Angeles Time ---
             metrics["server_timestamp"] = datetime.now(ZoneInfo(get_timezone())).isoformat()
-            metrics["server_start_time"] = datetime.now(ZoneInfo(get_timezone())).isoformat()
+            metrics["server_start_time"] = self.server_start_time.astimezone(
+                ZoneInfo(get_timezone())
+            ).isoformat()
 
             # Get the configured currency
             from config import get_currency

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -517,3 +517,22 @@ def test_fetch_metrics_power_configured(monkeypatch):
 
     assert metrics["power_usage_estimated"] is False
     assert abs(metrics["break_even_electricity_price"] - 0.46875) < 1e-4
+
+
+def test_server_start_time_constant(monkeypatch):
+    """Ensure server_start_time remains constant across fetches."""
+    svc = MiningDashboardService(0, 0, "w")
+
+    monkeypatch.setattr("data_service.get_timezone", lambda: "UTC")
+    monkeypatch.setattr(
+        svc,
+        "get_ocean_data",
+        lambda: data_service.OceanData(hashrate_3hr=100, hashrate_3hr_unit="TH/s", pool_fees_percentage=0.0),
+    )
+    monkeypatch.setattr(svc, "get_bitcoin_stats", lambda: (0, 100e18, 50000, 0))
+    monkeypatch.setattr(svc, "fetch_exchange_rates", lambda: {"USD": 1})
+
+    metrics1 = svc.fetch_metrics()
+    metrics2 = svc.fetch_metrics()
+
+    assert metrics1["server_start_time"] == metrics2["server_start_time"]


### PR DESCRIPTION
## Summary
- ensure MiningDashboardService keeps a consistent `server_start_time`
- expose consistent timestamp in `fetch_metrics`
- test that `server_start_time` doesn't change between fetches

## Testing
- `ruff check data_service.py`
- `ruff check tests/test_services.py`
- `PYTHONPATH=$PWD pytest -q`