### PR TITLE
Fix currency update not reusing service

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -492,11 +492,9 @@ class NotificationService:
             config = load_config()
             user_currency = config.get("currency", "USD")
 
-            # Get exchange rates
-            # ``get_exchange_rates`` can be patched by tests with a simple
-            # zero-argument callable.  Avoid passing ``dashboard_service`` so
-            # such patches don't receive unexpected arguments.
-            exchange_rates = get_exchange_rates()
+            # Get exchange rates using the shared dashboard service when
+            # available. Test patches typically ignore the argument.
+            exchange_rates = get_exchange_rates(self.dashboard_service)
 
             # Format with the user's currency
             formatted_profit = format_currency_value(daily_profit_usd, user_currency, exchange_rates)
@@ -790,10 +788,9 @@ class NotificationService:
                 config = load_config()
                 new_currency = config.get("currency", "USD")
 
-            # ``get_exchange_rates`` may be patched by tests with a simple
-            # zero-argument callable.  Call it without arguments to avoid
-            # issues when such a patch is in place.
-            exchange_rates = get_exchange_rates()
+            # Use the shared dashboard service for exchange rates when
+            # available. Test patches commonly ignore the argument.
+            exchange_rates = get_exchange_rates(self.dashboard_service)
             if new_currency not in exchange_rates:
                 logging.warning(
                     f"[NotificationService] Missing exchange rate for {new_currency}, skipping update"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -99,7 +99,10 @@ def test_notification_update_currency(monkeypatch):
             "data": {"daily_profit": 10.0, "currency": "USD"},
         }
     ]
-    monkeypatch.setattr("notification_service.get_exchange_rates", lambda: {"EUR": 0.5, "USD": 1})
+    monkeypatch.setattr(
+        "notification_service.get_exchange_rates",
+        lambda svc=None: {"EUR": 0.5, "USD": 1},
+    )
     updated = svc.update_notification_currency("EUR")
     assert updated == 1
     notif = svc.notifications[0]


### PR DESCRIPTION
## Summary
- use the existing `MiningDashboardService` when requesting exchange rates
- update service tests for new argument

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`