### PR TITLE
Fix placeholder stuck on calculating

### DIFF
--- a/App.py
+++ b/App.py
@@ -782,6 +782,8 @@ def dashboard():
                 "daily_power_cost": 0,
                 "daily_profit_usd": 0,
                 "monthly_profit_usd": 0,
+                "break_even_electricity_price": None,
+                "power_usage_estimated": True,
                 "daily_mined_sats": 0,
                 "monthly_mined_sats": 0,
                 "unpaid_earnings": "0",

--- a/data_service.py
+++ b/data_service.py
@@ -166,7 +166,11 @@ class MiningDashboardService:
                 estimated_power = self.estimate_total_power(metrics_for_estimate)
                 if estimated_power:
                     power_usage_for_calc = estimated_power
-                    power_usage_estimated = True
+                    # Consider it an estimate only if worker data was simulated
+                    if self.worker_service and getattr(self.worker_service, "last_fetch_was_real", False):
+                        power_usage_estimated = False
+                    else:
+                        power_usage_estimated = True
                     if power_cost_for_calc is None or power_cost_for_calc <= 0:
                         power_cost_for_calc = 0.07
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3535,7 +3535,9 @@ function updateUI() {
         }
 
         // Daily power cost with currency conversion
-        if (data.daily_power_cost != null) {
+        if (data.power_usage_estimated) {
+            updateElementText("daily_power_cost", "Calculating...");
+        } else if (data.daily_power_cost != null) {
             const dailyPowerCost = data.daily_power_cost;
             updateElementText("daily_power_cost", formatCurrencyValue(dailyPowerCost, currency));
         } else {
@@ -3544,9 +3546,12 @@ function updateUI() {
 
         // Break-even electricity price divider
         const bePrice = data.break_even_electricity_price;
-        const formattedBe = bePrice != null
-            ? formatCurrencyValue(bePrice, currency) + '/kWh'
-            : formatCurrencyValue(0, currency) + '/kWh';
+        let formattedBe;
+        if (data.power_usage_estimated || bePrice == null) {
+            formattedBe = 'Calculating...';
+        } else {
+            formattedBe = formatCurrencyValue(bePrice, currency) + '/kWh';
+        }
 
         const metricElPower = document.getElementById('daily_power_cost');
         if (!metricElPower) {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -358,10 +358,16 @@
                 <p>
                     <strong>Daily Power Cost:</strong>
                     <span id="daily_power_cost" class="metric-value red">
-                        {% if metrics and metrics.daily_power_cost is defined and metrics.daily_power_cost is not none %}
-                        ${{ "%.2f"|format(metrics.daily_power_cost) }}
+                        {% if metrics %}
+                            {% if metrics.power_usage_estimated %}
+                                Calculating...
+                            {% elif metrics.daily_power_cost is not none %}
+                                ${{ "%.2f"|format(metrics.daily_power_cost) }}
+                            {% else %}
+                                $0.00
+                            {% endif %}
                         {% else %}
-                        $0.00
+                            Calculating...
                         {% endif %}
                     </span>
                     <span id="indicator_daily_power_cost"></span>

--- a/tests/test_dashboard_defaults.py
+++ b/tests/test_dashboard_defaults.py
@@ -1,0 +1,42 @@
+import importlib
+import sys
+import types
+
+if "pytest" not in sys.modules:
+    pytest = types.ModuleType("pytest")
+
+    def fixture(func=None, **kwargs):
+        if func is None:
+            return lambda f: f
+        return func
+
+    pytest.fixture = fixture
+    sys.modules["pytest"] = pytest
+else:
+    import pytest
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import apscheduler.schedulers.background as bg
+
+    monkeypatch.setattr(bg.BackgroundScheduler, "start", lambda self: None)
+
+    App = importlib.reload(importlib.import_module("App"))
+
+    monkeypatch.setattr(App, "update_metrics_job", lambda force=False: None)
+    monkeypatch.setattr(App, "MiningDashboardService", lambda *a, **k: object())
+    monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
+
+    sample_cfg = {"wallet": "w"}
+    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+
+    App.cached_metrics = None
+    return App.app.test_client()
+
+
+def test_dashboard_placeholder(client):
+    resp = client.get("/dashboard")
+    assert resp.status_code == 200
+    assert "Calculating..." in resp.data.decode()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -483,6 +483,7 @@ def test_fetch_metrics_estimates_power(monkeypatch):
     class DummyWS:
         def __init__(self):
             self.last_cached_metrics = None
+            self.last_fetch_was_real = False
 
         def get_workers_data(self, cached_metrics, force_refresh=False):
             self.last_cached_metrics = cached_metrics
@@ -513,8 +514,43 @@ def test_fetch_metrics_estimates_power(monkeypatch):
     assert dummy.last_cached_metrics["hashrate_3hr"] == 100
 
 
+def test_fetch_metrics_real_worker_data(monkeypatch):
+    class DummyWS:
+        def __init__(self):
+            self.last_cached_metrics = None
+            self.last_fetch_was_real = True
+
+        def get_workers_data(self, cached_metrics, force_refresh=False):
+            self.last_cached_metrics = cached_metrics
+            return {"workers": [{"power_consumption": 1000}, {"power_consumption": 1500}]}
+
+    dummy = DummyWS()
+    svc = MiningDashboardService(0, 0, "w", worker_service=dummy)
+
+    monkeypatch.setattr("data_service.get_timezone", lambda: "UTC")
+    monkeypatch.setattr(
+        svc,
+        "get_ocean_data",
+        lambda: data_service.OceanData(
+            hashrate_3hr=100,
+            hashrate_3hr_unit="TH/s",
+            workers_hashing=2,
+            pool_fees_percentage=0.0,
+        ),
+    )
+    monkeypatch.setattr(svc, "get_bitcoin_stats", lambda: (0, 100e18, 50000, 0))
+
+    metrics = svc.fetch_metrics()
+
+    assert metrics["power_usage_estimated"] is False
+    assert dummy.last_cached_metrics["workers_hashing"] == 2
+
+
 def test_fetch_metrics_power_configured(monkeypatch):
     class DummyWS:
+        def __init__(self):
+            self.last_fetch_was_real = True
+
         def get_workers_data(self, cached_metrics, force_refresh=False):
             return {"workers": [{"power_consumption": 1000}]}
 


### PR DESCRIPTION
## Summary
- track whether worker metrics are real or simulated
- switch off the `Calculating...` placeholder when real metrics arrive
- extend service tests for the new flag

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d1c9d98808320a5ce7e5deb5d4ed6