### PR TITLE
Expose configurable hashrate thresholds

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,5 +5,7 @@
     "timezone": "America/Los_Angeles",
     "network_fee": 0.0,
     "currency": "USD",
+    "low_hashrate_threshold_ths": 3.0,
+    "high_hashrate_threshold_ths": 20.0,
     "EXCHANGE_RATE_API_KEY": "179cbeb07c900f20dde92d3b"
 }

--- a/config.py
+++ b/config.py
@@ -25,6 +25,8 @@ DEFAULT_CONFIG = {
     "timezone": "America/Los_Angeles",
     "network_fee": 0.0,
     "currency": "USD",
+    "low_hashrate_threshold_ths": 3.0,
+    "high_hashrate_threshold_ths": 20.0,
     "EXCHANGE_RATE_API_KEY": "179cbeb07c900f20dde92d3b",
 }
 
@@ -38,6 +40,8 @@ def validate_config(config):
         "timezone": str,
         "network_fee": (int, float),
         "currency": str,
+        "low_hashrate_threshold_ths": (int, float),
+        "high_hashrate_threshold_ths": (int, float),
         "EXCHANGE_RATE_API_KEY": str,
     }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,6 +16,8 @@ The default configuration file contains the following keys:
 | `timezone` | Local timezone identifier | `"America/Los_Angeles"` |
 | `network_fee` | Additional fees beyond pool fees | `0.0` |
 | `currency` | Preferred fiat currency for earnings display | `"USD"` |
+| `low_hashrate_threshold_ths` | Threshold below which the miner is considered in low hashrate mode (TH/s) | `3.0` |
+| `high_hashrate_threshold_ths` | Threshold above which normal hashrate mode resumes (TH/s) | `20.0` |
 
 Configuration files are validated when loaded. Missing keys or incorrect types
 cause the application to fall back to default values and log an error.

--- a/notification_service.py
+++ b/notification_service.py
@@ -594,8 +594,9 @@ class NotificationService:
                 elif "mh/s" in current_3hr_unit:
                     current_3hr /= 1000000
 
-                # If hashrate is less than 3 TH/s, consider it low hashrate mode
-                is_low_hashrate_mode = current_3hr < 3.0
+                cfg = load_config()
+                threshold = cfg.get("low_hashrate_threshold_ths", 3.0)
+                is_low_hashrate_mode = current_3hr < threshold
 
             logging.debug(f"[NotificationService] Low hashrate mode: {is_low_hashrate_mode}")
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -303,6 +303,12 @@ const arrowIndicator = new ArrowIndicator();
 let dashboardTimezone = 'America/Los_Angeles'; // Default
 window.dashboardTimezone = dashboardTimezone; // Make it globally accessible
 
+// Hashrate thresholds
+let lowHashrateThresholdTHS = 3.0;
+let highHashrateThresholdTHS = 20.0;
+window.lowHashrateThresholdTHS = lowHashrateThresholdTHS;
+window.highHashrateThresholdTHS = highHashrateThresholdTHS;
+
 // Fetch the configured timezone when the page loads
 function fetchTimezoneConfig() {
     fetch('/api/timezone')
@@ -317,8 +323,27 @@ function fetchTimezoneConfig() {
         .catch(error => console.error('Error fetching timezone config:', error));
 }
 
+function fetchHashrateThresholds() {
+    fetch('/api/config')
+        .then(response => response.json())
+        .then(cfg => {
+            if (cfg.low_hashrate_threshold_ths !== undefined) {
+                lowHashrateThresholdTHS = parseFloat(cfg.low_hashrate_threshold_ths);
+                window.lowHashrateThresholdTHS = lowHashrateThresholdTHS;
+            }
+            if (cfg.high_hashrate_threshold_ths !== undefined) {
+                highHashrateThresholdTHS = parseFloat(cfg.high_hashrate_threshold_ths);
+                window.highHashrateThresholdTHS = highHashrateThresholdTHS;
+            }
+        })
+        .catch(err => console.error('Error fetching hashrate thresholds:', err));
+}
+
 // Call this on page load
-document.addEventListener('DOMContentLoaded', fetchTimezoneConfig);
+document.addEventListener('DOMContentLoaded', () => {
+    fetchTimezoneConfig();
+    fetchHashrateThresholds();
+});
 
 // Global variables
 let previousMetrics = {};
@@ -2190,8 +2215,8 @@ function updateChartWithNormalizedData(chart, data) {
         // Get values with enhanced stability
         let useHashrate3hr = false;
         const currentTime = Date.now();
-        const LOW_HASHRATE_THRESHOLD = 0.01; // TH/s 
-        const HIGH_HASHRATE_THRESHOLD = 20.0; // TH/s
+        const LOW_HASHRATE_THRESHOLD = window.lowHashrateThresholdTHS || 0.01; // TH/s
+        const HIGH_HASHRATE_THRESHOLD = window.highHashrateThresholdTHS || 20.0; // TH/s
         const MODE_SWITCH_DELAY = 120000;     // Increase to 2 minutes for more stability
         const CONSECUTIVE_SPIKES_THRESHOLD = 3; // Increase to require more consistent high readings
         const MIN_MODE_STABILITY_TIME = 120000; // 2 minutes minimum between mode switches

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,16 @@ def test_load_config_file(tmp_path, monkeypatch):
     assert "EXCHANGE_RATE_API_KEY" in cfg
 
 
+def test_load_config_thresholds(tmp_path, monkeypatch):
+    temp_file = tmp_path / "cfg.json"
+    with open(temp_file, "w") as fh:
+        json.dump({"low_hashrate_threshold_ths": 5.5, "high_hashrate_threshold_ths": 25.0}, fh)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", str(temp_file))
+    cfg = importlib.reload(config_module).load_config()
+    assert cfg["low_hashrate_threshold_ths"] == 5.5
+    assert cfg["high_hashrate_threshold_ths"] == 25.0
+
+
 def test_config_caching(monkeypatch, tmp_path):
     temp_file = tmp_path / "cfg.json"
     with open(temp_file, "w") as fh:
@@ -64,6 +74,8 @@ def test_validate_config_valid():
         "timezone": "UTC",
         "network_fee": 0.0,
         "currency": "USD",
+        "low_hashrate_threshold_ths": 3.0,
+        "high_hashrate_threshold_ths": 20.0,
         "EXCHANGE_RATE_API_KEY": "KEY",
     }
     assert config_module.validate_config(cfg)
@@ -77,6 +89,8 @@ def test_validate_config_missing_key():
         "timezone": "UTC",
         "network_fee": 0.0,
         "currency": "USD",
+        "low_hashrate_threshold_ths": 3.0,
+        "high_hashrate_threshold_ths": 20.0,
         "EXCHANGE_RATE_API_KEY": "KEY",
     }
     cfg.pop("wallet")


### PR DESCRIPTION
## Summary
- allow user configuration of low/high hashrate thresholds
- use these configuration values throughout the application
- fetch hashrate thresholds in the dashboard JavaScript
- document new configuration options
- adjust tests for new config keys

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_683a732c80a883209b7ca22f89f6da11