### PR TITLE
Refactor reward and fee fetchers

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -87,12 +87,13 @@ class MiningDashboardService:
             logging.error(f"Error estimating power usage: {e}")
         return 0
 
+    @ttl_cache(ttl_seconds=3600, maxsize=1)
     def get_block_reward(self):
         """Return the current block subsidy using mempool.guide."""
         try:
             url = "https://mempool.guide/api/blocks/tip/height"
-            resp = self.session.get(url, timeout=10)
-            if resp.ok:
+            resp = self.fetch_url(url, timeout=10)
+            if resp and resp.ok:
                 height = int(resp.text)
                 halvings = height // 210000
                 reward = 50 / (2 ** halvings)
@@ -102,12 +103,13 @@ class MiningDashboardService:
         # Default to the current known reward
         return 3.125
 
+    @ttl_cache(ttl_seconds=3600, maxsize=1)
     def get_average_fee_per_block(self):
         """Return the average transaction fee per block from mempool.guide."""
         try:
             url = "https://mempool.guide/api/v1/mining/blocks/day"
-            resp = self.session.get(url, timeout=10)
-            if resp.ok:
+            resp = self.fetch_url(url, timeout=10)
+            if resp and resp.ok:
                 data = resp.json()
                 if isinstance(data, dict):
                     avg_fee = data.get("avgFee")

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -614,6 +614,7 @@ def test_fetch_metrics_estimates_power(monkeypatch):
     assert abs(metrics["break_even_electricity_price"] - 0.375) < 1e-6
     assert dummy.last_cached_metrics["workers_hashing"] == 2
     assert dummy.last_cached_metrics["hashrate_24hr"] == 100
+    assert metrics["avg_fee_per_block"] == 0.0
 
 
 def test_fetch_metrics_real_worker_data(monkeypatch):
@@ -648,6 +649,7 @@ def test_fetch_metrics_real_worker_data(monkeypatch):
 
     assert metrics["power_usage_estimated"] is False
     assert dummy.last_cached_metrics["workers_hashing"] == 2
+    assert metrics["avg_fee_per_block"] == 0.0
 
 
 def test_fetch_metrics_power_configured(monkeypatch):
@@ -674,6 +676,7 @@ def test_fetch_metrics_power_configured(monkeypatch):
 
     assert metrics["power_usage_estimated"] is False
     assert abs(metrics["break_even_electricity_price"] - 0.46875) < 1e-4
+    assert metrics["avg_fee_per_block"] == 0.0
 
 
 def test_server_start_time_constant(monkeypatch):


### PR DESCRIPTION
## Summary
- prevent resource leaks in `get_block_reward` and `get_average_fee_per_block`
- cache results of these methods for an hour to minimize network calls
- verify `avg_fee_per_block` is present when metrics are computed

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d9b3f7148320bc9d3a63909f3d6b