### PR TITLE
Fix ThreadPoolExecutor shutdown handling

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -89,7 +89,8 @@ class MiningDashboardService:
         """Close any open network resources."""
         try:
             self.session.close()
-            self.executor.shutdown(wait=False)
+            # Wait for any running executor tasks to finish so resources are released
+            self.executor.shutdown(wait=True)
         except Exception as e:
             logging.error(f"Error closing session: {e}")
 

--- a/tests/test_executor_shutdown.py
+++ b/tests/test_executor_shutdown.py
@@ -1,0 +1,17 @@
+def test_service_close_waits_for_executor(monkeypatch):
+    """MiningDashboardService.close should wait for executor threads to finish."""
+    from data_service import MiningDashboardService
+
+    svc = MiningDashboardService(0, 0, "wallet")
+
+    called = {}
+
+    def fake_shutdown(wait=True):
+        called["wait"] = wait
+
+    monkeypatch.setattr(svc.executor, "shutdown", fake_shutdown)
+    monkeypatch.setattr(svc.session, "close", lambda: None, raising=False)
+    svc.close()
+
+    assert called.get("wait") is True
+


### PR DESCRIPTION
## Summary
- wait for executor threads to finish when closing `MiningDashboardService`
- add regression test ensuring shutdown waits

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f818561d883208e42fe8943d1a37c