### PR TITLE
Fix payout card spacing

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1130,7 +1130,7 @@ function initPayoutTracking() {
         id: "view-payout-history",
         text: "VIEW LAST PAYOUT",
         click: togglePayoutHistoryDisplay,
-        class: "btn btn-sm mt-2",
+        class: "btn btn-sm mt-2 d-block",
         style: `
             background-color: ${theme.PRIMARY};
             color: ${isDeepSea ? 'white' : 'black'};
@@ -1139,13 +1139,18 @@ function initPayoutTracking() {
         `
     });
 
-    $("#est_time_to_payout").parent().after(viewHistoryButton);
+    const viewHistoryWrapper = $("<p>", {
+        id: "last-payout-btn-wrapper",
+        class: "mt-2 mb-0"
+    }).append(viewHistoryButton);
+
+    $("#est_time_to_payout").parent().after(viewHistoryWrapper);
 
     // Create a container for the payout history (initially hidden)
     $("<div>", {
         id: "payout-history-container",
         style: "display: none; margin-top: 10px;"
-    }).insertAfter(viewHistoryButton);
+    }).insertAfter(viewHistoryWrapper);
 
     // Update theme-change listener for the button with fixed colors for each theme
     $(document).on('themeChanged', function () {
@@ -3244,9 +3249,12 @@ function updateUI() {
                     poolFeesPercentage.insertAdjacentElement('afterend', poolFeesSats);
                 }
 
-                // Update the text and styling
-                poolFeesSats.textContent = " (" + formattedPoolFee + ")";
-                poolFeesSats.setAttribute("style", "color: #ff5555 !important; font-weight: bold !important; margin-left: 6px;");
+                // Update the text and styling with tighter spacing
+                poolFeesSats.textContent = "(" + formattedPoolFee + ")";
+                poolFeesSats.setAttribute(
+                    "style",
+                    "color: #ff5555 !important; font-weight: bold !important; margin-left: 4px; display: inline;"
+                );
             }
         }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -90,8 +90,7 @@
                         {% else %}
                         N/A
                         {% endif %}
-                    </span>
-                    <span id="pool_fees_sats" class="metric-value" style="color: #ff5555 !important; font-weight: bold !important; margin-left: 6px;"></span>
+                    </span><span id="pool_fees_sats" class="metric-value" style="color: #ff5555 !important; font-weight: bold !important; margin-left: 4px;"></span>
                     <span id="indicator_pool_fees_percentage"></span>
                 </p>
                 <p>


### PR DESCRIPTION
## Summary
- tweak spacing between Pool Fees percentage and SATS by removing whitespace in the template
- wrap the Last Payout button in its own paragraph so it always breaks to a new line

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`
- `node tests/js/formatCurrency.test.js`
- `node tests/js/formatDuration.test.js`
- `node tests/js/main_dom_safety.test.js`
- `node tests/js/main_chart_load.test.js`
- `node tests/js/normalizeHashrate.test.js`
- `node tests/js/arrowIndicator.test.js`
- `node tests/js/audioCrossfadeTheme.test.js`
- `node tests/js/blockProbability.test.js`
- `node tests/js/notificationsTimestamp.test.js`
- `node tests/js/workerUtils.test.js`
- `make minify`


------
https://chatgpt.com/codex/tasks/task_e_684274a4fdf883209e776fe20adcf06f