### PR TITLE
Add inline sparklines on dashboard metrics

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -796,3 +796,10 @@ html.bitcoin-theme #btc_price:hover {
     0 0 2px #fff !important;
   text-decoration: underline wavy #ffd700 !important;
 }
+
+/* Sparkline charts */
+.sparkline {
+    width: 60px;
+    height: 16px;
+    margin-left: 4px;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2946,6 +2946,11 @@ function updateUI() {
             width: 1rem;
             display: inline-flex;
         }
+        .sparkline {
+            width: 60px;
+            height: 16px;
+            margin-left: 4px;
+        }
         `;
             document.head.appendChild(styleEl);
         }
@@ -3779,6 +3784,9 @@ function updateUI() {
         updateIndicators(data);
         checkForBlockUpdates(data);
 
+        if (window.SparklineModule) {
+            SparklineModule.updateSparklines(data);
+        }
         // Add this call before storing current metrics as previous metrics
         trackPayoutPerformance(data);
 
@@ -4128,6 +4136,13 @@ $(document).ready(function () {
         // Setup theme change listener
         setupThemeChangeListener();
         loadBlockAnnotations();
+        if (window.SparklineModule) {
+            try {
+                SparklineModule.initSparklines();
+            } catch (err) {
+                console.error("Error initializing sparklines:", err);
+            }
+        }
     } catch (e) {
         console.error("Error handling theme:", e);
     }

--- a/static/js/sparklines.js
+++ b/static/js/sparklines.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * SparklineModule - renders tiny line charts inline with metrics.
+ */
+(function () {
+    const charts = {};
+
+    function ensureCanvas(id) {
+        let canvas = document.getElementById(id);
+        if (!canvas) {
+            canvas = document.createElement('canvas');
+            canvas.id = id;
+            canvas.className = 'sparkline';
+            canvas.width = 60;
+            canvas.height = 16;
+        }
+        return canvas;
+    }
+
+    function initSparklines() {
+        document.querySelectorAll('[id^="indicator_"]').forEach(indicator => {
+            const key = indicator.id.replace('indicator_', '');
+            const canvas = ensureCanvas(`sparkline_${key}`);
+            if (!indicator.nextSibling || indicator.nextSibling.id !== canvas.id) {
+                indicator.after(canvas);
+            }
+        });
+    }
+
+    function updateSparklines(data) {
+        if (!window.Chart || !data.arrow_history) {
+            return;
+        }
+        Object.entries(data.arrow_history).forEach(([key, list]) => {
+            const canvasId = `sparkline_${key}`;
+            const canvas = document.getElementById(canvasId);
+            if (!canvas) {
+                return;
+            }
+            const values = list.map(v => parseFloat(v.value)).filter(v => !isNaN(v));
+            if (values.length === 0) {
+                return;
+            }
+            let chart = charts[canvasId];
+            const labels = values.map((_, i) => i);
+            if (!chart) {
+                chart = new Chart(canvas.getContext('2d'), {
+                    type: 'line',
+                    data: { labels: labels, datasets: [{
+                        data: values,
+                        borderColor: '#0088cc',
+                        borderWidth: 1,
+                        pointRadius: 0,
+                        tension: 0.4,
+                        fill: false
+                    }] },
+                    options: {
+                        responsive: false,
+                        animation: false,
+                        scales: { x: { display: false }, y: { display: false } },
+                        plugins: { legend: { display: false } }
+                    }
+                });
+                charts[canvasId] = chart;
+            } else {
+                chart.data.labels = labels;
+                chart.data.datasets[0].data = values;
+                chart.update();
+            }
+        });
+    }
+
+    window.SparklineModule = { initSparklines, updateSparklines };
+})();
+

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -402,5 +402,6 @@
 
 {% block javascript %}
 <!-- External JavaScript file with our application logic -->
+<script src="{{ url_for('static', filename='js/sparklines.js') }}"></script>
 <script src="{{ url_for('static', filename='js/main.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `SparklineModule` for small inline charts
- include sparklines in dashboard
- call sparkline updater from `main.js`
- style sparkline elements

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`
- `make minify`


------
https://chatgpt.com/codex/tasks/task_e_6841b9ce3ba883208608f32efca877e4