### PR TITLE
Improve TTL cache cleanup

### DIFF
--- a/cache_utils.py
+++ b/cache_utils.py
@@ -21,6 +21,11 @@ def ttl_cache(ttl_seconds=60):
                 except Exception:
                     return str(value)
 
+        def _purge_expired(now):
+            expired = [k for k, (_, ts) in cache.items() if now - ts >= ttl_seconds]
+            for k in expired:
+                del cache[k]
+
         @wraps(func)
         def wrapper(*args, **kwargs):
             if args and hasattr(args[0], "__dict__"):
@@ -34,18 +39,25 @@ def ttl_cache(ttl_seconds=60):
             serialized_kwargs = tuple(sorted((k, _serialize(v)) for k, v in kwargs.items()))
             key = (key_prefix, serialized_args, serialized_kwargs)
             now = time.time()
+            _purge_expired(now)
             cached = cache.get(key)
             if cached and now - cached[1] < ttl_seconds:
                 return cached[0]
             result = func(*args, **kwargs)
             if result is not None:
+                now = time.time()
+                _purge_expired(now)
                 cache[key] = (result, now)
             return result
 
         def cache_clear():
             cache.clear()
 
+        def cache_size():
+            return len(cache)
+
         wrapper.cache_clear = cache_clear
+        wrapper.cache_size = cache_size
         return wrapper
 
     return decorator

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -50,3 +50,20 @@ def test_ttl_cache_unhashable(monkeypatch):
     fake_time[0] += 6
     assert add_dict(data) == 3
     assert call_count["count"] == 2
+
+
+def test_ttl_cache_cleanup(monkeypatch):
+    fake_time = [0]
+    monkeypatch.setattr(time, "time", lambda: fake_time[0])
+
+    @ttl_cache(ttl_seconds=1)
+    def identity(x):
+        return x
+
+    for i in range(10):
+        assert identity(i) == i
+        assert identity.cache_size() == 1
+        fake_time[0] += 2
+
+    identity(99)
+    assert identity.cache_size() == 1


### PR DESCRIPTION
## Summary
- expire entries whenever `ttl_cache` is accessed
- expose `cache_size` helper for inspecting cache state
- ensure TTL cache does not grow over time

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_683d919c94e88320919131a95d4da508