### PR TITLE
Fix in-place pruning of memory usage history

### DIFF
--- a/App.py
+++ b/App.py
@@ -294,9 +294,10 @@ def record_memory_metrics():
         with memory_usage_lock:
             memory_usage_history.append(entry)
 
-            # Prune old entries
-            if len(memory_usage_history) > MEMORY_CONFIG["MEMORY_HISTORY_MAX_ENTRIES"]:
-                memory_usage_history = memory_usage_history[-MEMORY_CONFIG["MEMORY_HISTORY_MAX_ENTRIES"] :]
+            # Prune old entries in-place to avoid leaking the previous list
+            max_entries = MEMORY_CONFIG["MEMORY_HISTORY_MAX_ENTRIES"]
+            if len(memory_usage_history) > max_entries:
+                del memory_usage_history[:-max_entries]
 
     except Exception as e:
         logging.error(f"Error recording memory metrics: {e}")

--- a/tests/test_memory_usage_history.py
+++ b/tests/test_memory_usage_history.py
@@ -1,0 +1,25 @@
+import importlib
+import types
+
+
+def test_record_memory_metrics_prunes_in_place(monkeypatch):
+    App = importlib.reload(importlib.import_module("App"))
+    history = App.memory_usage_history
+    monkeypatch.setitem(App.MEMORY_CONFIG, "MEMORY_HISTORY_MAX_ENTRIES", 3)
+
+    class DummyProc:
+        def memory_info(self):
+            return types.SimpleNamespace(rss=1, vms=1)
+
+        def memory_percent(self):
+            return 1.0
+
+    monkeypatch.setattr(App.psutil, "Process", lambda pid: DummyProc())
+    monkeypatch.setattr(App, "get_timezone", lambda: "UTC")
+    App.active_sse_connections = 0
+
+    for _ in range(5):
+        App.record_memory_metrics()
+
+    assert len(App.memory_usage_history) == 3
+    assert App.memory_usage_history is history


### PR DESCRIPTION
## Summary
- prevent memory leak when pruning memory usage history by modifying list in-place
- add regression test for memory history pruning

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_683ef67f67c88320ad844a6f70c23f50