### PR TITLE
Fix ttl_cache set hashing

### DIFF
--- a/cache_utils.py
+++ b/cache_utils.py
@@ -25,8 +25,10 @@ def ttl_cache(ttl_seconds=60, maxsize=None):
                 hash(value)
                 return value
             except TypeError:
+                if isinstance(value, (set, frozenset)):
+                    value = sorted(value)
                 try:
-                    return json.dumps(value, sort_keys=True)
+                    return json.dumps(value, sort_keys=True, default=str)
                 except Exception:
                     return str(value)
 


### PR DESCRIPTION
## Summary
- fix caching serialization to support set and frozenset
- test caching with set arguments

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847409ba2d883209eebe47a4c4c951f