### PR TITLE
Fix CodeQL security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4

--- a/App.py
+++ b/App.py
@@ -1712,8 +1712,8 @@ def api_earnings():
             headers = {"Content-Disposition": "attachment; filename=earnings.csv"}
             return Response(csv_data, mimetype="text/csv", headers=headers)
         return jsonify(earnings_data)
-    except Exception as e:
-        logging.error(f"Error in earnings API endpoint: {e}")
+    except Exception:
+        logging.exception("Error in earnings API endpoint")
         return jsonify({"error": "internal server error"}), 500
 
 

--- a/static/js/earnings.js
+++ b/static/js/earnings.js
@@ -93,8 +93,13 @@ function formatCurrencyValues() {
 
         const value = parseFloat(valueText.replace(/[^\d.-]/g, ''));
         if (!isNaN(value)) {
-            // Keep the currency symbol and add commas to the number
-            cell.innerHTML = `<span class="currency-symbol">${symbol}</span>${formatCurrency(value.toFixed(2))}`;
+            // Keep the currency symbol and add commas to the number without using innerHTML
+            const span = document.createElement('span');
+            span.className = 'currency-symbol';
+            span.textContent = symbol;
+            cell.textContent = '';
+            cell.appendChild(span);
+            cell.append(formatCurrency(value.toFixed(2)));
         }
     });
 
@@ -175,7 +180,13 @@ function updateEarningsUI(data) {
     document.getElementById('total-paid-sats').textContent = formatSats(data.total_paid_sats);
     document.getElementById('total-paid-btc').textContent = formatBTC(data.total_paid_btc);
     if (data.total_paid_fiat !== undefined) {
-        document.getElementById('total-paid-fiat').innerHTML = `<span id="total-paid-currency-symbol">${currencySymbol}</span>${formatCurrency(parseFloat(data.total_paid_fiat).toFixed(2))}`;
+        const totalPaidFiat = document.getElementById('total-paid-fiat');
+        const span = document.createElement('span');
+        span.id = 'total-paid-currency-symbol';
+        span.textContent = currencySymbol;
+        totalPaidFiat.textContent = '';
+        totalPaidFiat.appendChild(span);
+        totalPaidFiat.append(formatCurrency(parseFloat(data.total_paid_fiat).toFixed(2)));
     }
     document.getElementById('payment-count').textContent = formatCurrency(data.total_payments);
     if (data.payments && data.payments.length > 0) {


### PR DESCRIPTION
## Summary
- sanitize currency DOM updates in `earnings.js`
- avoid leaking exception messages in `api_earnings`
- restrict GitHub workflow permissions

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_683d0ab99fb08320bfc54eb2a5e0d28f