### PR TITLE
Fix worker name parsing boundaries

### DIFF
--- a/miner_specs.py
+++ b/miner_specs.py
@@ -81,7 +81,8 @@ def parse_worker_name(name: str) -> Optional[Dict[str, float]]:
         return None
     name_lower = name.lower()
     for pattern, specs in MODEL_SPECS:
-        if re.search(pattern, name_lower):
+        boundary_pattern = rf"(?<![A-Za-z0-9]){pattern}(?![A-Za-z0-9])"
+        if re.search(boundary_pattern, name_lower):
             power = specs.get("hashrate", 0) * specs.get("efficiency", 0)
             return {
                 "model": specs["model"],
@@ -90,4 +91,14 @@ def parse_worker_name(name: str) -> Optional[Dict[str, float]]:
                 "default_hashrate": specs["hashrate"],
                 "power": power,
             }
+    if "axe" in name_lower:
+        hashrate = 1.1
+        efficiency = 15
+        return {
+            "model": "Generic Bitaxe",
+            "type": "Bitaxe",
+            "efficiency": efficiency,
+            "default_hashrate": hashrate,
+            "power": hashrate * efficiency,
+        }
     return None

--- a/tests/test_parse_worker_name.py
+++ b/tests/test_parse_worker_name.py
@@ -18,3 +18,19 @@ def test_parse_worker_name_t21():
     assert specs["type"] == "ASIC"
     assert specs["efficiency"] == 20.2
     assert round(specs["power"]) == round(162 * 20.2)
+
+
+def test_parse_worker_name_no_false_positive():
+    """Ensure patterns don't match inside other words."""
+    assert miner_specs.parse_worker_name("foo1166bar") is None
+    assert miner_specs.parse_worker_name("mys9buddy") is None
+
+
+def test_parse_worker_name_generic_axe():
+    """Any worker name containing 'axe' should map to the Bitaxe family."""
+    specs = miner_specs.parse_worker_name("mycoolaxe123")
+    assert specs is not None
+    assert specs["model"] == "Generic Bitaxe"
+    assert specs["type"] == "Bitaxe"
+    assert specs["efficiency"] == 15
+    assert round(specs["power"]) == round(1.1 * 15)


### PR DESCRIPTION
## Summary
- prevent false positives when parsing worker model names
- test worker name parsing edge cases
- add generic Bitaxe family detection for any worker containing `axe`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
