### PR TITLE
Fix response leak in worker row fetch

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -1290,7 +1290,13 @@ class MiningDashboardService:
             logging.info(f"Fetching worker data from: {url} (page {page_num+1} of max {max_pages})")
             response = self.session.get(url, timeout=15)
             if not response.ok:
-                logging.error(f"Error fetching page {page_num}: status code {response.status_code}")
+                logging.error(
+                    f"Error fetching page {page_num}: status code {response.status_code}"
+                )
+                try:
+                    response.close()
+                except Exception:
+                    pass
                 break
 
             soup = BeautifulSoup(response.text, "html.parser")


### PR DESCRIPTION
## Summary
- close HTTP response when worker row fetch fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7ed7c47483208fc3d850bd6aa755