### PR TITLE
Clarify and fix low hashrate thresholds

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,7 +16,7 @@ The default configuration file contains the following keys:
 | `timezone` | Local timezone identifier | `"America/Los_Angeles"` |
 | `network_fee` | Additional fees beyond pool fees | `0.0` |
 | `currency` | Preferred fiat currency for earnings display | `"USD"` |
-| `low_hashrate_threshold_ths` | Threshold below which the miner is considered in low hashrate mode (TH/s) | `3.0` |
+| `low_hashrate_threshold_ths` | Threshold used by the notification service to determine low hashrate mode (TH/s). Does **not** affect the front-end chart. | `3.0` |
 | `high_hashrate_threshold_ths` | Threshold above which normal hashrate mode resumes (TH/s) | `20.0` |
 
 Configuration files are validated when loaded. Missing keys or incorrect types

--- a/docs/LOW-HASHRATE-MODE.md
+++ b/docs/LOW-HASHRATE-MODE.md
@@ -10,4 +10,4 @@ The notification service uses a simpler rule. When the 3‑hour average is under
 
 ## Configuration
 
-Low hashrate mode does not currently expose any settings in `config.json`. The thresholds are hard coded. If future versions add configurable keys they will be documented here.
+Low hashrate mode does not currently expose any settings in `config.json`. The thresholds are hard coded at **0.01&nbsp;TH/s** for entry and **20&nbsp;TH/s** for exit. The configuration key `low_hashrate_threshold_ths` only influences the notification service and does not change the chart behavior. If future versions add configurable keys they will be documented here.

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2231,8 +2231,11 @@ function updateChartWithNormalizedData(chart, data) {
         // Get values with enhanced stability
         let useHashrate3hr = false;
         const currentTime = Date.now();
-        const LOW_HASHRATE_THRESHOLD = window.lowHashrateThresholdTHS || 0.01; // TH/s
-        const HIGH_HASHRATE_THRESHOLD = window.highHashrateThresholdTHS || 20.0; // TH/s
+        // Front-end low hashrate mode uses fixed thresholds independent of
+        // configuration to avoid accidental interference with notification
+        // settings.
+        const LOW_HASHRATE_THRESHOLD = 0.01; // TH/s
+        const HIGH_HASHRATE_THRESHOLD = 20.0; // TH/s
         const MODE_SWITCH_DELAY = 120000;     // Increase to 2 minutes for more stability
         const CONSECUTIVE_SPIKES_THRESHOLD = 3; // Increase to require more consistent high readings
         const MIN_MODE_STABILITY_TIME = 120000; // 2 minutes minimum between mode switches


### PR DESCRIPTION
## Summary
- keep low hashrate chart mode thresholds constant in JS
- clarify config docs around notification thresholds
- explain fixed thresholds in low-hashrate docs

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840808c6f288320b08d44f0bec6aedc