### PR TITLE
Restrict batch API paths and size

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ variance values remain visible after restarts.
 - `api/notifications/delete`: Deletes a specific notification.
 - `api/notifications/mark_read`: Marks a notification as read.
 - `api/notifications/unread_count`: Returns the count of unread notifications.
+- `/api/batch`: Batches multiple API calls. Only specific endpoints are allowed
+  and a single request may include at most 10 subrequests.
 
 ## Project Structure
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -250,3 +250,14 @@ def test_batch_invalid_method(client):
     assert resp.status_code == 200
     data = resp.get_json()
     assert data["responses"][0]["status"] == 400
+
+
+def test_batch_too_many_requests(client, monkeypatch):
+    import App
+
+    monkeypatch.setattr(App, "MAX_BATCH_REQUESTS", 5)
+    reqs = [{"method": "GET", "path": "/api/health"} for _ in range(6)]
+    resp = client.post("/api/batch", json={"requests": reqs})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["error"] == "too many requests"


### PR DESCRIPTION
## Summary
- add `MAX_BATCH_REQUESTS` and `ALLOWED_BATCH_PATHS`
- enforce limits and path validation in `/api/batch`
- document batch API restrictions
- test maximum batch request enforcement

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`