### PR TITLE
Start music after loader fade

### DIFF
--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -74,6 +74,28 @@
             }
         };
 
+        const startPlaybackAfterLoader = () => {
+            const start = () => {
+                loadAndResume();
+            };
+
+            const loader = document.getElementById('theme-loader');
+            if (!loader) {
+                start();
+                return;
+            }
+
+            const onEnd = (e) => {
+                if (e.propertyName === 'opacity') {
+                    loader.removeEventListener('transitionend', onEnd);
+                    start();
+                }
+            };
+
+            loader.addEventListener('transitionend', onEnd);
+            setTimeout(start, 1000); // Fallback
+        };
+
         const startCrossfade = () => {
             if (isCrossfading) { return; }
             isCrossfading = true;
@@ -152,7 +174,7 @@
         window.crossfadeToTheme = crossfadeToTheme;
         window.audioCrossfadeDuration = crossfadeDuration;
 
-        loadAndResume();
+        startPlaybackAfterLoader();
 
         audio.muted = storedMuted;
         if (icon) {
@@ -179,7 +201,7 @@
             loadTrack(audio, trackIndex);
             loadTrack(nextAudio, (trackIndex + 1) % playlist.length);
             storedTime = 0;
-            loadAndResume();
+            startPlaybackAfterLoader();
         };
 
         if (playlist.length > 1) {


### PR DESCRIPTION
## Summary
- delay background music playback until the theme loader fades out

## Testing
- `make minify-js`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`