### PR TITLE
Adjust Matrix theme toggle hover glow

### DIFF
--- a/static/css/matrix.css
+++ b/static/css/matrix.css
@@ -14,7 +14,7 @@ html.matrix-theme .theme-toggle-btn {
 html.matrix-theme #themeToggle:hover,
 html.matrix-theme .theme-toggle-btn:hover {
   background-color: rgba(57, 255, 20, 0.1);
-  box-shadow: 0 4px 8px rgba(57, 255, 20, 0.3);
+  box-shadow: 0 0 10px rgba(57, 255, 20, 0.6);
 }
 
 html.matrix-theme #themeToggle:focus,


### PR DESCRIPTION
## Summary
- tweak Matrix theme's button hover box-shadow for consistent glow

## Testing
- `make minify-css`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68477d83d35883208da823c2b04d9776