### PR TITLE
Fix currency conversion bug in notification service

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -856,6 +856,11 @@ class NotificationService:
                         except (ValueError, TypeError):
                             profit_usd = profit_value
                     else:
+                        if old_currency not in exchange_rates:
+                            logging.warning(
+                                f"[NotificationService] Missing exchange rate for {old_currency}, skipping update"
+                            )
+                            continue
                         old_rate = exchange_rates.get(old_currency, 1.0)
                         try:
                             profit_usd = profit_value / old_rate

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -77,7 +77,7 @@ class NotificationCurrencyTest(unittest.TestCase):
         ]
 
     def test_update_notification_currency(self):
-        with patch("notification_service.get_exchange_rates", return_value={"EUR": 0.5}):
+        with patch("notification_service.get_exchange_rates", return_value={"EUR": 0.5, "USD": 1.0}):
             updated = self.service.update_notification_currency("EUR")
 
         self.assertEqual(updated, 1)
@@ -117,6 +117,19 @@ class NotificationCurrencyTest(unittest.TestCase):
         notif = self.service.notifications[0]
         self.assertEqual(notif["data"]["currency"], "USD")
         self.assertAlmostEqual(notif["data"]["daily_profit"], 10.0)
+
+    def test_update_notification_currency_missing_old_rate(self):
+        """Skip update when existing currency has no exchange rate."""
+        self.service.notifications[0]["data"]["currency"] = "JPY"
+        self.service.notifications[0]["data"]["daily_profit"] = 1500.0
+
+        with patch("notification_service.get_exchange_rates", return_value={"USD": 1.0}):
+            updated = self.service.update_notification_currency("USD")
+
+        self.assertEqual(updated, 0)
+        notif = self.service.notifications[0]
+        self.assertEqual(notif["data"]["currency"], "JPY")
+        self.assertEqual(notif["data"]["daily_profit"], 1500.0)
 
     def test_parse_timestamp_with_z_suffix(self):
         with patch("notification_service.get_timezone", return_value="UTC"):


### PR DESCRIPTION
## Summary
- handle missing exchange rate for existing notification currency
- test update_notification_currency with unknown original rate

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68479c2da77883209c18023492566655