### PR TITLE
Fix blocks.js error when fetch fails

### DIFF
--- a/static/js/blocks.js
+++ b/static/js/blocks.js
@@ -767,6 +767,9 @@ function loadLatestBlocks() {
 
             // Show error toast
             showToast("Failed to load latest blocks. Please try again later.");
+
+            // Return empty array so downstream handlers receive a consistent value
+            return [];
         })
         .finally(function () {
             isLoading = false;


### PR DESCRIPTION
## Summary
- avoid undefined `data` after fetch failures by returning an empty array in `loadLatestBlocks`
- regenerate minified assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest`