### PR TITLE
Hide delete icon for block notifications

### DIFF
--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -307,6 +307,11 @@ function createNotificationElement(notification) {
         deleteNotification(notification.id);
     });
 
+    // Hide delete button for block notifications
+    if (notification.category === 'block') {
+        element.find('.delete-button').remove();
+    }
+
     // Hide mark as read button if already read
     if (notification.read) {
         element.find('.mark-read-button').hide();


### PR DESCRIPTION
## Summary
- remove delete button from block notifications so blocks can't be removed via UI
- regenerate minified assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`