### PR TITLE
Improve sparkline charts and metric dividers

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2921,7 +2921,7 @@ function updateUI() {
         .metric-divider {
             display: inline-flex;
             align-items: center;
-            margin-left: 1rem;
+            margin-left: 0;
             padding-left: 0.75rem;
             height: 1.5em;
             white-space: nowrap;
@@ -2949,7 +2949,7 @@ function updateUI() {
         .sparkline {
             width: 60px;
             height: 16px;
-            margin-left: 4px;
+            margin-left: 0.5rem;
         }
         `;
             document.head.appendChild(styleEl);

--- a/static/js/sparklines.js
+++ b/static/js/sparklines.js
@@ -5,6 +5,7 @@
  */
 (function () {
     const charts = {};
+    let lastTheme = null;
 
     function ensureCanvas(id) {
         let canvas = document.getElementById(id);
@@ -58,24 +59,43 @@
         if (!window.Chart || !data.arrow_history) {
             return;
         }
+        const theme = window.getCurrentTheme ? window.getCurrentTheme() : { PRIMARY: '#0088cc' };
+        if (lastTheme !== theme) {
+            lastTheme = theme;
+        }
+
         Object.entries(data.arrow_history).forEach(([key, list]) => {
             const canvasId = `sparkline_${key}`;
             const canvas = document.getElementById(canvasId);
             if (!canvas) {
+                const existing = charts[canvasId];
+                if (existing) {
+                    existing.destroy();
+                    delete charts[canvasId];
+                }
                 return;
             }
+
             const values = list.map(v => parseFloat(v.value)).filter(v => !isNaN(v));
             if (values.length === 0) {
                 return;
             }
+
             let chart = charts[canvasId];
             const labels = values.map((_, i) => i);
+
+            if (chart && !document.contains(canvas)) {
+                chart.destroy();
+                delete charts[canvasId];
+                chart = null;
+            }
+
             if (!chart) {
                 chart = new Chart(canvas.getContext('2d'), {
                     type: 'line',
                     data: { labels: labels, datasets: [{
                         data: values,
-                        borderColor: '#0088cc',
+                        borderColor: theme.PRIMARY,
                         borderWidth: 1,
                         pointRadius: 0,
                         tension: 0.4,
@@ -85,18 +105,33 @@
                         responsive: false,
                         animation: false,
                         scales: { x: { display: false }, y: { display: false } },
-                        plugins: { legend: { display: false } }
+                        plugins: {
+                            legend: { display: false },
+                            tooltip: { enabled: false }
+                        }
                     }
                 });
+                chart._theme = theme;
                 charts[canvasId] = chart;
             } else {
                 chart.data.labels = labels;
                 chart.data.datasets[0].data = values;
+                if (chart._theme !== theme) {
+                    chart.data.datasets[0].borderColor = theme.PRIMARY;
+                    chart._theme = theme;
+                }
                 chart.update();
             }
         });
     }
 
-    window.SparklineModule = { initSparklines, updateSparklines };
+    function destroySparklines() {
+        Object.values(charts).forEach(chart => chart.destroy());
+        Object.keys(charts).forEach(id => delete charts[id]);
+    }
+
+    window.addEventListener('beforeunload', destroySparklines);
+
+    window.SparklineModule = { initSparklines, updateSparklines, destroySparklines };
 })();
 


### PR DESCRIPTION
## Summary
- update sparkline charts to use theme colors
- remove tooltips and clean up charts to avoid leaks
- destroy sparkline charts when page unloads
- tweak CSS spacing for metric dividers and sparklines

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `make minify`

------
https://chatgpt.com/codex/tasks/task_e_68426d7e5c848320b26a2022fc9c49df