### PR TITLE
Fix scheduler cleanup wait

### DIFF
--- a/App.py
+++ b/App.py
@@ -1777,7 +1777,8 @@ if last_update:
 # Initialize the scheduler, shutting down any previous instance first
 if _previous_scheduler:
     try:
-        _previous_scheduler.shutdown(wait=False)
+        # Wait for any running jobs to finish to prevent thread leaks
+        _previous_scheduler.shutdown(wait=True)
     except Exception as e:
         logging.error(f"Error shutting down previous scheduler: {e}")
 

--- a/tests/test_scheduler_restart.py
+++ b/tests/test_scheduler_restart.py
@@ -33,10 +33,10 @@ def test_reload_shuts_down_scheduler(monkeypatch):
     class DummyScheduler:
         def __init__(self):
             self.running = True
-            self.shutdown_called = False
+            self.shutdown_wait = None
 
         def shutdown(self, wait=False):
-            self.shutdown_called = True
+            self.shutdown_wait = wait
 
         def add_job(self, *a, **k):
             pass
@@ -57,5 +57,5 @@ def test_reload_shuts_down_scheduler(monkeypatch):
 
     App = importlib.reload(App)
 
-    assert old_sched.shutdown_called
+    assert old_sched.shutdown_wait is True
     assert isinstance(App.scheduler, DummyScheduler)


### PR DESCRIPTION
## Summary
- avoid leaking threads when reloading scheduler by waiting for shutdown
- check that scheduler reload waits for shutdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc0f2b95c8320b92dd14c194eb249