### PR TITLE
Fix resource cleanup to avoid memory leaks

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -93,6 +93,10 @@ class MiningDashboardService:
         except Exception as e:
             logging.error(f"Error closing session: {e}")
 
+    def __del__(self):
+        """Ensure resources are released when the service is garbage collected."""
+        self.close()
+
     def fetch_metrics(self):
         """
         Fetch metrics from Ocean.xyz and other sources.

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -672,3 +672,19 @@ def test_server_start_time_constant(monkeypatch):
     metrics2 = svc.fetch_metrics()
 
     assert metrics1["server_start_time"] == metrics2["server_start_time"]
+
+
+def test_service_del_calls_close(monkeypatch):
+    """Ensure __del__ calls close to avoid lingering threads."""
+    svc = MiningDashboardService(0, 0, "w")
+
+    called = {"flag": False}
+
+    def fake_close():
+        called["flag"] = True
+
+    monkeypatch.setattr(svc, "close", fake_close)
+
+    svc.__del__()
+
+    assert called["flag"]


### PR DESCRIPTION
## Summary
- ensure `MiningDashboardService` releases resources when garbage collected
- test that `__del__` calls `close`

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f07feabec8320ac2a08610fe0d08f