### PR TITLE
Fix earnings API error leakage

### DIFF
--- a/App.py
+++ b/App.py
@@ -1705,6 +1705,9 @@ def api_earnings():
     try:
         # Get the earnings data with a reasonable timeout
         earnings_data = dashboard_service.get_earnings_data()
+        if isinstance(earnings_data, dict) and "error" in earnings_data:
+            logging.error("Earnings data error: %s", earnings_data["error"])
+            earnings_data = {k: v for k, v in earnings_data.items() if k != "error"}
         state_manager.save_last_earnings(earnings_data)
         fmt = request.args.get("format", "json").lower()
         if fmt == "csv":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -320,3 +320,19 @@ def test_earnings_csv_export(client, monkeypatch):
     assert resp.mimetype == "text/csv"
     text = resp.data.decode()
     assert "date,txid,lightning_txid,amount_btc,amount_sats,status" in text
+
+
+
+def test_earnings_sanitizes_error_field(client, monkeypatch):
+    import App
+
+    sample = {"payments": [], "error": "something went wrong"}
+    monkeypatch.setattr(App.dashboard_service, "get_earnings_data", lambda: sample)
+    monkeypatch.setattr(App.state_manager, "save_last_earnings", lambda e: True)
+
+    resp = client.get("/api/earnings")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "error" not in data
+    assert data["payments"] == []
+


### PR DESCRIPTION
## Summary
- sanitize earnings data before returning to clients to avoid leaking internal errors
- add test for error sanitization

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d0c9e3ec88320a442317e59c63dc0