### PR TITLE
Add state manager cleanup

### DIFF
--- a/App.py
+++ b/App.py
@@ -1862,6 +1862,13 @@ def graceful_shutdown(signum, frame):
         except Exception as e:
             logging.error(f"Error closing dashboard service: {e}")
 
+    # Close state manager resources
+    if state_manager:
+        try:
+            state_manager.close()
+        except Exception as e:
+            logging.error(f"Error closing state manager: {e}")
+
     # Close all logging handlers to avoid file descriptor leaks
     for handler in logging.getLogger().handlers:
         try:

--- a/state_manager.py
+++ b/state_manager.py
@@ -63,6 +63,20 @@ class StateManager:
         self.load_payout_history()
         self.load_last_earnings()
 
+    def close(self):
+        """Close Redis connection and release resources."""
+        if self.redis_client:
+            try:
+                self.redis_client.close()
+            except Exception as e:
+                logging.error(f"Error closing Redis connection: {e}")
+            finally:
+                self.redis_client = None
+
+    def __del__(self):
+        """Ensure Redis connection is closed on garbage collection."""
+        self.close()
+
     def _connect_to_redis(self, redis_url):
         """
         Connect to Redis with retry logic.

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -265,3 +265,25 @@ def test_metrics_log_snapshot_omits_history(monkeypatch):
     assert "arrow_history" not in latest
     assert "history" not in latest
 
+
+def test_close_closes_redis_connection():
+    mgr = StateManager()
+
+    class DummyRedis:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+        def ping(self):
+            pass
+
+    dummy = DummyRedis()
+    mgr.redis_client = dummy
+
+    mgr.close()
+
+    assert dummy.closed
+    assert mgr.redis_client is None
+


### PR DESCRIPTION
## Summary
- ensure Redis connections close when the state manager is destroyed
- invoke this cleanup during graceful shutdown
- test that StateManager.close() closes the Redis client

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68475350ae0c8320a229886d4c5231b8