### PR TITLE
Implement service worker

### DIFF
--- a/App.py
+++ b/App.py
@@ -1373,6 +1373,13 @@ def notifications_page():
     return render_template("notifications.html", current_time=current_time)
 
 
+# Service worker route
+@app.route('/service-worker.js')
+def service_worker_file():
+    """Serve the service worker JavaScript file."""
+    return app.send_static_file('js/service-worker.js')
+
+
 
 
 class RobustMiddleware:

--- a/static/favicon/site.webmanifest
+++ b/static/favicon/site.webmanifest
@@ -13,6 +13,8 @@
             "type": "image/png"
         }
     ],
+    "start_url": "/dashboard",
+    "scope": "/",
     "theme_color": "#f7931a",
     "background_color": "#0a0a0a",
     "display": "standalone"

--- a/static/js/service-worker.js
+++ b/static/js/service-worker.js
@@ -1,0 +1,61 @@
+const CACHE_NAME = 'ds-cache-v1';
+const ASSETS_TO_CACHE = [
+    '/',
+    '/dashboard',
+    '/workers',
+    '/blocks',
+    '/earnings',
+    '/notifications',
+    '/static/css/common.css',
+    '/static/css/theme-toggle.css',
+    '/static/css/easter-egg.css',
+    '/static/js/main.js',
+    '/static/js/workers.js',
+    '/static/js/blocks.js',
+    '/static/js/notifications.js',
+    '/static/js/BitcoinProgressBar.js',
+    '/static/js/theme.js',
+    '/static/js/logger.js',
+    '/static/js/batchFetch.js',
+    '/static/js/audio.js',
+    '/static/js/easterEgg.js',
+    '/static/js/service-worker.js',
+    'https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=VT323&display=swap',
+    'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css'
+];
+
+self.addEventListener('install', event => {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS_TO_CACHE))
+    );
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+    event.waitUntil(
+        caches.keys().then(keys =>
+            Promise.all(keys.map(key => (key !== CACHE_NAME ? caches.delete(key) : null)))
+        )
+    );
+    self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+    if (event.request.method !== 'GET') return;
+    event.respondWith(
+        caches.match(event.request).then(cached => {
+            if (cached) {
+                return cached;
+            }
+            return fetch(event.request)
+                .then(response => {
+                    const respClone = response.clone();
+                    caches.open(CACHE_NAME).then(cache => {
+                        cache.put(event.request, respClone);
+                    });
+                    return response;
+                })
+                .catch(() => cached);
+        })
+    );
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -387,5 +387,12 @@
     </script>
     <script src="{{ url_for('static', filename='js/audio.js') }}"></script>
     <script src="/static/js/easterEgg.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            if ('serviceWorker' in navigator) {
+                navigator.serviceWorker.register('/service-worker.js');
+            }
+        });
+    </script>
 </body>
 </html>

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import importlib
+import sys
+import types
+
+if "pytest" not in sys.modules:
+    pytest = types.ModuleType("pytest")
+
+    def fixture(func=None, **kwargs):
+        if func is None:
+            return lambda f: f
+        return func
+
+    pytest.fixture = fixture
+    sys.modules["pytest"] = pytest
+else:
+    import pytest
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import apscheduler.schedulers.background as bg
+
+    monkeypatch.setattr(bg.BackgroundScheduler, "start", lambda self: None)
+
+    App = importlib.reload(importlib.import_module("App"))
+
+    monkeypatch.setattr(App, "update_metrics_job", lambda force=False: None)
+    monkeypatch.setattr(App, "MiningDashboardService", lambda *a, **k: object())
+    monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
+
+    sample_cfg = {"wallet": "w"}
+    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+
+    return App.app.test_client()
+
+
+def test_service_worker_route(client):
+    resp = client.get("/service-worker.js")
+    assert resp.status_code == 200
+    assert b"self.addEventListener" in resp.data
+
+
+def test_service_worker_asset_list():
+    js_path = Path("static/js/service-worker.js")
+    assert js_path.exists()
+    content = js_path.read_text()
+    assert "/static/css/common.css" in content
+    assert "/static/js/main.js" in content


### PR DESCRIPTION
## Summary
- add a service worker script to cache core assets
- register the worker on page load
- expose the worker as `/service-worker.js`
- update the webmanifest for PWA usage
- test service worker routing and caching

## Testing
- `PYTHONPATH=$PWD pytest -q`