### PR TITLE
Fix scheduler shutdown memory leak

### DIFF
--- a/App.py
+++ b/App.py
@@ -564,7 +564,7 @@ def create_scheduler():
                 # Check if scheduler is running before attempting to shut it down
                 if hasattr(scheduler, "running") and scheduler.running:
                     logging.info("Shutting down existing scheduler before creating a new one")
-                    scheduler.shutdown(wait=False)
+                    scheduler.shutdown(wait=True)
             except Exception as e:
                 logging.error(f"Error shutting down existing scheduler: {e}")
 

--- a/tests/test_scheduler_restart.py
+++ b/tests/test_scheduler_restart.py
@@ -1,0 +1,27 @@
+import importlib
+
+
+def test_create_scheduler_waits(monkeypatch):
+    App = importlib.reload(importlib.import_module("App"))
+
+    class DummyScheduler:
+        def __init__(self):
+            self.running = True
+            self.shutdown_called = None
+        def shutdown(self, wait=False):
+            self.shutdown_called = wait
+        def add_job(self, *a, **k):
+            pass
+        def start(self):
+            pass
+        def get_jobs(self):
+            return []
+
+    existing = DummyScheduler()
+    App.scheduler = existing
+    monkeypatch.setattr(App, "BackgroundScheduler", lambda job_defaults=None: DummyScheduler())
+
+    new_sched = App.create_scheduler()
+
+    assert existing.shutdown_called is True
+    assert isinstance(new_sched, DummyScheduler)


### PR DESCRIPTION
## Summary
- shutdown existing scheduler threads when recreating scheduler to avoid thread leak
- test that `create_scheduler` waits for shutdown before starting a new scheduler

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f8bda02988320b98ebe569eff1ef8