### PR TITLE
Fix mobile nav toggle key support

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -332,12 +332,12 @@
                 navToggle.style.color = '#f2a900';
             }
         
-            // Toggle menu open/closed when hamburger is clicked
-            navToggle.addEventListener('click', function() {
+            // Toggle menu open/closed when hamburger is clicked or activated via keyboard
+            function toggleMenu() {
                 navLinks.classList.toggle('is-open');
                 const isOpen = navLinks.classList.contains('is-open');
                 navToggle.setAttribute('aria-expanded', isOpen);
-            
+
                 // Change icon based on state
                 const icon = navToggle.querySelector('i');
                 if (icon) {
@@ -348,6 +348,14 @@
                         icon.classList.remove('fa-times');
                         icon.classList.add('fa-bars');
                     }
+                }
+            }
+
+            navToggle.addEventListener('click', toggleMenu);
+            navToggle.addEventListener('keydown', function(event) {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    toggleMenu();
                 }
             });
         


### PR DESCRIPTION
## Summary
- make mobile nav toggle accessible via keyboard
- rebuild minified assets

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `node tests/js/formatCurrency.test.js`
- `node tests/js/formatDuration.test.js`
- `node tests/js/main_dom_safety.test.js`
- `node tests/js/normalizeHashrate.test.js`
- `node tests/js/arrowIndicator.test.js`
- `node tests/js/audioCrossfadeTheme.test.js`
- `node tests/js/blockProbability.test.js`
- `node tests/js/notificationsTimestamp.test.js`
- `node tests/js/workerUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_683fbbaff9a88320a2f47705f94fcb74