### PR TITLE
Improve mobile sparkline width

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -803,3 +803,9 @@ html.bitcoin-theme #btc_price:hover {
     height: 16px;
     margin-left: 4px;
 }
+
+@media (max-width: 576px) {
+  .sparkline {
+    width: 45px;
+  }
+}


### PR DESCRIPTION
## Summary
- style `.sparkline` charts at smaller width for mobile view

## Testing
- `make minify-css`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844185b94348320a47f5a6b9d259d40