### PR TITLE
Fix HTTP response leak in Bitcoin stats

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -1089,6 +1089,7 @@ class MiningDashboardService:
         btc_price = self.cache.get("btc_price")
         block_count = self.cache.get("block_count")
 
+        responses = {}
         try:
             # Add all API endpoints to futures using the shared executor
             futures = {}
@@ -1214,6 +1215,13 @@ class MiningDashboardService:
 
         except Exception as e:
             logging.error(f"Error fetching Bitcoin stats: {e}")
+        finally:
+            for resp in responses.values():
+                if resp is not None:
+                    try:
+                        resp.close()
+                    except Exception:
+                        pass
 
         return difficulty, network_hashrate, btc_price, block_count
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -78,6 +78,28 @@ def test_fetch_url_error(monkeypatch):
     assert svc.fetch_url("http://x") is None
 
 
+def test_get_bitcoin_stats_closes_responses(monkeypatch):
+    svc = MiningDashboardService(0, 0, "w")
+
+    created = []
+
+    def fake_get(url, timeout=5):
+        resp = MagicMock()
+        resp.ok = True
+        resp.text = "1"
+        resp.json.return_value = {}
+        resp.close = MagicMock()
+        created.append(resp)
+        return resp
+
+    monkeypatch.setattr(svc.session, "get", fake_get)
+
+    svc.get_bitcoin_stats()
+
+    assert created
+    assert all(r.close.called for r in created)
+
+
 def test_notification_update_currency(monkeypatch):
     class DummyState:
         def get_notifications(self):


### PR DESCRIPTION
## Summary
- close HTTP responses in `get_bitcoin_stats`
- add regression test to ensure responses are closed

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e8d4adf308320840285b6e1fe41b3