### PR TITLE
Fix variance progress when data missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ dataset (arrow history, metrics log and hashrate history) is capped at 180
 entries, equating to roughly three hours of data. Older points are pruned by the
 `StateManager` before saving to Redis, ensuring memory usage remains stable.
 Short-term variance history for earnings metrics is also persisted so 3-hour
-variance values remain visible after restarts.
+variance values remain visible after restarts. Minor gaps of a few minutes are
+filled automatically using the last known metric so the variance progress can
+reach 100% even with occasional missing samples.
 
 ## API Endpoints
 - `/api/metrics`: Provides real-time mining metrics.

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -134,6 +134,28 @@ def test_network_hashrate_variance_calculation(monkeypatch):
     assert second["network_hashrate_variance_progress"] == 100
 
 
+def test_autofill_variance_gaps(monkeypatch):
+    mgr = StateManager()
+    monkeypatch.setattr("state_manager.get_timezone", lambda: "UTC")
+
+    from datetime import datetime, timedelta
+    from zoneinfo import ZoneInfo
+
+    first = {"network_hashrate": 400}
+    mgr.update_metrics_history(first)
+
+    history = mgr.variance_history["network_hashrate"]
+    for _ in range(MAX_VARIANCE_HISTORY_ENTRIES - 2):
+        history.append({"time": history[-1]["time"], "value": first["network_hashrate"]})
+
+    history[-1]["time"] = datetime.now(ZoneInfo("UTC")) - timedelta(minutes=2)
+
+    second = {"network_hashrate": 450}
+    mgr.update_metrics_history(second)
+
+    assert second["network_hashrate_variance_progress"] == 100
+
+
 def test_variance_history_persistence(monkeypatch):
     mgr = StateManager()
     mgr.redis_client = DummyRedis()


### PR DESCRIPTION
## Summary
- add constant to auto-fill small gaps in variance history
- fill missing variance entries with the last known value
- document new gap filling behavior
- test autofill logic for variance gaps

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`