### PR TITLE
Fix payout history memory leak

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -27,6 +27,8 @@ MAX_HISTORY_ENTRIES = 180  # 3 hours worth at 1 min intervals
 MAX_VARIANCE_HISTORY_ENTRIES = 180  # 3 hours at 1 min intervals
 # Maximum number of minutes to autofill when variance data is missing
 MAX_FILL_GAP_MINUTES = 3
+# Limit for stored payout records to prevent memory leaks
+MAX_PAYOUT_HISTORY_ENTRIES = 100
 
 # Lock for thread safety
 state_lock = threading.Lock()
@@ -688,6 +690,10 @@ class StateManager:
     def save_payout_history(self, history):
         """Save payout history to Redis and memory."""
         try:
+            # Trim to the most recent MAX_PAYOUT_HISTORY_ENTRIES records
+            if len(history) > MAX_PAYOUT_HISTORY_ENTRIES:
+                history = history[:MAX_PAYOUT_HISTORY_ENTRIES]
+
             self.payout_history = history
             if self.redis_client:
                 self.redis_client.set("payout_history", json.dumps(history))

--- a/tests/test_payout_history_limit.py
+++ b/tests/test_payout_history_limit.py
@@ -1,0 +1,10 @@
+import importlib
+import state_manager
+
+
+def test_save_payout_history_prunes(monkeypatch):
+    App = importlib.reload(importlib.import_module('App'))
+    mgr = App.state_manager
+    long_history = [{"id": i} for i in range(state_manager.MAX_PAYOUT_HISTORY_ENTRIES + 5)]
+    mgr.save_payout_history(long_history)
+    assert len(mgr.get_payout_history()) == state_manager.MAX_PAYOUT_HISTORY_ENTRIES


### PR DESCRIPTION
## Summary
- cap payout history length in StateManager to avoid memory buildup
- test that saving long history prunes to max entries

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487876a7948320bb6c9429a13c4901