### PR TITLE
Fix mobile nav color for Matrix theme

### DIFF
--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -483,6 +483,12 @@ function applyMatrixTheme() {
             themeToggle.style.color = '#39ff14';
         }
 
+        const mobileNavToggle = document.getElementById('mobileNavToggle');
+        if (mobileNavToggle) {
+            mobileNavToggle.style.borderColor = '#39ff14';
+            mobileNavToggle.style.color = '#39ff14';
+        }
+
         document.documentElement.classList.remove('bitcoin-theme', 'deepsea-theme');
         document.documentElement.classList.add('matrix-theme');
 


### PR DESCRIPTION
## Summary
- update Matrix theme application to recolor the mobile nav toggle
- run minify on assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_684779f7440c83209f0351963b7a09fb