### PR TITLE
Fix worker service when worker count is string

### DIFF
--- a/tests/test_worker_service.py
+++ b/tests/test_worker_service.py
@@ -66,6 +66,23 @@ def test_generate_fallback_data_counts(monkeypatch):
     assert data["daily_sats"] == 500
 
 
+def test_generate_fallback_data_workers_hashing_str(monkeypatch):
+    """String values for workers_hashing should be handled gracefully."""
+    monkeypatch.setattr("worker_service.get_timezone", lambda: "UTC")
+    svc = WorkerService()
+    metrics = {
+        "workers_hashing": "2",
+        "hashrate_3hr": 60,
+        "hashrate_3hr_unit": "TH/s",
+        "unpaid_earnings": 0.1,
+        "daily_mined_sats": 500,
+    }
+    data = svc.generate_fallback_data(metrics)
+    assert data["workers_total"] == 2
+    assert data["workers_online"] == 1
+    assert data["workers_offline"] == 1
+
+
 def test_generate_fallback_data_earnings_distribution(monkeypatch):
     monkeypatch.setattr("worker_service.get_timezone", lambda: "UTC")
     svc = WorkerService()

--- a/worker_service.py
+++ b/worker_service.py
@@ -391,11 +391,15 @@ class WorkerService:
         # Check if we have workers_hashing information
         workers_count = cached_metrics.get("workers_hashing")
 
-        # Handle None value for workers_count
+        # Normalize workers_count to an integer
+        try:
+            workers_count = int(float(workers_count))
+        except (TypeError, ValueError):
+            workers_count = None
+
         if workers_count is None:
             logging.warning("No workers_hashing value in cached metrics, defaulting to 1 worker")
             workers_count = 1
-        # Force at least 1 worker if the count is 0
         elif workers_count <= 0:
             logging.warning("No workers reported in metrics, forcing 1 worker")
             workers_count = 1


### PR DESCRIPTION
## Summary
- convert workers_hashing to int safely
- test string `workers_hashing` handling in `generate_fallback_data`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68409a952c948320bd5d79d657bc0384