### PR TITLE
Add Matrix rain background

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ informed with minimal fuss.
 - **Theme Toggle**: Switch between Bitcoin and DeepSea themes with a single click.
 
 ### Secret Matrix Theme
-- **Activation**: Enable the easter egg with the Konami code and then enter `IDDQD` to reveal a green Matrix-style look.
+- **Activation**: Enable the easter egg with the Konami code and then enter `IDDQD` to reveal a green Matrix-style look. Now includes an animated matrix rain background for extra immersion.
 
 ## Documentation
 

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -63,6 +63,11 @@ html.deepsea-theme #theme-loader {
   color: #0088cc;
 }
 
+html.matrix-theme #theme-loader {
+  background-color: #000000;
+  color: #39ff14;
+}
+
 #loader-icon {
   font-size: 48px;
   margin-bottom: 20px;

--- a/static/css/matrix.css
+++ b/static/css/matrix.css
@@ -21,3 +21,18 @@ body.matrix-theme #themeToggle:focus,
 body.matrix-theme .theme-toggle-btn:focus {
   box-shadow: 0 0 0 3px rgba(57, 255, 20, 0.3);
 }
+
+html.matrix-theme body {
+  background: linear-gradient(135deg, #000000 0%, #003300 100%);
+  overflow: hidden;
+}
+
+.matrix-rain {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+}

--- a/static/js/matrixRain.js
+++ b/static/js/matrixRain.js
@@ -1,0 +1,50 @@
+(function() {
+    "use strict";
+
+    function initMatrixRain() {
+        const canvas = document.createElement('canvas');
+        canvas.id = 'matrixRain';
+        canvas.className = 'matrix-rain';
+        document.body.appendChild(canvas);
+
+        const ctx = canvas.getContext('2d');
+        let width, height, columns, drops;
+
+        function resize() {
+            width = window.innerWidth;
+            height = window.innerHeight;
+            canvas.width = width;
+            canvas.height = height;
+            columns = Math.floor(width / 20);
+            drops = Array(columns).fill(0);
+        }
+
+        function draw() {
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
+            ctx.fillRect(0, 0, width, height);
+            ctx.fillStyle = '#39ff14';
+            ctx.font = '16px monospace';
+
+            for (let i = 0; i < drops.length; i++) {
+                const text = String.fromCharCode(0x30A0 + Math.random() * 96);
+                ctx.fillText(text, i * 20, drops[i] * 20);
+                if (drops[i] * 20 > height && Math.random() > 0.975) {
+                    drops[i] = 0;
+                }
+                drops[i]++;
+            }
+        }
+
+        resize();
+        window.addEventListener('resize', resize);
+        setInterval(draw, 50);
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        if (localStorage.getItem('useMatrixTheme') === 'true') {
+            initMatrixRain();
+        }
+    });
+
+    window.initMatrixRain = initMatrixRain;
+})();

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -482,6 +482,10 @@ function applyMatrixTheme() {
         document.documentElement.classList.remove('bitcoin-theme', 'deepsea-theme');
         document.documentElement.classList.add('matrix-theme');
 
+        if (window.initMatrixRain) {
+            window.initMatrixRain();
+        }
+
         updateMatrixHeaderText();
         updateChartControlsLabel(true);
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,7 @@
 
     <!-- Theme JS (added to ensure consistent application of theme) -->
     <script src="/static/js/theme.js"></script>
+    <script src="/static/js/matrixRain.js"></script>
 
     <!-- Logging wrapper -->
     <script src="/static/js/logger.js"></script>


### PR DESCRIPTION
## Summary
- style theme loader for Matrix theme
- add matrix rain effect with new script
- expand Matrix theme CSS and wire up script loading
- trigger the rain effect when applying the Matrix theme
- document Matrix theme animation in README

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest`