### PR TITLE
Fix monitor restore position

### DIFF
--- a/static/js/BitcoinProgressBar.js
+++ b/static/js/BitcoinProgressBar.js
@@ -1910,6 +1910,10 @@ const BitcoinMinuteRefresh = (function () {
             showButton.style.display = 'none';
         }
 
+        // Recalculate position now that the terminal is visible
+        // Delay slightly so the browser can compute dimensions
+        setTimeout(restoreTerminalPosition, 50);
+
         // Clear hidden state when shown
         localStorage.setItem(STORAGE_KEYS.HIDDEN, 'false');
     }


### PR DESCRIPTION
## Summary
- update `showTerminal` to restore monitor position after showing
- minify JS
- confirm tests pass with Python and Node

## Testing
- `make minify-js`
- `PYTHONPATH=$PWD pytest -q`
- `node tests/js/formatCurrency.test.js`
- `node tests/js/formatDuration.test.js`
- `node tests/js/main_dom_safety.test.js`
- `node tests/js/main_chart_load.test.js`
- `node tests/js/normalizeHashrate.test.js`
- `node tests/js/arrowIndicator.test.js`
- `node tests/js/audioCrossfadeTheme.test.js`
- `node tests/js/blockProbability.test.js`
- `node tests/js/notificationsTimestamp.test.js`
- `node tests/js/workerUtils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6847824a6f04832094f1a05ca6358389