### PR TITLE
Enable Matrix theme via mobile card taps

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ informed with minimal fuss.
 
 ### Secret Matrix Theme
 - **Activation**: Enable the easter egg with the Konami code and then enter `MATRIX` to reveal a green Matrix-style look. Now includes an animated matrix rain background for extra immersion.
+- **Mobile Shortcut**: While the easter egg is active, tap any card header ten times quickly to jump straight into the Matrix theme.
 - **Authentic Rain**: Characters fall from a mixed set of Katakana, letters, digits and symbols, with rare hidden words like `OCEAN`, `BITCOIN` and `MATRIX`, rendered in a variety of monospace fonts for a more cinematic feel.
 - **Random Rotation**: Each character now rotates slightly at random as it falls, creating a dynamic cascade.
 

--- a/static/js/easterEgg.js
+++ b/static/js/easterEgg.js
@@ -293,6 +293,35 @@
 
   window.addEventListener('keydown', handleKey);
 
+  // --- Mobile Matrix Theme Activation ---
+  let headerTaps = [];
+
+  /**
+   * Track taps on card headers and enable the Matrix theme when
+   * 10 taps occur within two seconds while the easter egg is active.
+   */
+  function handleHeaderTap() {
+    const now = Date.now();
+    headerTaps.push(now);
+    headerTaps = headerTaps.filter(t => now - t < 2000);
+    const active = document.body.classList.contains('easterEggActive') ||
+                   localStorage.getItem('easterEggActive') === 'true';
+    if (headerTaps.length >= 10 && active) {
+      headerTaps = [];
+      activateMatrixTheme();
+    }
+  }
+
+  /**
+   * Listener for clicks or touches on card headers.
+   */
+  function headerListener(e) {
+    const target = e.target.closest('.card-header');
+    if (target) {
+      handleHeaderTap();
+    }
+  }
+
   function handleCursorClick() {
     const now = Date.now();
     cursorClicks.push(now);
@@ -309,6 +338,9 @@
       handleCursorClick();
     }
   }
+
+  window.addEventListener('click', headerListener);
+  window.addEventListener('touchstart', headerListener);
 
   window.addEventListener('click', cursorListener);
   window.addEventListener('touchstart', cursorListener);


### PR DESCRIPTION
## Summary
- allow mobile users to trigger the Matrix theme by tapping any card header ten times while the easter egg is active
- document the mobile shortcut for the Matrix theme

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684852dc98b08320815c512084ddaba8