### PR TITLE
Clean up unused stableModePeriod state

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2162,8 +2162,7 @@ function updateChartWithNormalizedData(chart, data) {
                 spikeCount: 0,
                 lowHashrateConfirmTime: 0,
                 modeSwitchTimeoutId: null,
-                lastModeChange: 0,
-                stableModePeriod: 600000
+                lastModeChange: 0
             };
 
             // If we have stored state, use it
@@ -2177,6 +2176,7 @@ function updateChartWithNormalizedData(chart, data) {
                         highHashrateSpikeTime: parsedState.highHashrateSpikeTime || 0,
                         modeSwitchTimeoutId: null
                     };
+                    delete chart.lowHashrateState.stableModePeriod;
                     console.log("Restored low hashrate mode from localStorage:", chart.lowHashrateState.isLowHashrateMode);
                 } catch (e) {
                     console.error("Error parsing stored low hashrate state:", e);
@@ -2309,8 +2309,7 @@ function updateChartWithNormalizedData(chart, data) {
                     highHashrateSpikeTime: state.highHashrateSpikeTime,
                     spikeCount: state.spikeCount,
                     lowHashrateConfirmTime: state.lowHashrateConfirmTime,
-                    lastModeChange: state.lastModeChange,
-                    stableModePeriod: state.stableModePeriod
+                    lastModeChange: state.lastModeChange
                 };
                 localStorage.setItem('lowHashrateState', JSON.stringify(stateToSave));
                 console.log("Saved low hashrate state:", state.isLowHashrateMode);


### PR DESCRIPTION
## Summary
- remove the `stableModePeriod` field from low hashrate mode
- strip legacy `stableModePeriod` from restored state
- adjust saved state accordingly

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a73417f7c83208994f4e00992b266