### PR TITLE
Adjust memory watchdog threshold

### DIFF
--- a/App.py
+++ b/App.py
@@ -37,7 +37,8 @@ MEMORY_CONFIG = {
     "MAX_METRICS_LOG_ENTRIES": 180,  # Maximum metrics log entries to keep
     "MAX_ARROW_HISTORY_ENTRIES": 180,  # Maximum arrow history entries per key
     "GC_INTERVAL_SECONDS": 3600,  # How often to force full GC (1 hour)
-    "MEMORY_HIGH_WATERMARK": 80.0,  # Memory percentage to trigger emergency cleanup
+    # Trigger emergency cleanup when memory usage exceeds this percentage
+    "MEMORY_HIGH_WATERMARK": 2.0,
     "ADAPTIVE_GC_ENABLED": True,  # Whether to use adaptive GC
     "MEMORY_MONITORING_INTERVAL": 300,  # How often to log memory usage (5 minutes)
     "MEMORY_HISTORY_MAX_ENTRIES": 72,  # Keep 6 hours of memory history at 5-min intervals

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ informed with minimal fuss.
 - **API Worker Fallback**: Uses the Ocean.xyz API for worker lists when HTML parsing fails
 - **Cross-Tab Synchronization**: Data consistency across multiple browser tabs
 - **Server Health Monitoring**: Built-in watchdog processes ensure reliability
+- **Memory Watchdog**: Triggers emergency cleanup when usage exceeds 2% of system RAM
 - **Error Handling**: Centralized error handlers return a user-friendly page (`error.html`) for unexpected issues.
 
 ### Distinctive Design Elements

--- a/tests/test_memory_watchdog.py
+++ b/tests/test_memory_watchdog.py
@@ -1,0 +1,44 @@
+import importlib
+import types
+
+import pytest
+
+
+def test_memory_watchdog_emergency(monkeypatch):
+    """Ensure memory watchdog performs emergency cleanup when usage exceeds the threshold."""
+    App = importlib.reload(importlib.import_module("App"))
+
+    monkeypatch.setitem(App.MEMORY_CONFIG, "MEMORY_HIGH_WATERMARK", 2)
+
+    class DummyProc:
+        def memory_percent(self):
+            return 3.0
+
+        def memory_info(self):
+            return types.SimpleNamespace(rss=1024 * 1024)
+
+    monkeypatch.setattr(App.psutil, "Process", lambda pid: DummyProc())
+    monkeypatch.setattr(App, "record_memory_metrics", lambda: None)
+    gc_called = {"flag": False}
+    monkeypatch.setattr(App.gc, "collect", lambda generation=2: gc_called.update(flag=True))
+    prune_called = {"flag": False}
+    monkeypatch.setattr(App.state_manager, "prune_old_data", lambda aggressive=True: prune_called.update(flag=True))
+
+    cleared = {"flag": False}
+    class DummyCache:
+        def clear(self):
+            cleared["flag"] = True
+    App.dashboard_service = types.SimpleNamespace(cache=DummyCache())
+
+    notified = {"flag": False}
+    def dummy_notify(*args, **kwargs):
+        notified["flag"] = True
+    monkeypatch.setattr(App.notification_service, "add_notification", dummy_notify)
+
+    App.memory_watchdog()
+
+    assert gc_called["flag"]
+    assert prune_called["flag"]
+    assert cleared["flag"]
+    assert notified["flag"]
+

--- a/tests/test_memory_watchdog.py
+++ b/tests/test_memory_watchdog.py
@@ -1,8 +1,6 @@
 import importlib
 import types
 
-import pytest
-
 
 def test_memory_watchdog_emergency(monkeypatch):
     """Ensure memory watchdog performs emergency cleanup when usage exceeds the threshold."""


### PR DESCRIPTION
## Summary
- lower MEMORY_HIGH_WATERMARK to 2%
- document new memory watchdog threshold in README
- test emergency cleanup path for memory_watchdog

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e49de4f008320a70e1cf8b2d955ba