### PR TITLE
Switch Matrix activation code and refresh chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ informed with minimal fuss.
 - **Theme Toggle**: Switch between Bitcoin and DeepSea themes with a single click.
 
 ### Secret Matrix Theme
-- **Activation**: Enable the easter egg with the Konami code and then enter `IDDQD` to reveal a green Matrix-style look. Now includes an animated matrix rain background for extra immersion.
+- **Activation**: Enable the easter egg with the Konami code and then enter `MATRIX` to reveal a green Matrix-style look. Now includes an animated matrix rain background for extra immersion.
 
 ## Documentation
 

--- a/static/css/matrix.css
+++ b/static/css/matrix.css
@@ -36,3 +36,8 @@ html.matrix-theme body {
   pointer-events: none;
   z-index: 0; /* draw above background but below content */
 }
+
+/* Chart button text should be black to match navigation */
+html.matrix-theme .toggle-btn.active {
+  color: #000 !important;
+}

--- a/static/js/easterEgg.js
+++ b/static/js/easterEgg.js
@@ -1,6 +1,6 @@
 (function() {
   const konami = ['ArrowUp','ArrowUp','ArrowDown','ArrowDown','ArrowLeft','ArrowRight','ArrowLeft','ArrowRight','b','a'];
-  const matrix = ['i','d','d','q','d'];
+  const matrix = ['m','a','t','r','i','x'];
   let index = 0;
   let matrixIndex = 0;
   let cursorClicks = [];
@@ -183,6 +183,48 @@
       localStorage.setItem('useMatrixTheme', 'true');
       localStorage.setItem('useDeepSeaTheme', 'true');
       window.applyMatrixTheme();
+
+      // Refresh the main chart with new theme colors
+      try {
+        if (window.trendChart && window.initializeChart &&
+            window.updateChartWithNormalizedData && window.updateBlockAnnotations) {
+          const fontConfig = {
+            xTicks: { ...trendChart.options.scales.x.ticks.font },
+            yTicks: { ...trendChart.options.scales.y.ticks.font },
+            yTitle: { ...trendChart.options.scales.y.title.font },
+            tooltip: {
+              title: { ...trendChart.options.plugins.tooltip.titleFont },
+              body: { ...trendChart.options.plugins.tooltip.bodyFont }
+            }
+          };
+          const isMobile = window.innerWidth < 768;
+          trendChart.destroy();
+          trendChart = initializeChart();
+          if (isMobile) {
+            trendChart.options.scales.x.ticks.font = { ...fontConfig.xTicks };
+            trendChart.options.scales.y.ticks.font = { ...fontConfig.yTicks };
+            trendChart.options.scales.y.title.font = { ...fontConfig.yTitle };
+            trendChart.options.plugins.tooltip.titleFont = { ...fontConfig.tooltip.title };
+            trendChart.options.plugins.tooltip.bodyFont = { ...fontConfig.tooltip.body };
+          } else {
+            trendChart.options.scales.x.ticks.font = fontConfig.xTicks;
+            trendChart.options.scales.y.ticks.font = fontConfig.yTicks;
+            trendChart.options.scales.y.title.font = fontConfig.yTitle;
+            trendChart.options.plugins.tooltip.titleFont = fontConfig.tooltip.title;
+            trendChart.options.plugins.tooltip.bodyFont = fontConfig.tooltip.body;
+          }
+          updateChartWithNormalizedData(trendChart, window.latestMetrics);
+          updateBlockAnnotations(trendChart);
+          trendChart.update('none');
+        }
+      } catch (e) {
+        console.error('Error refreshing chart for Matrix theme:', e);
+      }
+
+      // Notify listeners of theme change
+      if (window.jQuery) {
+        window.jQuery(document).trigger('themeChanged');
+      }
 
       const overlay = document.createElement('div');
       overlay.id = 'matrixOverlay';


### PR DESCRIPTION
## Summary
- update secret Matrix theme activation code to `MATRIX`
- refresh trend chart when Matrix theme activates and trigger theme change event
- set chart button text black in Matrix theme
- update README with new activation instructions

## Testing
- `PYTHONPATH=$PWD pytest`
