### PR TITLE
Fix timer cleanup to avoid thread leaks

### DIFF
--- a/App.py
+++ b/App.py
@@ -525,6 +525,11 @@ def update_metrics_job(force=False):
         finally:
             # Cancel timer in finally block to ensure it's always canceled
             timer.cancel()
+            if timer.is_alive():
+                try:
+                    timer.join()
+                except Exception:
+                    pass
     except Exception as e:
         logging.error(f"Background job: Unhandled exception: {e}")
         import traceback

--- a/tests/test_timer_cleanup.py
+++ b/tests/test_timer_cleanup.py
@@ -1,0 +1,38 @@
+import importlib
+
+
+def test_update_metrics_job_joins_timer(monkeypatch):
+    App = importlib.reload(importlib.import_module("App"))
+
+    events = {"cancel": False, "join": False}
+
+    class DummyTimer:
+        def __init__(self, timeout, handler):
+            self.timeout = timeout
+            self.handler = handler
+        def start(self):
+            pass
+        def cancel(self):
+            events["cancel"] = True
+        def is_alive(self):
+            return True
+        def join(self):
+            events["join"] = True
+
+    monkeypatch.setattr(App.threading, "Timer", DummyTimer)
+    monkeypatch.setattr(App.dashboard_service, "fetch_metrics", lambda: {"server_timestamp": 1})
+    monkeypatch.setattr(App.notification_service, "check_and_generate_notifications", lambda *a, **k: None)
+    monkeypatch.setattr(App.state_manager, "update_metrics_history", lambda metrics: None)
+    monkeypatch.setattr(App.state_manager, "persist_critical_state", lambda *a, **k: None)
+    monkeypatch.setattr(App.state_manager, "prune_old_data", lambda *a, **k: None)
+    monkeypatch.setattr(App.state_manager, "save_graph_state", lambda: None)
+    monkeypatch.setattr(App, "adaptive_gc", lambda: False)
+    monkeypatch.setattr(App, "log_memory_usage", lambda: None)
+    monkeypatch.setattr(App.notification_service, "add_notification", lambda *a, **k: None)
+    monkeypatch.setattr(App, "load_config", lambda: {})
+    monkeypatch.setitem(App.MEMORY_CONFIG, "ADAPTIVE_GC_ENABLED", False)
+
+    App.update_metrics_job(force=True)
+
+    assert events["cancel"]
+    assert events["join"]


### PR DESCRIPTION
## Summary
- clean up timer threads by joining after cancellation
- add regression test ensuring timers are joined

## Testing
- `ruff tests/test_timer_cleanup.py`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbdea71c083208b35f96493721252