### PR TITLE
Fix metrics log memory growth

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -597,7 +597,12 @@ class StateManager:
             metrics["arrow_history"] = aggregated_history
             metrics["history"] = self.hashrate_history
 
-            entry = {"timestamp": datetime.now().isoformat(), "metrics": metrics}
+            # Store a lightweight snapshot in metrics_log to avoid memory growth
+            snapshot = metrics.copy()
+            snapshot.pop("arrow_history", None)
+            snapshot.pop("history", None)
+
+            entry = {"timestamp": datetime.now().isoformat(), "metrics": snapshot}
             self.metrics_log.append(entry)
 
     def save_notifications(self, notifications):

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -225,3 +225,16 @@ def test_prune_old_data():
 
     assert len(mgr.arrow_history["hashrate_60sec"]) <= MAX_HISTORY_ENTRIES
     assert len(mgr.metrics_log) <= MAX_HISTORY_ENTRIES
+
+
+def test_metrics_log_snapshot_omits_history(monkeypatch):
+    """metrics_log should not store arrow_history or history fields."""
+    mgr = StateManager()
+    monkeypatch.setattr("state_manager.get_timezone", lambda: "UTC")
+
+    metrics = {"hashrate_60sec": 1}
+    mgr.update_metrics_history(metrics)
+
+    latest = mgr.metrics_log[-1]["metrics"]
+    assert "arrow_history" not in latest
+    assert "history" not in latest


### PR DESCRIPTION
## Summary
- avoid storing full `arrow_history` in metrics log
- test that metrics log snapshot omits history

## Testing
- `PYTHONPATH=$PWD pytest tests/test_state_manager.py::test_metrics_log_snapshot_omits_history -q`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410e1b41c483208c112ae51d8f1533