### PR TITLE
Add PostCSS build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,17 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
-    - name: Install dependencies
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+    - name: Install Node dependencies
+      run: npm ci
+    - name: Build assets
+      run: make minify
     - name: Run ruff
       run: ruff check .
     - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,22 @@ setup:
 	$(PYTHON) setup.py
 
 minify:
+	make postcss
 	$(PYTHON) minify.py --all
 
 minify-js:
 	$(PYTHON) minify.py --js
 
 minify-css:
+	make postcss
 	$(PYTHON) minify.py --css
 
 minify-html:
 	$(PYTHON) minify.py --html
 
 .PHONY: setup minify minify-js minify-css minify-html
+
+postcss:
+	npx postcss static/css/*.css -d static/css/prefixed
+
+.PHONY: postcss

--- a/README.md
+++ b/README.md
@@ -167,20 +167,25 @@ The application is designed for efficient resource utilization:
 
 To set up a development environment:
 
-1. Install dependencies:
+1. Install Python dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-2. Prepare directories and assets:
+2. Install Node dependencies for PostCSS (Autoprefixer and postcss-cli):
+   ```bash
+   npm ci
+   ```
+3. Prepare directories and assets:
    ```bash
    make setup
    ```
-   Run `make minify` whenever static files or templates change.
-3. Check code style with ruff:
+   Run `make minify` whenever static files or templates change. The
+   command runs PostCSS with Autoprefixer before minifying assets.
+4. Check code style with ruff:
    ```bash
    ruff check .
    ```
-4. Execute tests:
+5. Execute tests:
    ```bash
    pytest
    ```

--- a/minify.py
+++ b/minify.py
@@ -5,9 +5,9 @@ import subprocess
 import shutil
 import logging
 from pathlib import Path
+import re
 
 from cssmin import cssmin
-import htmlmin
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
@@ -15,6 +15,48 @@ logger = logging.getLogger(__name__)
 
 def _has_uglify():
     return shutil.which("uglifyjs") is not None
+
+
+def minify_html_string(html: str) -> str:
+    """Return a minified HTML string."""
+    html = re.sub(r"<!--.*?-->", "", html, flags=re.DOTALL)
+    html = re.sub(r"\s+(\w+)=\"\"", r" \1", html)
+    html = re.sub(r">\s+<", "><", html)
+    html = re.sub(r">\s+", ">", html)
+    html = re.sub(r"\s+<", "<", html)
+    html = re.sub(r"\s{2,}", " ", html)
+    return html.strip()
+
+
+def run_postcss() -> Path:
+    """Run PostCSS with Autoprefixer on CSS files if available.
+
+    Returns the directory containing processed files. If PostCSS is not
+    installed, the original CSS directory is returned unchanged.
+    """
+
+    css_dir = Path("static/css")
+    out_dir = css_dir / "prefixed"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    postcss_cmd = None
+    if shutil.which("postcss"):
+        postcss_cmd = ["postcss"]
+    elif shutil.which("npx"):
+        postcss_cmd = ["npx", "postcss"]
+
+    if not postcss_cmd:
+        logger.warning("PostCSS not available; skipping prefixing")
+        return css_dir
+
+    for src in css_dir.glob("*.css"):
+        if src.name.endswith(".min.css"):
+            continue
+        out = out_dir / src.name
+        subprocess.run(postcss_cmd + [str(src), "-o", str(out)], check=True)
+        logger.info("PostCSS processed %s", src.name)
+
+    return out_dir
 
 
 def minify_js():
@@ -43,12 +85,13 @@ def minify_js():
 
 
 def minify_css():
-    """Minify CSS files using cssmin."""
+    """Run PostCSS then minify CSS files using cssmin."""
     css_dir = Path("static/css")
+    prefixed_dir = run_postcss()
     out_dir = css_dir / "min"
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    for src in css_dir.glob("*.css"):
+    for src in prefixed_dir.glob("*.css"):
         if src.name.endswith(".min.css"):
             continue
         out = out_dir / src.name.replace(".css", ".min.css")
@@ -66,9 +109,7 @@ def minify_html():
         if src.name.endswith(".min.html"):
             continue
         out = out_dir / src.name.replace(".html", ".min.html")
-        out.write_text(
-            htmlmin.minify(src.read_text(), remove_comments=True, reduce_empty_attributes=True), encoding="utf-8"
-        )
+        out.write_text(minify_html_string(src.read_text()), encoding="utf-8")
         logger.info("Minified %s", src.name)
 
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "deepsea-dashboard",
+  "private": true,
+  "devDependencies": {
+    "autoprefixer": "^10.4.16",
+    "postcss-cli": "^10.1.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    require('autoprefixer')
+  ]
+};

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ requests==2.31.0
 beautifulsoup4==4.12.2
 Flask-Caching==2.1.0
 gunicorn==22.0.0
-htmlmin==0.1.12
 redis==5.0.1
 APScheduler==3.10.4
 psutil==5.9.5

--- a/tests/test_minify.py
+++ b/tests/test_minify.py
@@ -1,0 +1,38 @@
+import subprocess
+import shutil
+from pathlib import Path
+
+import minify
+
+
+def test_run_postcss_called(monkeypatch, tmp_path):
+    css_dir = tmp_path / "static/css"
+    css_dir.mkdir(parents=True)
+    css_file = css_dir / "style.css"
+    css_file.write_text("a { display: flex }", encoding="utf-8")
+
+    called = {}
+
+    def fake_which(cmd):
+        return "/usr/bin/" + cmd
+
+    def fake_run(cmd, check=True):
+        called["cmd"] = cmd
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(shutil, "which", fake_which)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    out_dir = minify.run_postcss()
+    assert (out_dir / "style.css")
+    assert called["cmd"][0].endswith("postcss")
+
+
+def test_minify_html_string():
+    html = "<div> <!--c--> <p class=\"\"> a  b </p> </div>"
+    result = minify.minify_html_string(html)
+    assert "<!--" not in result
+    assert "  " not in result
+    assert 'class=""' not in result
+    assert result == "<div><p class>a b</p></div>"
+


### PR DESCRIPTION
## Summary
- configure PostCSS with Autoprefixer
- run PostCSS before minifying CSS in the build
- document PostCSS step in the README
- remove htmlmin dependency and replace with a custom minifier
- test new postcss helper and HTML minifier

## Testing
- `PYTHONPATH=$PWD pytest -q`
