### PR TITLE
Fix numeric parser handling of spaced negative sign

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -588,7 +588,9 @@ class NotificationService:
         if isinstance(value_str, str):
             # Remove commas and search for the first numeric portion to handle
             # values like "Hashrate: 1,234.5TH/s" or "1,234.5TH/s".
-            cleaned = value_str.replace(",", "").strip()
+            cleaned = value_str.replace(",", "")
+            # Remove spaces between a sign and the digits (e.g. "- 1.2" -> "-1.2")
+            cleaned = re.sub(r"([+-])\s+(?=\d)", r"\1", cleaned).strip()
             match = re.search(r"[-+]?\d*\.?\d+", cleaned)
             if match:
                 try:

--- a/tests/test_parse_numeric_value.py
+++ b/tests/test_parse_numeric_value.py
@@ -68,3 +68,9 @@ def test_parse_numeric_value_with_prefix_text():
     """Numbers appearing after text should still be parsed correctly."""
     svc = NotificationService(DummyState())
     assert svc._parse_numeric_value("Hashrate: 1,234.5 TH/s") == pytest.approx(1234.5)
+
+
+def test_parse_numeric_value_with_sign_and_space():
+    """Negative values with spaces after the sign should parse correctly."""
+    svc = NotificationService(DummyState())
+    assert svc._parse_numeric_value("- 2,000.5 TH/s") == pytest.approx(-2000.5)


### PR DESCRIPTION
## Summary
- support spaces after the sign when parsing numeric values
- add regression test for spaced sign parsing

## Testing
- `ruff notification_service.py`
- `ruff tests/test_parse_numeric_value.py`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fba8864e88320bd969060ccb71bb1