### PR TITLE
Protect block notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ For more details, refer to the [docker-compose documentation](https://docs.docke
 ### Notifications
 - Real-time alerts for important events
 - Notification history with read/unread status
+- Block-found alerts are permanent and cannot be deleted
 
 ### System Monitor
 


### PR DESCRIPTION
## Summary
- keep block found notifications from being deleted
- ensure clear operation always retains block notifications
- document the behavior in the README
- test API delete and clear endpoints for block notifications

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`