### PR TITLE
Update docs for reward logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ informed with minimal fuss.
 ## Key Features
 
 
-### Real-Time Mining Metrics
+-### Real-Time Mining Metrics
 - **Live Hashrate Tracking**: Monitor 60-second, 10-minute, 3-hour, and 24-hour average hashrates
-- **Profitability Analysis**: View daily and monthly earnings in both BTC and USD
+- **Profitability Analysis**: View daily and monthly earnings in both BTC and USD using your 24-hour hashrate
 - **Financial Calculations**: Automatically calculate revenue, power costs, and net profit
 - **Break-Even Electricity Price**: Shows the maximum power rate that still yields profit
-- **Network Statistics**: Track current Bitcoin price, difficulty, and network hashrate
+- **Dynamic Reward Modeling**: Combines the block subsidy with the average fee per block for accurate projections
+- **Network Statistics**: Track current Bitcoin price, difficulty, network hashrate, and average fee per block
 - **Payout Monitoring**: View unpaid balance and estimated time to next payout
 - **Pool Fee Analysis**: Monitor pool fee percentages with visual indicator when optimal rates (0.9-1.3%) are detected
 - **Official Ocean API**: Supplement scraping with data from the official Ocean.xyz API for greater accuracy

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2,7 +2,10 @@
 
 The dashboard can be customized through a combination of a `config.json` file and environment variables. Environment variables always override values found in the configuration file.
 
-Profitability calculations are always performed in USD. When a non-USD currency is configured, values are converted using the latest exchange rates before being displayed.
+Profitability calculations are always performed in USD. When a non-USD currency is configured,
+values are converted using the latest exchange rates before being displayed.
+Earnings projections now rely on your 24-hour average hashrate rather than shorter intervals to
+smooth volatility.
 
 ## `config.json`
 

--- a/docs/ocean-api-integration.md
+++ b/docs/ocean-api-integration.md
@@ -70,6 +70,7 @@ https://api.ocean.xyz/v1/user_hashrate/3QomtEj5nfzEkxPXoVD3hvxgJDzA6M6evt
 - username typically refers to the user's Bitcoin payout address.
 - Append /csv or /text to endpoints to receive alternate formats if supported.
 - Ocean uses a proprietary reward model called TIDES, which depends on time-based difficulty1 share logs.
+- The dashboard calculates rewards dynamically using the current block subsidy and the `avg_fee_per_block` metric.
 - Timestamps can be formatted as:
   - YYYY-MM-DD
   - YYYY-MM-DDTHH:MM:SS


### PR DESCRIPTION
## Summary
- note 24-hour hashrate profitability in Configuration
- mention dynamic reward modeling and average fee metric in README
- document avg_fee_per_block usage in Ocean API guide

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d9b4c0fc8320914dceb69c3c1f97