### PR TITLE
Fix unpaid earnings distribution in worker fallback data

### DIFF
--- a/tests/test_worker_service.py
+++ b/tests/test_worker_service.py
@@ -1,6 +1,7 @@
 import types
 import sys
 import random
+import pytest
 
 # Provide lightweight stubs for external deps if missing
 if "pytz" not in sys.modules:
@@ -60,6 +61,21 @@ def test_generate_fallback_data_counts(monkeypatch):
     assert data["workers_online"] == 1
     assert data["workers_offline"] == 1
     assert data["daily_sats"] == 500
+
+
+def test_generate_fallback_data_earnings_distribution(monkeypatch):
+    monkeypatch.setattr("worker_service.get_timezone", lambda: "UTC")
+    svc = WorkerService()
+    metrics = {
+        "workers_hashing": 2,
+        "hashrate_3hr": 60,
+        "hashrate_3hr_unit": "TH/s",
+        "unpaid_earnings": 0.2,
+        "daily_mined_sats": 500,
+    }
+    data = svc.generate_fallback_data(metrics)
+    earnings_sum = sum(w["earnings"] for w in data["workers"])
+    assert pytest.approx(earnings_sum) == 0.2
 
 
 def test_generate_fallback_data_zero_workers(monkeypatch):

--- a/worker_service.py
+++ b/worker_service.py
@@ -393,24 +393,6 @@ class WorkerService:
                 if name and name.lower() not in ["online", "offline", "total"]:
                     real_worker_names.append(name)
 
-        # Generate worker data
-        workers_data = []
-
-        # If we have real worker names, use them
-        if real_worker_names:
-            logging.info(f"Using {len(real_worker_names)} real worker names from cache")
-            workers_data = self.generate_simulated_workers(
-                workers_count, original_hashrate_3hr, hashrate_unit, real_worker_names=real_worker_names
-            )
-        else:
-            # Otherwise use sequential names
-            logging.info("No real worker names available, using sequential names")
-            workers_data = self.generate_sequential_workers(workers_count, original_hashrate_3hr, hashrate_unit)
-
-        # Calculate basic statistics
-        workers_online = len([w for w in workers_data if w["status"] == "online"])
-        workers_offline = len(workers_data) - workers_online
-
         # Use unpaid_earnings from main dashboard
         unpaid_earnings = cached_metrics.get("unpaid_earnings", 0)
         # Handle case where unpaid_earnings might be a string
@@ -425,6 +407,29 @@ class WorkerService:
         if unpaid_earnings is None or unpaid_earnings <= 0:
             unpaid_earnings = 0.001
 
+        # Generate worker data
+        workers_data = []
+
+        # If we have real worker names, use them
+        if real_worker_names:
+            logging.info(f"Using {len(real_worker_names)} real worker names from cache")
+            workers_data = self.generate_simulated_workers(
+                workers_count,
+                original_hashrate_3hr,
+                hashrate_unit,
+                total_unpaid_earnings=unpaid_earnings,
+                real_worker_names=real_worker_names,
+            )
+        else:
+            # Otherwise use sequential names
+            logging.info("No real worker names available, using sequential names")
+            workers_data = self.generate_sequential_workers(
+                workers_count, original_hashrate_3hr, hashrate_unit, total_unpaid_earnings=unpaid_earnings
+            )
+
+        # Calculate basic statistics
+        workers_online = len([w for w in workers_data if w["status"] == "online"])
+        workers_offline = len(workers_data) - workers_online
         # Use unpaid_earnings as total_earnings
         total_earnings = unpaid_earnings
 


### PR DESCRIPTION
## Summary
- fix worker_service fallback to pass unpaid earnings into worker generator
- test distribution of unpaid earnings among generated workers

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`