### PR TITLE
Fix cache_size to ignore expired entries

### DIFF
--- a/cache_utils.py
+++ b/cache_utils.py
@@ -68,6 +68,8 @@ def ttl_cache(ttl_seconds=60, maxsize=None):
                 cache.clear()
 
         def cache_size():
+            now = time.time()
+            _purge_expired(now)
             with lock:
                 return len(cache)
 


### PR DESCRIPTION
## Summary
- ensure `ttl_cache.cache_size` purges expired entries before reporting size

## Testing
- `ruff cache_utils.py`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbde1b4c88320874b3b9179bfe795