### PR TITLE
Add CSV export button

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ For more details, refer to the [docker-compose documentation](https://docs.docke
 - Detailed earnings breakdown by time period
 - Currency conversion for earnings in selected fiat
 - Historical data for earnings analysis
+- Download payment history as CSV
 
 ### Blocks Explorer
 

--- a/static/css/earnings.css
+++ b/static/css/earnings.css
@@ -64,6 +64,26 @@ html.deepsea-theme {
   z-index: 1;
 }
 
+.earnings-actions {
+  margin-bottom: 0.5rem;
+}
+
+.download-btn {
+  display: inline-block;
+  padding: 4px 8px;
+  font-family: var(--terminal-font);
+  font-size: 0.9rem;
+  color: var(--primary-color);
+  border: 1px solid var(--primary-color);
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.download-btn:hover {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+}
+
 .stats-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));

--- a/templates/earnings.html
+++ b/templates/earnings.html
@@ -101,6 +101,11 @@
     <!-- Payments History Section -->
     <div class="earnings-section">
         <h2>Payment History</h2>
+        <div class="earnings-actions">
+            <a href="/api/earnings?format=csv" class="download-btn" download>
+                <i class="fa-solid fa-download"></i> Download CSV
+            </a>
+        </div>
         <div class="table-container">
             <table class="earnings-table">
                 <thead>


### PR DESCRIPTION
## Summary
- add link for downloading CSV on the Earnings page
- style the new button
- document the feature in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c5c195670832096de0412f66bbe98