### PR TITLE
Fix hashrate history memory leak

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -49,7 +49,7 @@ class StateManager:
 
         # Initialize in-memory structures for historical data
         self.arrow_history = {}  # Stored per second
-        self.hashrate_history = []
+        self.hashrate_history = deque(maxlen=MAX_HISTORY_ENTRIES)
         self.metrics_log = deque(maxlen=MAX_HISTORY_ENTRIES)
         self.payout_history = []
         # Maintain short-term history for 3hr variance calculations
@@ -153,7 +153,9 @@ class StateManager:
                         )
 
                     # Restore hashrate_history
-                    self.hashrate_history = state.get("hashrate_history", [])
+                    self.hashrate_history = deque(
+                        state.get("hashrate_history", []), maxlen=MAX_HISTORY_ENTRIES
+                    )
 
                     # Restore variance_history if present
                     compact_variance = state.get("variance_history", {})
@@ -185,7 +187,9 @@ class StateManager:
                     self.arrow_history = {
                         key: deque(values, maxlen=MAX_HISTORY_ENTRIES) for key, values in raw_history.items()
                     }
-                    self.hashrate_history = state.get("hashrate_history", [])
+                    self.hashrate_history = deque(
+                        state.get("hashrate_history", []), maxlen=MAX_HISTORY_ENTRIES
+                    )
                     self.metrics_log = deque(state.get("metrics_log", []), maxlen=MAX_HISTORY_ENTRIES)
 
                 logging.info(f"Loaded graph state from Redis (format version {version}).")
@@ -235,7 +239,7 @@ class StateManager:
 
             # Compact hashrate_history
             compact_hashrate_history = (
-                self.hashrate_history[-60:] if len(self.hashrate_history) > 60 else self.hashrate_history
+                list(self.hashrate_history)[-60:] if len(self.hashrate_history) > 60 else list(self.hashrate_history)
             )
 
             # Compact metrics_log with unit preservation

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -225,3 +225,31 @@ def test_prune_old_data():
 
     assert len(mgr.arrow_history["hashrate_60sec"]) <= MAX_HISTORY_ENTRIES
     assert len(mgr.metrics_log) <= MAX_HISTORY_ENTRIES
+
+
+def test_hashrate_history_limit():
+    mgr = StateManager()
+    for i in range(MAX_HISTORY_ENTRIES + 10):
+        mgr.hashrate_history.append(i)
+
+    assert isinstance(mgr.hashrate_history, deque)
+    assert len(mgr.hashrate_history) == MAX_HISTORY_ENTRIES
+
+
+def test_hashrate_history_loaded_as_deque(monkeypatch):
+    mgr = StateManager()
+    mgr.redis_client = DummyRedis()
+    data = {
+        "arrow_history": {},
+        "hashrate_history": list(range(5)),
+        "metrics_log": [],
+    }
+    mgr.redis_client.set(f"{mgr.STATE_KEY}_version", "2.0")
+    mgr.redis_client.set(mgr.STATE_KEY, json.dumps(data))
+
+    new_mgr = StateManager()
+    new_mgr.redis_client = mgr.redis_client
+    new_mgr.load_graph_state()
+
+    assert isinstance(new_mgr.hashrate_history, deque)
+    assert new_mgr.hashrate_history.maxlen == MAX_HISTORY_ENTRIES


### PR DESCRIPTION
## Summary
- ensure `hashrate_history` is always a bounded deque
- preserve deque when loading from Redis
- adjust graph state serialization for deque
- test new bounded behaviour

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410e027c1483209eb4847868f573cc