### PR TITLE
Fix response leak when scraping worker pages

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -1329,41 +1329,47 @@ class MiningDashboardService:
 
         while page_num < max_pages:  # Only fetch up to max_pages
             url = f"https://ocean.xyz/stats/{self.wallet}?wpage={page_num}#workers-fulltable"
-            logging.info(f"Fetching worker data from: {url} (page {page_num+1} of max {max_pages})")
-            response = self.session.get(url, timeout=15)
-            if not response.ok:
-                logging.error(
-                    f"Error fetching page {page_num}: status code {response.status_code}"
-                )
-                try:
-                    response.close()
-                except Exception:
-                    pass
-                break
-
-            soup = BeautifulSoup(response.text, "html.parser")
+            logging.info(
+                f"Fetching worker data from: {url} (page {page_num+1} of max {max_pages})"
+            )
+            response = None
             try:
-                workers_table = soup.find("tbody", id="workers-tablerows")
-                if not workers_table:
-                    logging.debug(f"No workers table found on page {page_num}")
+                response = self.session.get(url, timeout=15)
+                if not response.ok:
+                    logging.error(
+                        f"Error fetching page {page_num}: status code {response.status_code}"
+                    )
                     break
 
-                rows = workers_table.find_all("tr", class_="table-row")
-                if not rows:
-                    logging.debug(f"No worker rows found on page {page_num}, stopping pagination")
-                    break
+                soup = BeautifulSoup(response.text, "html.parser")
+                try:
+                    workers_table = soup.find("tbody", id="workers-tablerows")
+                    if not workers_table:
+                        logging.debug(f"No workers table found on page {page_num}")
+                        break
 
-                logging.info(f"Found {len(rows)} worker rows on page {page_num}")
-                for row in rows:
-                    row_dict = {
-                        "text": row.get_text(separator=" ", strip=True),
-                        "cells": [c.get_text(strip=True) for c in row.find_all(["td", "th"])],
-                        "attrs": dict(row.attrs),
-                    }
-                    all_rows.append(row_dict)
-                page_num += 1
+                    rows = workers_table.find_all("tr", class_="table-row")
+                    if not rows:
+                        logging.debug(
+                            f"No worker rows found on page {page_num}, stopping pagination"
+                        )
+                        break
+
+                    logging.info(f"Found {len(rows)} worker rows on page {page_num}")
+                    for row in rows:
+                        row_dict = {
+                            "text": row.get_text(separator=" ", strip=True),
+                            "cells": [c.get_text(strip=True) for c in row.find_all(["td", "th"])],
+                            "attrs": dict(row.attrs),
+                        }
+                        all_rows.append(row_dict)
+                    page_num += 1
+                finally:
+                    soup.decompose()
+            except Exception as e:
+                logging.error(f"Error fetching worker page {page_num}: {e}")
+                break
             finally:
-                soup.decompose()
                 if response:
                     try:
                         response.close()

--- a/tests/test_worker_scrape_new.py
+++ b/tests/test_worker_scrape_new.py
@@ -1,0 +1,26 @@
+from data_service import MiningDashboardService
+import data_service
+
+
+def make_service():
+    return MiningDashboardService(0, 0, "w")
+
+
+def test_get_all_worker_rows_closes_on_exception(monkeypatch):
+    svc = make_service()
+
+    class DummyResp:
+        ok = True
+        text = "<html></html>"
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    dummy_resp = DummyResp()
+    monkeypatch.setattr(svc.session, "get", lambda url, timeout=15: dummy_resp)
+    monkeypatch.setattr(data_service, "BeautifulSoup", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    rows = svc.get_all_worker_rows()
+    assert rows == []
+    assert dummy_resp.closed


### PR DESCRIPTION
## Summary
- ensure `get_all_worker_rows` always closes HTTP responses
- add regression test to verify response cleanup

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409a9f421883209d67877c495fec18