### PR TITLE
Fix static asset paths and offline caching

### DIFF
--- a/static/js/service-worker.js
+++ b/static/js/service-worker.js
@@ -19,6 +19,9 @@ const ASSETS_TO_CACHE = [
     '/static/js/batchFetch.js',
     '/static/js/audio.js',
     '/static/js/easterEgg.js',
+    '/static/vendor/jquery-3.7.0.min.js',
+    '/static/vendor/chart.min.js',
+    '/static/js/chartjs-plugin-annotation-lite.js',
     '/static/js/service-worker.js',
     'https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=VT323&display=swap',
     'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css'

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,20 +25,20 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Common CSS -->
-    <link rel="stylesheet" href="/static/css/common.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/common.css') }}">
 
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/static/css/theme-toggle.css">
-    <link rel="stylesheet" href="/static/css/easter-egg.css">
-    <link rel="stylesheet" href="/static/css/matrix.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/theme-toggle.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/easter-egg.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/matrix.css') }}">
 
     <!-- Theme JS (added to ensure consistent application of theme) -->
-    <script src="/static/js/theme.js"></script>
-    <script src="/static/js/matrixRain.js"></script>
+    <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/matrixRain.js') }}"></script>
 
     <!-- Logging wrapper -->
-    <script src="/static/js/logger.js"></script>
-    <script src="/static/js/batchFetch.js"></script>
+    <script src="{{ url_for('static', filename='js/logger.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/batchFetch.js') }}"></script>
 
     <!-- Page-specific CSS -->
     {% block css %}{% endblock %}
@@ -306,7 +306,7 @@
     {% block javascript %}{% endblock %}
 
     <!-- Bitcoin Progress Bar -->
-    <script src="/static/js/BitcoinProgressBar.js"></script>
+    <script src="{{ url_for('static', filename='js/BitcoinProgressBar.js') }}"></script>
 
     <!-- Mobile Navigation Script -->
     <script>
@@ -422,12 +422,12 @@
     });
     </script>
     <script src="{{ url_for('static', filename='js/audio.js') }}"></script>
-    <script src="/static/js/shortcuts.js"></script>
-    <script src="/static/js/easterEgg.js"></script>
+    <script src="{{ url_for('static', filename='js/shortcuts.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/easterEgg.js') }}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             if ('serviceWorker' in navigator) {
-                navigator.serviceWorker.register('/service-worker.js');
+                navigator.serviceWorker.register('{{ url_for('static', filename='js/service-worker.js') }}');
             }
         });
     </script>

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -5,8 +5,8 @@
 {% block title %}BLOCKS - BTC-OS Dashboard {% endblock %}
 
 {% block css %}
-<link rel="stylesheet" href="/static/css/blocks.css">
-<link rel="stylesheet" href="/static/css/theme-toggle.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/blocks.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/theme-toggle.css') }}">
 {% endblock %}
 
 {% block header %}BLOCKCHAIN MONITOR{% endblock %}
@@ -104,5 +104,5 @@
 {% endblock %}
 
 {% block javascript %}
-<script src="/static/js/blocks.js"></script>
+<script src="{{ url_for('static', filename='js/blocks.js') }}"></script>
 {% endblock %}

--- a/templates/boot.html
+++ b/templates/boot.html
@@ -14,12 +14,12 @@
     <link rel="apple-touch-icon" href="/static/favicon/apple-touch-icon.png">
     <link rel="manifest" href="/static/favicon/site.webmanifest">
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/static/css/boot.css">
-    <link rel="stylesheet" href="/static/css/theme-toggle.css">
-    <link rel="stylesheet" href="/static/css/matrix.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/boot.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/theme-toggle.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/matrix.css') }}">
     <!-- Add Theme JS -->
-    <script src="/static/js/theme.js"></script>
-    <script src="/static/js/matrixRain.js"></script>
+    <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/matrixRain.js') }}"></script>
     <script>
         (function () {
             if (localStorage.getItem('hasStartedBefore') !== 'true') {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,8 +6,8 @@
 {% block title %}BTC-OS Dashboard{% endblock %}
 
 {% block css %}
-<link rel="stylesheet" href="/static/css/dashboard.css">
-<link rel="stylesheet" href="/static/css/theme-toggle.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/theme-toggle.css') }}">
 {% endblock %}
 
 {% block dashboard_active %}active{% endblock %}
@@ -396,5 +396,5 @@
 
 {% block javascript %}
 <!-- External JavaScript file with our application logic -->
-<script src="/static/js/main.js"></script>
+<script src="{{ url_for('static', filename='js/main.js') }}"></script>
 {% endblock %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -7,9 +7,9 @@
     <!-- Include both Orbitron and VT323 fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=VT323&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="/static/css/error.css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/error.css') }}">
     <!-- Add theme.js script for theme awareness -->
-    <script src="/static/js/theme.js"></script>
+    <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
     <script>// Apply theme class on page load
     document.addEventListener('DOMContentLoaded', function() {
       // Check if DeepSea theme is active

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -5,8 +5,8 @@
 {% block title %}NOTIFICATIONS - BTC-OS Dashboard{% endblock %}
 
 {% block css %}
-<link rel="stylesheet" href="/static/css/notifications.css">
-<link rel="stylesheet" href="/static/css/theme-toggle.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/theme-toggle.css') }}">
 {% endblock %}
 
 {% block header %}NOTIFICATION CENTER{% endblock %}
@@ -93,5 +93,5 @@
 {% endblock %}
 
 {% block javascript %}
-<script src="/static/js/notifications.js"></script>
+<script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
 {% endblock %}

--- a/templates/workers.html
+++ b/templates/workers.html
@@ -5,8 +5,8 @@
 {% block title %}WORKERS - BTC-OS Dashboard{% endblock %}
 
 {% block css %}
-<link rel="stylesheet" href="/static/css/workers.css">
-<link rel="stylesheet" href="/static/css/theme-toggle.css">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/workers.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/theme-toggle.css') }}">
 {% endblock %}
 
 {% block header %}WORKERS OVERVIEW{% endblock %}
@@ -112,5 +112,5 @@
 {% endblock %}
 
 {% block javascript %}
-<script src="/static/js/workers.js"></script>
+<script src="{{ url_for('static', filename='js/workers.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- correct static asset links by using `url_for`
- cache vendor scripts in `service-worker.js` for offline use
- update service worker registration path
- regenerate minified assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_683d12a845988320b28c8b6beb147cb2