### PR TITLE
Add navigation keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Comprehensive guides have been moved to the `docs` directory:
 - [Configuration options](docs/CONFIGURATION.md)
 - [Worker naming guide](docs/WORKER-NAMING.md)
 - [Testing guide](docs/TESTING.md)
+- [Keyboard shortcuts](docs/KEYBOARD-SHORTCUTS.md)
 
 ### Customization
 

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -1,0 +1,16 @@
+# Keyboard Shortcuts
+
+The dashboard supports a few quick keyboard commands to speed up navigation and common actions.
+
+| Shortcut | Action |
+|---------|--------|
+| **Alt+1** | Go to the Dashboard |
+| **Alt+2** | Open the Workers page |
+| **Alt+3** | Open the Earnings page |
+| **Alt+4** | Open the Blocks page |
+| **Alt+5** | Open the Notifications page |
+| **Alt+W** | Reset wallet address and chart data |
+| **Shift+R** | Reset the Dashboard chart |
+| **Esc** | Close any open block modal |
+
+Use these shortcuts to move around the interface without taking your hands off the keyboard.

--- a/static/js/shortcuts.js
+++ b/static/js/shortcuts.js
@@ -1,0 +1,30 @@
+$(document).keydown(function (event) {
+    if (!event.altKey) {
+        return;
+    }
+
+    switch (event.keyCode) {
+        case 49: // Alt+1 -> Dashboard
+            window.location.href = '/dashboard';
+            event.preventDefault();
+            break;
+        case 50: // Alt+2 -> Workers
+            window.location.href = '/workers';
+            event.preventDefault();
+            break;
+        case 51: // Alt+3 -> Earnings
+            window.location.href = '/earnings';
+            event.preventDefault();
+            break;
+        case 52: // Alt+4 -> Blocks
+            window.location.href = '/blocks';
+            event.preventDefault();
+            break;
+        case 53: // Alt+5 -> Notifications
+            window.location.href = '/notifications';
+            event.preventDefault();
+            break;
+        default:
+            break;
+    }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -225,11 +225,11 @@
     
             <!-- Navigation links (horizontal on desktop, vertical on mobile) -->
             <div class="navigation-links" id="navLinks">
-                <a href="/dashboard" class="nav-link {% block dashboard_active %}{% endblock %}">DASHBOARD</a>
-                <a href="/workers" class="nav-link {% block workers_active %}{% endblock %}">WORKERS</a>
-                <a href="/earnings" class="nav-link {% block earnings_active %}{% endblock %}">EARNINGS</a>
-                <a href="/blocks" class="nav-link {% block blocks_active %}{% endblock %}">BLOCKS</a>
-                <a href="/notifications" class="nav-link {% block notifications_active %}{% endblock %}">
+                <a id="navDashboard" href="/dashboard" class="nav-link {% block dashboard_active %}{% endblock %}">DASHBOARD</a>
+                <a id="navWorkers" href="/workers" class="nav-link {% block workers_active %}{% endblock %}">WORKERS</a>
+                <a id="navEarnings" href="/earnings" class="nav-link {% block earnings_active %}{% endblock %}">EARNINGS</a>
+                <a id="navBlocks" href="/blocks" class="nav-link {% block blocks_active %}{% endblock %}">BLOCKS</a>
+                <a id="navNotifications" href="/notifications" class="nav-link {% block notifications_active %}{% endblock %}">
                     NOTIFICATIONS
                     <span id="nav-unread-badge" class="nav-badge"></span>
                 </a>
@@ -421,6 +421,7 @@
     });
     </script>
     <script src="{{ url_for('static', filename='js/audio.js') }}"></script>
+    <script src="/static/js/shortcuts.js"></script>
     <script src="/static/js/easterEgg.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary
- implement Alt+1..5 navigation shortcuts
- include new global shortcuts script
- link to new documentation for shortcuts
- update base template with IDs for navigation links

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683c5ed9146083208817e367aa3e9fc0