### PR TITLE
Fix executor/session leak in MiningDashboardService

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -120,6 +120,9 @@ class MiningDashboardService:
                 except Exception:
                     pass
 
+            # Release the executor reference to free threads
+            self.executor = None
+
             # Close session and underlying adapters
             try:
                 self.session.close()
@@ -130,6 +133,8 @@ class MiningDashboardService:
                             adapter.close()
                         except Exception:
                             pass
+                # Drop the session reference to free connection pools
+                self.session = None
         except Exception as e:
             logging.error(f"Error closing session: {e}")
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -705,6 +705,23 @@ def test_service_del_calls_close(monkeypatch):
     assert called["flag"]
 
 
+def test_close_clears_resources(monkeypatch):
+    """close() should drop session and executor references."""
+    svc = MiningDashboardService(0, 0, "w")
+
+    monkeypatch.setattr(svc.executor, "shutdown", lambda **kw: None)
+    class DummySession:
+        def close(self):
+            pass
+
+    svc.session = DummySession()
+
+    svc.close()
+
+    assert svc.session is None
+    assert svc.executor is None
+
+
 def test_fetch_metrics_cancels_futures(monkeypatch):
     """Futures should be cancelled when fetch_metrics times out."""
     svc = MiningDashboardService(0, 0, "w")


### PR DESCRIPTION
## Summary
- release executor and HTTP session references in `MiningDashboardService.close`
- add regression test verifying references are cleared

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684118d82b60832092d8e0ae1d6040f0