### PR TITLE
Fix Redis state loading when values returned as strings

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -403,7 +403,11 @@ class StateManager:
         try:
             state_json = self.redis_client.get("critical_state")
             if state_json:
-                state = json.loads(state_json.decode("utf-8"))
+                if isinstance(state_json, bytes):
+                    state_json = state_json.decode("utf-8")
+                else:
+                    state_json = str(state_json)
+                state = json.loads(state_json)
                 last_successful_run = state.get("last_successful_run")
                 last_update_time = state.get("last_update_time")
 

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -206,6 +206,19 @@ def test_persist_critical_state_and_load():
     assert last_update == 300
 
 
+def test_load_critical_state_handles_str():
+    mgr = StateManager()
+    mgr.redis_client = DummyRedis()
+
+    state = {"last_successful_run": 1, "last_update_time": 2, "cached_metrics_timestamp": 3}
+    # Store raw string rather than bytes
+    mgr.redis_client.storage["critical_state"] = json.dumps(state)
+
+    last_run, last_update = mgr.load_critical_state()
+    assert last_run == 1
+    assert last_update == 2
+
+
 def test_prune_old_data():
     mgr = StateManager()
     mgr.redis_client = DummyRedis()


### PR DESCRIPTION
## Summary
- handle string values when loading critical state from Redis
- test loading critical state with string data

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848785a177c83208fe374c2abf7204d