### PR TITLE
Improve worker regex

### DIFF
--- a/miner_specs.py
+++ b/miner_specs.py
@@ -10,11 +10,11 @@ MODEL_SPECS = [
     (r"s17[-_\s]*pro", {"model": "Bitmain Antminer S17 Pro", "type": "ASIC", "hashrate": 53, "efficiency": 39.5}),
     (r"t19", {"model": "Bitmain Antminer T19", "type": "ASIC", "hashrate": 84, "efficiency": 37.5}),
     (
-        r"s19\s*pro\+\s*hydro",
+        r"s19[-_\s]*pro\+[-_\s]*hydro",
         {"model": "Bitmain Antminer S19 Pro+ Hydro", "type": "ASIC", "hashrate": 198, "efficiency": 27.5},
     ),
     (
-        r"s19\s*xp\s*hydro",
+        r"s19[-_\s]*xp[-_\s]*hydro",
         {"model": "Bitmain Antminer S19 XP Hydro", "type": "ASIC", "hashrate": 255, "efficiency": 20.8},
     ),
     (r"s19k[-_\s]*pro", {"model": "Bitmain Antminer S19k Pro", "type": "ASIC", "hashrate": 112, "efficiency": 23}),
@@ -26,13 +26,13 @@ MODEL_SPECS = [
     (r"s19[-_\s]*xp", {"model": "Bitmain Antminer S19 XP", "type": "ASIC", "hashrate": 140, "efficiency": 21.5}),
     (r"s19\b", {"model": "Bitmain Antminer S19", "type": "ASIC", "hashrate": 95, "efficiency": 34.5}),
     (
-        r"s21\s*xp\s*hydro",
+        r"s21[-_\s]*xp[-_\s]*hydro",
         {"model": "Bitmain Antminer S21 XP Hydro", "type": "ASIC", "hashrate": 300, "efficiency": 12},
     ),
     (r"s21[-_\s]*pro", {"model": "Bitmain Antminer S21 Pro", "type": "ASIC", "hashrate": 234, "efficiency": 15.0}),
-    (r"s21\+\s*hydro", {"model": "Bitmain Antminer S21+ Hydro", "type": "ASIC", "hashrate": 350, "efficiency": 15.0}),
+    (r"s21\+[-_\s]*hydro", {"model": "Bitmain Antminer S21+ Hydro", "type": "ASIC", "hashrate": 350, "efficiency": 15.0}),
     (r"s21\+", {"model": "Bitmain Antminer S21+", "type": "ASIC", "hashrate": 250, "efficiency": 16.5}),
-    (r"s21\s*hydro", {"model": "Bitmain Antminer S21 Hydro", "type": "ASIC", "hashrate": 335, "efficiency": 16.0}),
+    (r"s21[-_\s]*hydro", {"model": "Bitmain Antminer S21 Hydro", "type": "ASIC", "hashrate": 335, "efficiency": 16.0}),
     (r"s21\b", {"model": "Bitmain Antminer S21", "type": "ASIC", "hashrate": 200, "efficiency": 17.5}),
     (r"t21\b", {"model": "Bitmain Antminer T21", "type": "ASIC", "hashrate": 162, "efficiency": 19.0}),
     # MicroBT Whatsminer series
@@ -66,7 +66,7 @@ MODEL_SPECS = [
     (r"t3\+", {"model": "Innosilicon T3+", "type": "ASIC", "hashrate": 52, "efficiency": 53.8}),
     (r"e11\+\+", {"model": "Ebang Ebit E11++", "type": "ASIC", "hashrate": 44, "efficiency": 45}),
     # Small form factor miners
-    (r"apollo\s*btc\s*ii", {"model": "FutureBit Apollo BTC II", "type": "ASIC", "hashrate": 6, "efficiency": 28.0}),
+    (r"apollo[-_\s]*btc[-_\s]*ii", {"model": "FutureBit Apollo BTC II", "type": "ASIC", "hashrate": 6, "efficiency": 28.0}),
     (r"apollo", {"model": "FutureBit Apollo BTC", "type": "ASIC", "hashrate": 3, "efficiency": 65.0}),
     (r"compac", {"model": "GekkoScience Compac F", "type": "USB", "hashrate": 0.3, "efficiency": 35}),
     (r"supra", {"model": "Bitaxe Supra", "type": "Bitaxe", "hashrate": 1.0, "efficiency": 17.5}),
@@ -77,6 +77,16 @@ MODEL_SPECS = [
     (r"urlacher", {"model": "The Urlacher", "type": "DIY", "hashrate": 56, "efficiency": 23}),
     (r"slim", {"model": "Antminer Slim", "type": "DIY", "hashrate": 32, "efficiency": 28}),
     (r"heatbit", {"model": "Heatbit Heater", "type": "DIY", "hashrate": 10, "efficiency": 40}),
+]
+
+
+COMPILED_SPECS = [
+    (
+        re.compile(rf"(?<![A-Za-z0-9]){pattern}(?![A-Za-z0-9])", re.IGNORECASE),
+        re.compile(rf"(?<![A-Za-z]){pattern}(?![A-Za-z])", re.IGNORECASE),
+        specs,
+    )
+    for pattern, specs in MODEL_SPECS
 ]
 
 
@@ -91,11 +101,8 @@ def parse_worker_name(name: str) -> Optional[Dict[str, float]]:
     """
     if not name:
         return None
-    name_lower = name.lower()
-    for pattern, specs in MODEL_SPECS:
-        strict_pattern = rf"(?<![A-Za-z0-9]){pattern}(?![A-Za-z0-9])"
-        relaxed_pattern = rf"(?<![A-Za-z]){pattern}(?![A-Za-z])"
-        if re.search(strict_pattern, name_lower) or re.search(relaxed_pattern, name_lower):
+    for strict_re, relaxed_re, specs in COMPILED_SPECS:
+        if strict_re.search(name) or relaxed_re.search(name):
             power = specs.get("hashrate", 0) * specs.get("efficiency", 0)
             return {
                 "model": specs["model"],
@@ -104,6 +111,7 @@ def parse_worker_name(name: str) -> Optional[Dict[str, float]]:
                 "default_hashrate": specs["hashrate"],
                 "power": power,
             }
+    name_lower = name.lower()
     if "axe" in name_lower:
         hashrate = 1.1
         efficiency = 15

--- a/tests/test_parse_worker_name.py
+++ b/tests/test_parse_worker_name.py
@@ -49,3 +49,19 @@ def test_parse_worker_name_allows_trailing_digits():
     """Keywords should match even if the worker name ends with numbers."""
     assert miner_specs.parse_worker_name("urlacher1")["model"] == "The Urlacher"
     assert miner_specs.parse_worker_name("bitchimney1")["model"] == "BitChimney Heater"
+
+
+def test_parse_worker_name_separator_variations():
+    """Patterns should match with hyphens or underscores between keywords."""
+    assert (
+        miner_specs.parse_worker_name("rig-s19pro+-hydro")["model"]
+        == "Bitmain Antminer S19 Pro+ Hydro"
+    )
+    assert (
+        miner_specs.parse_worker_name("farm_s21xp-hydro")["model"]
+        == "Bitmain Antminer S21 XP Hydro"
+    )
+    assert (
+        miner_specs.parse_worker_name("apollo-btc_ii")["model"]
+        == "FutureBit Apollo BTC II"
+    )


### PR DESCRIPTION
## Summary
- update miner model regex to allow hyphen/underscore separators
- precompile worker name patterns for faster lookup
- expand tests for separator variations

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`