### PR TITLE
Add hashrate change tests and currency util

### DIFF
--- a/static/js/earnings.js
+++ b/static/js/earnings.js
@@ -70,8 +70,11 @@ function fetchServerTimeAndInitializeMonitor() {
 }
 
 // Function to format currency values with commas
-function formatCurrency(amount) {
-    return amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+// Provided by utils/formatCurrency.js but fallback defined for safety
+if (typeof formatCurrency === 'undefined') {
+    function formatCurrency(amount) {
+        return amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    }
 }
 
 // Format all currency values on the page

--- a/static/js/formatCurrency.js
+++ b/static/js/formatCurrency.js
@@ -1,0 +1,13 @@
+(function(root, factory){
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.formatCurrency = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function(){
+    function formatCurrency(amount) {
+        return amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    }
+    return formatCurrency;
+}));
+

--- a/templates/earnings.html
+++ b/templates/earnings.html
@@ -151,5 +151,6 @@
 {% endblock %}
 
 {% block javascript %}
+<script src="{{ url_for('static', filename='js/formatCurrency.js') }}"></script>
 <script src="{{ url_for('static', filename='js/earnings.js') }}"></script>
 {% endblock %}

--- a/tests/js/formatCurrency.test.js
+++ b/tests/js/formatCurrency.test.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const formatCurrency = require('../../static/js/formatCurrency');
+
+assert.strictEqual(formatCurrency(1000), '1,000');
+assert.strictEqual(formatCurrency(1234567), '1,234,567');
+assert.strictEqual(formatCurrency('2500'), '2,500');
+console.log('formatCurrency tests passed');

--- a/tests/test_hashrate_change.py
+++ b/tests/test_hashrate_change.py
@@ -1,0 +1,95 @@
+import sys
+import types
+from notification_service import NotificationService
+
+# Provide lightweight stubs for missing dependencies
+if "pytz" not in sys.modules:
+    tz_module = types.ModuleType("pytz")
+
+    class DummyTZInfo:
+        def utcoffset(self, dt):
+            return None
+        def dst(self, dt):
+            return None
+        def tzname(self, dt):
+            return "UTC"
+        def localize(self, dt_obj):
+            return dt_obj.replace(tzinfo=self)
+
+    tz_module.timezone = lambda name: DummyTZInfo()
+    sys.modules["pytz"] = tz_module
+
+if "requests" not in sys.modules:
+    req_module = types.ModuleType("requests")
+
+    class DummySession:
+        def get(self, *args, **kwargs):
+            raise NotImplementedError
+
+    req_module.Session = DummySession
+    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
+    sys.modules["requests"] = req_module
+
+if "bs4" not in sys.modules:
+    bs4_module = types.ModuleType("bs4")
+
+    class DummySoup:
+        pass
+
+    bs4_module.BeautifulSoup = DummySoup
+    sys.modules["bs4"] = bs4_module
+
+
+class DummyState:
+    def get_notifications(self):
+        return []
+    def save_notifications(self, notifications):
+        pass
+
+
+def make_service():
+    return NotificationService(DummyState())
+
+
+def test_switches_to_3hr_when_low_hashrate():
+    svc = make_service()
+    current = {
+        "hashrate_3hr": "2.0",
+        "hashrate_3hr_unit": "TH/s",
+        "hashrate_10min": "2.2",
+        "hashrate_10min_unit": "TH/s",
+    }
+    previous = {
+        "hashrate_3hr": "4.0",
+        "hashrate_3hr_unit": "TH/s",
+        "hashrate_10min": "2.2",
+        "hashrate_10min_unit": "TH/s",
+    }
+    result = svc._check_hashrate_change(current, previous)
+    assert result is not None
+    assert result["data"]["timeframe"] == "3hr"
+    assert result["data"]["is_low_hashrate_mode"] is True
+    assert result["data"]["previous"] == 4.0
+    assert result["data"]["current"] == 2.0
+
+
+def test_uses_10min_when_hashrate_normal():
+    svc = make_service()
+    current = {
+        "hashrate_3hr": "5.0",
+        "hashrate_3hr_unit": "TH/s",
+        "hashrate_10min": "8.0",
+        "hashrate_10min_unit": "TH/s",
+    }
+    previous = {
+        "hashrate_3hr": "4.5",
+        "hashrate_3hr_unit": "TH/s",
+        "hashrate_10min": "4.0",
+        "hashrate_10min_unit": "TH/s",
+    }
+    result = svc._check_hashrate_change(current, previous)
+    assert result is not None
+    assert result["data"]["timeframe"] == "10min"
+    assert result["data"]["is_low_hashrate_mode"] is False
+    assert result["data"]["previous"] == 4.0
+    assert result["data"]["current"] == 8.0


### PR DESCRIPTION
## Summary
- add tests checking that `_check_hashrate_change` uses 3hr averages when threshold crossed
- expose `formatCurrency` helper and include it in earnings template
- fallback for `formatCurrency` in `earnings.js`
- add simple node test for `formatCurrency`

## Testing
- `node tests/js/formatCurrency.test.js`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_683a7334f05c83209ec4a506ac58dd6f