### PR TITLE
Patch exchange rate test to use dummy API key

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -128,6 +128,9 @@ def test_exchange_rate_caching(monkeypatch):
     fake_time = [0]
     monkeypatch.setattr(data_service.time, "time", lambda: fake_time[0])
 
+    # Provide a dummy API key so the service does not abort early
+    monkeypatch.setenv("EXCHANGE_RATE_API_KEY", "TESTKEY")
+
     call_count = {"count": 0}
 
     def fake_get(url, timeout=5):


### PR DESCRIPTION
## Summary
- ensure exchange rate caching test sets a dummy API key so it doesn't fail when the real key is absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847219e4d908320be791ada17f9cfb7