### PR TITLE
Improve Matrix theme boot text visibility

### DIFF
--- a/static/css/easter-egg.css
+++ b/static/css/easter-egg.css
@@ -32,6 +32,7 @@
 
 #matrixOverlay.matrix {
   color: #39ff14;
+  font-size: 4rem;
 }
 
 #easterEggOverlay .whale,
@@ -85,6 +86,10 @@
 @media (max-width: 600px) {
   #easterEggOverlay {
     font-size: 1.2rem;
+  }
+
+  #matrixOverlay {
+    font-size: 2rem;
   }
 
   #easterEggOverlay .whale,


### PR DESCRIPTION
## Summary
- enlarge Matrix theme overlay text
- add responsive size adjustment for small screens

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_684887e8409883209e53cb06da015fce