### PR TITLE
Handle negative durations

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -523,6 +523,9 @@ function loadBlockAnnotations(minutes = 180, maxEntries = 100) {
 
 // --- Block timer helpers ---
 function formatDuration(seconds) {
+    if (seconds < 0) {
+        seconds = 0;
+    }
     const m = Math.floor(seconds / 60);
     const s = seconds % 60;
     return `${m}m ${s.toString().padStart(2, '0')}s`;

--- a/tests/js/formatDuration.test.js
+++ b/tests/js/formatDuration.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const filePath = path.join(__dirname, '../../static/js/main.js');
+const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+const start = lines.findIndex(l => l.includes('function formatDuration('));
+let end = start;
+while (end < lines.length && !lines[end].startsWith('}')) {
+    end++;
+}
+const snippet = lines.slice(start, end + 1).join('\n');
+
+const context = {};
+vm.createContext(context);
+vm.runInContext(snippet, context);
+
+assert.strictEqual(context.formatDuration(-5), '0m 00s');
+console.log('formatDuration negative input test passed');


### PR DESCRIPTION
## Summary
- clamp negative values in `formatDuration`
- add tests for negative duration behavior

## Testing
- `make minify-js`
- `node tests/js/formatCurrency.test.js && node tests/js/formatDuration.test.js`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_683bdd32aed48320be9140b7aa920553