### PR TITLE
Add info tooltips throughout dashboard

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -9,6 +9,8 @@
   --bg-gradient: linear-gradient(135deg, #0a0a0a, #1a1a1a);
   --primary-color: #f7931a;
   --primary-color-rgb: 247, 147, 26;
+  --bitcoin-color: #f7931a;
+  --deepsea-color: #0088cc;
   --accent-color: #00ffff;
   --text-color: #ffffff;
   --card-padding: 0.5rem;
@@ -1307,4 +1309,47 @@ html.deepsea-theme #congratsMessage {
   .audio-controls {
     flex-direction: row;
   }
+}
+
+/* ----- TOOLTIP STYLING (shared) ----- */
+.tooltip {
+    position: relative;
+    display: inline-block;
+    margin-left: 5px;
+    width: 14px;
+    height: 14px;
+    background-color: #333;
+    color: var(--text-color);
+    border-radius: 50%;
+    text-align: center;
+    line-height: 14px;
+    font-size: 10px;
+    cursor: help;
+}
+
+.tooltip .tooltip-text {
+    visibility: hidden;
+    width: 200px;
+    background-color: #000;
+    color: var(--text-color);
+    text-align: center;
+    padding: 5px;
+    position: absolute;
+    z-index: 1;
+    bottom: 125%;
+    left: 50%;
+    margin-left: -100px;
+    opacity: 0;
+    transition: opacity 0.3s;
+    font-size: 14px;
+    border: 1px solid var(--bitcoin-color);
+}
+
+.tooltip:hover .tooltip-text {
+    visibility: visible;
+    opacity: 1;
+}
+
+body.deepsea-theme .tooltip .tooltip-text {
+    border: 1px solid var(--deepsea-color);
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -200,6 +200,9 @@
             <a href="/" style="text-decoration:none; color:inherit;">
                 {{ header_content }}
             </a>
+            <span class="tooltip">?
+                <span class="tooltip-text">Use Alt+1-4 to switch pages</span>
+            </span>
         </h1>
 
         <!-- Top right link -->

--- a/templates/blocks.html
+++ b/templates/blocks.html
@@ -19,7 +19,11 @@
 <div class="row mb-2">
     <div class="col-12">
         <div class="card">
-            <div class="card-header">MINER DISTRIBUTION (LAST 25 BLOCKS)</div>
+            <div class="card-header">MINER DISTRIBUTION (LAST 25 BLOCKS)
+                <span class="tooltip">?
+                    <span class="tooltip-text">Shows which pools mined the last 25 blocks</span>
+                </span>
+            </div>
             <div class="card-body text-center">
                 <canvas id="minerChart" height="240"></canvas>
             </div>
@@ -31,7 +35,11 @@
 <div class="row mb-2 equal-height">
     <div class="col-12">
         <div class="card">
-            <div class="card-header">LATEST BLOCK STATS</div>
+            <div class="card-header">LATEST BLOCK STATS
+                <span class="tooltip">?
+                    <span class="tooltip-text">Details about the most recent mined block</span>
+                </span>
+            </div>
             <div class="card-body">
                 <div class="latest-block-stats">
                     <div class="stat-item">

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -18,7 +18,11 @@
     <canvas id="trendGraph" style="width: 100%; height: 100%; position: relative; z-index: 2;"></canvas>
 </div>
 <div class="chart-controls">
-    <span class="chart-controls-label">Depth:</span>
+    <span class="chart-controls-label">Depth:
+        <span class="tooltip">?
+            <span class="tooltip-text">Switch time window or use low hashrate mode when rates drop</span>
+        </span>
+    </span>
     <div class="chart-points-toggle">
         <button id="btn-30" class="toggle-btn active" onclick="setChartPoints(30)">30m</button>
         <button id="btn-60" class="toggle-btn" onclick="setChartPoints(60)">60m</button>
@@ -44,6 +48,9 @@
                 <!-- New line for DATUM status -->
                 <p>
                     <strong>DATUM GATEWAY:</strong>
+                    <span class="tooltip">?
+                        <span class="tooltip-text">Connection status to the DATUM gateway used to determine pool fees</span>
+                    </span>
                     <span id="datum_status" class="metric-value">
                         {% if metrics and metrics.pool_fees_percentage is defined and metrics.pool_fees_percentage is not none %}
                             {% if metrics.pool_fees_percentage >= 0.9 and metrics.pool_fees_percentage <= 1.3 %}
@@ -58,6 +65,9 @@
                 </p>
                 <p>
                     <strong>Workers Hashing:</strong>
+                    <span class="tooltip">?
+                        <span class="tooltip-text">Number of miners currently submitting shares</span>
+                    </span>
                     <span id="workers_hashing" class="metric-value">{{ metrics.workers_hashing or 0 }}</span>
                     <span id="indicator_workers_hashing"></span>
                 </p>
@@ -238,6 +248,9 @@
                 </p>
                 <p>
                     <strong>Block Number:</strong>
+                    <span class="tooltip">?
+                        <span class="tooltip-text">Current height of the Bitcoin blockchain</span>
+                    </span>
                     <span id="block_number" class="metric-value white">
                         {% if metrics and metrics.block_number %}
                         {{ metrics.block_number|commafy }}
@@ -249,6 +262,9 @@
                 </p>
                 <p>
                     <strong>Network Hashrate:</strong>
+                    <span class="tooltip">?
+                        <span class="tooltip-text">Estimated total hashrate for the Bitcoin network</span>
+                    </span>
                     <span id="network_hashrate" class="metric-value white">
                         {% if metrics and metrics.network_hashrate %}
                         {{ metrics.network_hashrate|round|commafy }} EH/s
@@ -260,6 +276,9 @@
                 </p>
                 <p>
                     <strong>Difficulty:</strong>
+                    <span class="tooltip">?
+                        <span class="tooltip-text">Mining difficulty for the current epoch</span>
+                    </span>
                     <span id="difficulty" class="metric-value white">
                         {% if metrics and metrics.difficulty %}
                         {{ metrics.difficulty|round|commafy }}
@@ -278,7 +297,11 @@
 <div class="row equal-height">
     <div class="col-md-6">
         <div class="card">
-            <div class="card-header">SATOSHI EARNINGS</div>
+            <div class="card-header">SATOSHI EARNINGS
+                <span class="tooltip">?
+                    <span class="tooltip-text">Projected net rewards after fees</span>
+                </span>
+            </div>
             <div class="card-body">
                 <p>
                     <strong>Projected Daily (Net):</strong>
@@ -341,7 +364,11 @@
 
     <div class="col-md-6">
         <div class="card">
-            <div class="card-header" id="currency-earnings-header">{% if metrics and metrics.power_usage_estimated %}Est. {% endif %}{{ user_currency|default('') }} EARNINGS</div>
+            <div class="card-header" id="currency-earnings-header">{% if metrics and metrics.power_usage_estimated %}Est. {% endif %}{{ user_currency|default('') }} EARNINGS
+                <span class="tooltip">?
+                    <span class="tooltip-text">Conversion of sats to your selected currency</span>
+                </span>
+            </div>
             <div class="card-body">
                 <p>
                     <strong>Daily Revenue:</strong>

--- a/templates/earnings.html
+++ b/templates/earnings.html
@@ -21,7 +21,11 @@
     <!-- Summary Cards Section -->
     <div class="stats-grid">
         <div class="stat-card">
-            <h2><i class="fa-solid fa-coins"></i> Unpaid Earnings</h2>
+            <h2><i class="fa-solid fa-coins"></i> Unpaid Earnings
+                <span class="tooltip">?
+                    <span class="tooltip-text">Balance awaiting payout. Timing shown below.</span>
+                </span>
+            </h2>
             <div class="stat-value">
                 <span id="unpaid-sats">{{ earnings.unpaid_earnings_sats|default(0)|int|commafy }}</span>
                 <span class="stat-unit">sats</span>
@@ -33,7 +37,11 @@
         </div>
 
         <div class="stat-card">
-            <h2><i class="fa-solid fa-wallet"></i> Total Paid</h2>
+            <h2><i class="fa-solid fa-wallet"></i> Total Paid
+                <span class="tooltip">?
+                    <span class="tooltip-text">All payouts sent to your wallet</span>
+                </span>
+            </h2>
             <div class="stat-value">
                 <span id="total-paid-sats">{{ earnings.total_paid_sats|default(0)|int|commafy }}</span>
                 <span class="stat-unit">sats</span>
@@ -47,7 +55,11 @@
         </div>
 
         <div class="stat-card">
-            <h2><i class="fa-solid fa-file-invoice-dollar"></i> Total Payments</h2>
+            <h2><i class="fa-solid fa-file-invoice-dollar"></i> Total Payments
+                <span class="tooltip">?
+                    <span class="tooltip-text">Number of payouts received</span>
+                </span>
+            </h2>
             <div class="stat-value">
                 <span id="payment-count">{{ earnings.total_payments|default(0) }}</span>
             </div>

--- a/templates/notifications.html
+++ b/templates/notifications.html
@@ -22,17 +22,17 @@
             <div class="card-body">
                 <div class="notification-controls">
                     <div class="filter-buttons">
-                        <button class="filter-button active" data-filter="all">All</button>
-                        <button class="filter-button" data-filter="hashrate">Hashrate</button>
-                        <button class="filter-button" data-filter="block">Blocks</button>
-                        <button class="filter-button" data-filter="worker">Workers</button>
-                        <button class="filter-button" data-filter="earnings">Earnings</button>
-                        <button class="filter-button" data-filter="system">System</button>
+                        <button class="filter-button active" data-filter="all" title="Show all notifications">All</button>
+                        <button class="filter-button" data-filter="hashrate" title="Only hashrate alerts">Hashrate</button>
+                        <button class="filter-button" data-filter="block" title="Block found notifications">Blocks</button>
+                        <button class="filter-button" data-filter="worker" title="Worker status alerts">Workers</button>
+                        <button class="filter-button" data-filter="earnings" title="Earnings related">Earnings</button>
+                        <button class="filter-button" data-filter="system" title="System messages">System</button>
                     </div>
                     <div class="notification-actions">
-                        <button id="mark-all-read" class="action-button">Mark All as Read</button>
-                        <button id="clear-read" class="action-button">Clear Read Notifications</button>
-                        <button id="clear-all" class="action-button danger">Clear All</button>
+                        <button id="mark-all-read" class="action-button" title="Mark every notification as read">Mark All as Read</button>
+                        <button id="clear-read" class="action-button" title="Remove only read notifications">Clear Read Notifications</button>
+                        <button id="clear-all" class="action-button danger" title="Delete every notification">Clear All</button>
                     </div>
                 </div>
             </div>

--- a/templates/workers.html
+++ b/templates/workers.html
@@ -74,7 +74,11 @@
                         <div class="summary-stat-value red-glow" id="total-power-usage">
                             N/A
                         </div>
-                        <div class="summary-stat-label">TOTAL EST. POWER USAGE</div>
+                        <div class="summary-stat-label">TOTAL EST. POWER USAGE
+                            <span class="tooltip">?
+                                <span class="tooltip-text">Requires worker names to contain model keywords</span>
+                            </span>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- reuse tooltip style across all templates
- provide keyboard shortcut hint in header
- add guidance tooltips for DATUM gateway, network metrics and earnings
- clarify power estimation on workers page
- add button titles for notification filters
- document recent blocks and miner distribution charts

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_6844fc4b67888320a8dd2daa0b78497b