### PR TITLE
Remove payout sparklines

### DIFF
--- a/static/js/sparklines.js
+++ b/static/js/sparklines.js
@@ -24,7 +24,14 @@
      * consistently so the charts appear inline with the metric value.
      */
     function initSparklines() {
-        const skipKeys = new Set(['workers_hashing', 'unpaid_earnings']);
+        // Metrics under the Payout Info section don't require sparklines
+        const skipKeys = new Set([
+            'workers_hashing',
+            'unpaid_earnings',
+            'pool_fees_percentage',
+            'last_block',
+            'est_time_to_payout'
+        ]);
 
         document.querySelectorAll('[id^="indicator_"]').forEach(indicator => {
             const key = indicator.id.replace('indicator_', '');

--- a/tests/test_sparklines_skip_keys.py
+++ b/tests/test_sparklines_skip_keys.py
@@ -1,0 +1,13 @@
+import ast
+import re
+from pathlib import Path
+
+
+def test_sparklines_skip_keys():
+    js_path = Path('static/js/sparklines.js')
+    content = js_path.read_text()
+    match = re.search(r"skipKeys = new Set\((\[[^\]]*\])\)", content)
+    assert match, 'skipKeys set not found'
+    keys = ast.literal_eval(match.group(1))
+    for key in ['pool_fees_percentage', 'last_block', 'est_time_to_payout']:
+        assert key in keys


### PR DESCRIPTION
## Summary
- skip rendering sparklines for payout info metrics
- test that payout metrics are excluded from the sparkline list

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427b3ac6e08320ad43b78c90f719c5