### PR TITLE
Fix earnings error handling

### DIFF
--- a/App.py
+++ b/App.py
@@ -1705,9 +1705,12 @@ def api_earnings():
     try:
         # Get the earnings data with a reasonable timeout
         earnings_data = dashboard_service.get_earnings_data()
-        if isinstance(earnings_data, dict) and "error" in earnings_data:
-            logging.error("Earnings data error: %s", earnings_data["error"])
-            earnings_data = {k: v for k, v in earnings_data.items() if k != "error"}
+        if not isinstance(earnings_data, dict) or earnings_data.get("error"):
+            if isinstance(earnings_data, dict):
+                logging.error("Earnings data error: %s", earnings_data.get("error"))
+            else:
+                logging.error("Earnings data unavailable")
+            return jsonify({"error": "internal server error"}), 500
         state_manager.save_last_earnings(earnings_data)
         fmt = request.args.get("format", "json").lower()
         if fmt == "csv":

--- a/data_service.py
+++ b/data_service.py
@@ -992,15 +992,12 @@ class MiningDashboardService:
             return result
 
         except Exception as e:
-            logging.error(f"Error fetching earnings data: {e}")
-            import traceback
-
-            logging.error(traceback.format_exc())
+            logging.exception("Error fetching earnings data")
             return {
                 "payments": [],
                 "total_payments": 0,
                 "avg_days_between_payouts": None,
-                "error": str(e),
+                "error": "internal server error",
                 "timestamp": datetime.now(ZoneInfo(get_timezone())).isoformat(),
             }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -323,16 +323,15 @@ def test_earnings_csv_export(client, monkeypatch):
 
 
 
-def test_earnings_sanitizes_error_field(client, monkeypatch):
+def test_earnings_returns_generic_error(client, monkeypatch):
     import App
 
-    sample = {"payments": [], "error": "something went wrong"}
+    sample = {"payments": [], "error": "internal server error"}
     monkeypatch.setattr(App.dashboard_service, "get_earnings_data", lambda: sample)
     monkeypatch.setattr(App.state_manager, "save_last_earnings", lambda e: True)
 
     resp = client.get("/api/earnings")
-    assert resp.status_code == 200
+    assert resp.status_code == 500
     data = resp.get_json()
-    assert "error" not in data
-    assert data["payments"] == []
+    assert data["error"] == "internal server error"
 


### PR DESCRIPTION
## Summary
- log stack traces when earnings data fails
- return generic error from `get_earnings_data`
- ensure `/api/earnings` never exposes exception details
- adjust test for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d0e62e48c83208c512a4c6ae1a0b9