### PR TITLE
Add front-end tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,9 @@ jobs:
       run: ruff check .
     - name: Run tests
       run: pytest -q
+    - name: Run front-end tests
+      run: |
+        node tests/js/formatCurrency.test.js
+        node tests/js/formatDuration.test.js
+        node tests/js/main_dom_safety.test.js
+        node tests/js/normalizeHashrate.test.js


### PR DESCRIPTION
## Summary
- run Node-based front-end tests in CI workflow

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `for f in tests/js/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_683caeaec338832089df822511e1b44d