### PR TITLE
Fix timezone fallback in NotificationService

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 import pytz
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone, tzinfo
 from enum import Enum
 from typing import List, Dict, Any, Optional
 from config import get_timezone, load_config
@@ -128,9 +128,11 @@ class NotificationService:
         """Get current datetime with the configured timezone."""
         try:
             tz = pytz.timezone(get_timezone())
+            if not isinstance(tz, tzinfo):
+                raise TypeError("Timezone object must derive from tzinfo")
         except Exception as e:
             logging.error(f"[NotificationService] Error getting timezone: {e}")
-            tz = pytz.utc
+            tz = getattr(pytz, "utc", timezone.utc)
         return datetime.now(tz)
 
     def _parse_timestamp(self, timestamp_str: str) -> datetime:


### PR DESCRIPTION
## Summary
- handle missing pytz.utc and invalid tz objects gracefully

## Testing
- `pytest tests/test_notification_generation.py::NotificationGenerationTest::test_generation_flow tests/test_notification_service.py::NotificationCurrencyTest::test_get_current_time_fallback_tz -q`