### PR TITLE
Fix payment history API cleanup

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -781,6 +781,7 @@ class MiningDashboardService:
 
         url = f"{api_base}/earnpay/{self.wallet}/{start_str}/{end_str}"
         payments = []
+        resp = None
 
         try:
             resp = self.session.get(url, timeout=10)
@@ -850,6 +851,8 @@ class MiningDashboardService:
             "Cache-Control": "no-cache",
         }
         payments = []
+        resp = None
+        soup = None
         try:
             page = 0
             while True:
@@ -923,7 +926,8 @@ class MiningDashboardService:
 
                     page += 1
                 finally:
-                    soup.decompose()
+                    if soup:
+                        soup.decompose()
                     if resp:
                         try:
                             resp.close()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -372,6 +372,21 @@ def test_get_payment_history_scrape_closes_on_error(monkeypatch):
     assert dummy_resp.closed
 
 
+def test_get_payment_history_api_handles_request_error(monkeypatch):
+    """Ensure API errors do not raise due to uninitialized variables."""
+    svc = MiningDashboardService(0, 0, "w")
+
+    class DummySession:
+        def get(self, url, timeout=10):
+            raise ValueError("fail")
+
+    svc.session = DummySession()
+
+    monkeypatch.setattr("data_service.get_timezone", lambda: "UTC")
+
+    assert svc.get_payment_history_api() is None
+
+
 def test_get_earnings_data_fallback_to_scrape(monkeypatch):
     svc = MiningDashboardService(0, 0, "w")
 


### PR DESCRIPTION
## Summary
- prevent unbound `resp`/`soup` in payment history helpers
- test handling of request errors in `get_payment_history_api`

## Testing
- `PYTHONPATH=$PWD pytest tests/test_services.py::test_get_payment_history_api_handles_request_error -q`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f05e08fa88320a36d2350ae8aca6f