### PR TITLE
Adjust divider alignment

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2918,15 +2918,17 @@ function updateUI() {
         /* All dividers */
         .metric-divider-container {
             grid-column: 3;
-            justify-self: end;
+            justify-self: stretch;
             display: flex;
             align-items: center;
+            justify-content: flex-end;
+            width: 100%;
         }
         
         .metric-divider {
             display: inline-flex;
             align-items: center;
-            margin-left: 0;
+            margin-left: auto;
             padding-left: 0.75rem;
             height: 1.5em;
             white-space: nowrap;


### PR DESCRIPTION
## Summary
- tweak metric divider style for better alignment
- minify static assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843cbeaa2ac83209f9fc4e5a0e9a7f6