### PR TITLE
Show placeholder for power metrics until real data

### DIFF
--- a/App.py
+++ b/App.py
@@ -782,6 +782,8 @@ def dashboard():
                 "daily_power_cost": 0,
                 "daily_profit_usd": 0,
                 "monthly_profit_usd": 0,
+                "break_even_electricity_price": None,
+                "power_usage_estimated": True,
                 "daily_mined_sats": 0,
                 "monthly_mined_sats": 0,
                 "unpaid_earnings": "0",

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3535,7 +3535,9 @@ function updateUI() {
         }
 
         // Daily power cost with currency conversion
-        if (data.daily_power_cost != null) {
+        if (data.power_usage_estimated) {
+            updateElementText("daily_power_cost", "Calculating...");
+        } else if (data.daily_power_cost != null) {
             const dailyPowerCost = data.daily_power_cost;
             updateElementText("daily_power_cost", formatCurrencyValue(dailyPowerCost, currency));
         } else {
@@ -3544,9 +3546,12 @@ function updateUI() {
 
         // Break-even electricity price divider
         const bePrice = data.break_even_electricity_price;
-        const formattedBe = bePrice != null
-            ? formatCurrencyValue(bePrice, currency) + '/kWh'
-            : formatCurrencyValue(0, currency) + '/kWh';
+        let formattedBe;
+        if (data.power_usage_estimated || bePrice == null) {
+            formattedBe = 'Calculating...';
+        } else {
+            formattedBe = formatCurrencyValue(bePrice, currency) + '/kWh';
+        }
 
         const metricElPower = document.getElementById('daily_power_cost');
         if (!metricElPower) {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -358,10 +358,16 @@
                 <p>
                     <strong>Daily Power Cost:</strong>
                     <span id="daily_power_cost" class="metric-value red">
-                        {% if metrics and metrics.daily_power_cost is defined and metrics.daily_power_cost is not none %}
-                        ${{ "%.2f"|format(metrics.daily_power_cost) }}
+                        {% if metrics %}
+                            {% if metrics.power_usage_estimated %}
+                                Calculating...
+                            {% elif metrics.daily_power_cost is not none %}
+                                ${{ "%.2f"|format(metrics.daily_power_cost) }}
+                            {% else %}
+                                $0.00
+                            {% endif %}
                         {% else %}
-                        $0.00
+                            Calculating...
                         {% endif %}
                     </span>
                     <span id="indicator_daily_power_cost"></span>

--- a/tests/test_dashboard_defaults.py
+++ b/tests/test_dashboard_defaults.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+import types
+
+if "pytest" not in sys.modules:
+    pytest = types.ModuleType("pytest")
+
+    def fixture(func=None, **kwargs):
+        if func is None:
+            return lambda f: f
+        return func
+
+    pytest.fixture = fixture
+    sys.modules["pytest"] = pytest
+else:
+    import pytest
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import apscheduler.schedulers.background as bg
+
+    monkeypatch.setattr(bg.BackgroundScheduler, "start", lambda self: None)
+
+    App = importlib.reload(importlib.import_module("App"))
+
+    monkeypatch.setattr(App, "update_metrics_job", lambda force=False: None)
+    monkeypatch.setattr(App, "MiningDashboardService", lambda *a, **k: object())
+    monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
+
+    sample_cfg = {"wallet": "w"}
+    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+
+    App.cached_metrics = None
+    return App.app.test_client()
+
+
+def test_dashboard_placeholder(client):
+    resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    assert "Calculating..." in resp.data.decode()


### PR DESCRIPTION
## Summary
- display `Calculating...` for daily power cost while power usage is estimated
- output `Calculating...` for break-even price until metrics are real
- include `power_usage_estimated` in default metrics
- test that dashboard page shows the placeholder

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d1c9d98808320a5ce7e5deb5d4ed6