### PR TITLE
Add maxsize support to ttl_cache

### DIFF
--- a/cache_utils.py
+++ b/cache_utils.py
@@ -5,8 +5,14 @@ import time
 from functools import wraps
 
 
-def ttl_cache(ttl_seconds=60):
-    """Simple decorator providing a time based cache."""
+def ttl_cache(ttl_seconds=60, maxsize=None):
+    """Simple decorator providing a time-based cache.
+
+    Args:
+        ttl_seconds (int): How long to store each cached item.
+        maxsize (int, optional): Maximum number of entries to keep in the cache.
+
+    """
 
     def decorator(func):
         cache = {}
@@ -47,6 +53,9 @@ def ttl_cache(ttl_seconds=60):
             if result is not None:
                 now = time.time()
                 _purge_expired(now)
+                if maxsize is not None and len(cache) >= maxsize:
+                    oldest_key = min(cache.items(), key=lambda item: item[1][1])[0]
+                    del cache[oldest_key]
                 cache[key] = (result, now)
             return result
 

--- a/data_service.py
+++ b/data_service.py
@@ -650,7 +650,7 @@ class MiningDashboardService:
         except Exception as e:
             logging.error(f"Error dumping table structure: {e}")
 
-    @ttl_cache(ttl_seconds=30)
+    @ttl_cache(ttl_seconds=30, maxsize=20)
     def fetch_url(self, url: str, timeout: int = 5):
         """
         Fetch URL with error handling.
@@ -1184,7 +1184,7 @@ class MiningDashboardService:
 
         return difficulty, network_hashrate, btc_price, block_count
 
-    @ttl_cache(ttl_seconds=60)
+    @ttl_cache(ttl_seconds=60, maxsize=1)
     def get_all_worker_rows(self):
         """Collect worker row data from the stats pages."""
         all_rows = []

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -67,3 +67,23 @@ def test_ttl_cache_cleanup(monkeypatch):
 
     identity(99)
     assert identity.cache_size() == 1
+
+
+def test_ttl_cache_maxsize(monkeypatch):
+    fake_time = [0]
+    monkeypatch.setattr(time, "time", lambda: fake_time[0])
+
+    @ttl_cache(ttl_seconds=10, maxsize=2)
+    def identity(x):
+        return x
+
+    identity(1)
+    identity(2)
+    assert identity.cache_size() == 2
+
+    identity(3)
+    assert identity.cache_size() == 2
+    fake_time[0] += 1
+    # Oldest entry (1) should have been removed
+    assert identity(1) == 1
+    assert identity.cache_size() == 2


### PR DESCRIPTION
## Summary
- improve `ttl_cache` with optional `maxsize` parameter
- limit cached request responses in `data_service`
- test cache size limit behavior

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `ruff .`

------
https://chatgpt.com/codex/tasks/task_e_683dbe4121e08320aa9d470f2ec3f1ad