### PR TITLE
Add block found sound

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ informed with minimal fuss.
   `bitcoin.mp3`, `bitcoin1.mp3` and `bitcoin2.mp3`. Playback position persists between page loads. Place the files
   in `static/audio/`. The Docker configuration mounts this directory automatically. Hover the speaker icon to reveal
   a vertical volume slider. Tracks now crossfade seamlessly with a 2 second overlap and when switching themes.
+  Add an optional `block.mp3` file in the same directory to play a short sound whenever a new block is found.
 
 ### DeepSea Theme
 - **Underwater Effects**: Light rays and digital noise create an immersive experience.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -108,6 +108,9 @@ For better performance and reliability in production environments:
       bitcoin-mining-dashboard
    ```
 
+   The `static/audio` directory should contain the background tracks and an optional
+   `block.mp3` file that plays when a new block is found.
+
 3. Access the dashboard at `http://localhost:5000`
 
 ### Option 4: Docker Compose with Redis Persistence
@@ -132,12 +135,12 @@ For better performance and reliability in production environments:
          - REDIS_URL=redis://redis:6379
          - WALLET=your-wallet-address
          - POWER_COST=0.12
-         - POWER_USAGE=3450
-        volumes:
-          - ./logs:/app/logs
-          - ./static/audio:/app/static/audio
-        depends_on:
-          - redis
+        - POWER_USAGE=3450
+       volumes:
+         - ./logs:/app/logs
+         - ./static/audio:/app/static/audio  # include block.mp3 here if desired
+       depends_on:
+         - redis
    
    volumes:
      redis_data:

--- a/static/audio/README.md
+++ b/static/audio/README.md
@@ -1,2 +1,3 @@
-This directory stores background audio tracks for the dashboard. Use `ocean.mp3` for the DeepSea theme and
+This directory stores audio tracks for the dashboard. Use `ocean.mp3` for the DeepSea theme and
 `bitcoin.mp3`, `bitcoin1.mp3`, and `bitcoin2.mp3` for the Bitcoin theme.
+Place an optional `block.mp3` file here to play when the pool discovers a new block.

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1994,6 +1994,7 @@ function checkForBlockUpdates(data) {
     if (previousMetrics.last_block_height !== undefined &&
         data.last_block_height !== previousMetrics.last_block_height) {
         showCongrats("Congrats! New Block Found: " + data.last_block_height);
+        playBlockSound();
         if (trendChart && trendChart.data && trendChart.data.labels.length > 0) {
             const label = trendChart.data.labels[trendChart.data.labels.length - 1];
             blockAnnotations.push(label);
@@ -2086,6 +2087,30 @@ function showCongrats(message) {
     $congrats.off('click').on('click', function () {
         $(this).fadeOut(500);
     });
+}
+
+// Play celebratory audio when a new block is found
+function playBlockSound() {
+    const audioSrc = '/static/audio/block.mp3';
+    const blockAudio = new Audio(audioSrc);
+    const bgAudio = document.getElementById('backgroundAudio');
+    let originalVolume = null;
+
+    if (bgAudio && !bgAudio.muted && !bgAudio.paused) {
+        originalVolume = bgAudio.volume;
+        bgAudio.volume = Math.max(0, originalVolume * 0.3);
+    }
+
+    const restoreVolume = () => {
+        if (originalVolume !== null && bgAudio) {
+            bgAudio.volume = originalVolume;
+        }
+    };
+
+    blockAudio.addEventListener('ended', restoreVolume);
+    blockAudio.addEventListener('error', restoreVolume);
+
+    blockAudio.play().catch(restoreVolume);
 }
 
 // Enhanced Chart Update Function to handle temporary hashrate spikes


### PR DESCRIPTION
## Summary
- play `block.mp3` when a new block is found
- briefly lower background music volume for clarity
- document the optional new audio file in README and deployment guide

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`