### PR TITLE
Fix numeric parsing for prefixed strings

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -586,10 +586,10 @@ class NotificationService:
             return float(value_str)
 
         if isinstance(value_str, str):
-            # Remove commas and extract leading numeric portion to handle
-            # values like "1,234.5TH/s" without a space before the unit.
+            # Remove commas and search for the first numeric portion to handle
+            # values like "Hashrate: 1,234.5TH/s" or "1,234.5TH/s".
             cleaned = value_str.replace(",", "").strip()
-            match = re.match(r"[-+]?\d*\.?\d+", cleaned)
+            match = re.search(r"[-+]?\d*\.?\d+", cleaned)
             if match:
                 try:
                     return float(match.group(0))

--- a/tests/test_parse_numeric_value.py
+++ b/tests/test_parse_numeric_value.py
@@ -62,3 +62,9 @@ def test_parse_numeric_value_with_commas():
 def test_parse_numeric_value_without_space():
     svc = NotificationService(DummyState())
     assert svc._parse_numeric_value("1,234.56TH/s") == pytest.approx(1234.56)
+
+
+def test_parse_numeric_value_with_prefix_text():
+    """Numbers appearing after text should still be parsed correctly."""
+    svc = NotificationService(DummyState())
+    assert svc._parse_numeric_value("Hashrate: 1,234.5 TH/s") == pytest.approx(1234.5)


### PR DESCRIPTION
## Summary
- handle numeric strings with prefix text when parsing notification values
- add regression test for prefix text parsing

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb5dd6d588320bc0237c3502a0223