### PR TITLE
Fix resource leak in graceful shutdown

### DIFF
--- a/App.py
+++ b/App.py
@@ -1800,6 +1800,13 @@ def graceful_shutdown(signum, frame):
         except Exception as e:
             logging.error(f"Error closing dashboard service: {e}")
 
+    # Close all logging handlers to avoid file descriptor leaks
+    for handler in logging.getLogger().handlers:
+        try:
+            handler.close()
+        except Exception as e:
+            logging.error(f"Error closing log handler: {e}")
+
     # Log connection info before exit
     logging.info(f"Active SSE connections at shutdown: {active_sse_connections}")
 

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,30 @@
+import importlib
+import logging
+import signal
+
+
+def test_graceful_shutdown_closes_handlers(monkeypatch):
+    App = importlib.reload(importlib.import_module("App"))
+
+    closed = []
+
+    class DummyHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+        def close(self):
+            closed.append(True)
+
+    handler = DummyHandler()
+    logging.getLogger().addHandler(handler)
+
+    monkeypatch.setattr(App, "scheduler", None)
+    monkeypatch.setattr(App, "dashboard_service", None)
+    monkeypatch.setattr(App.state_manager, "save_graph_state", lambda: None)
+    monkeypatch.setattr(App.sys, "exit", lambda code=0: None)
+
+    App.graceful_shutdown(signal.SIGTERM, None)
+
+    logging.getLogger().removeHandler(handler)
+
+    assert closed


### PR DESCRIPTION
## Summary
- prevent file descriptor leak by closing logging handlers during graceful shutdown
- test graceful_shutdown ensures handlers are closed

## Testing
- `ruff .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb5ea7c208320ab9272d0be46b78a