### PR TITLE
Theme-aware refresh button

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1747,8 +1747,12 @@ function showConnectionIssue(message) {
     }
     $connectionStatus.html(`<i class="fas fa-exclamation-triangle"></i> ${message}`).show();
 
-    // Show manual refresh button with theme color
-    $("#refreshButton").css('background-color', theme.PRIMARY).show();
+    // Show manual refresh button with theme color and appropriate text color
+    const textColor = theme === THEME.DEEPSEA ? '#ffffff' : '#000000';
+    $("#refreshButton").css({
+        'background-color': theme.PRIMARY,
+        'color': textColor
+    }).show();
 }
 
 // Helper function to hide connection issue message
@@ -4733,8 +4737,15 @@ $(document).ready(function () {
     // Live block timer update every second
     blockTimerInterval = setInterval(updateBlockTimerValue, 1000);
 
-    // Update the manual refresh button color
-    $("body").append('<button id="refreshButton" style="position: fixed; bottom: 20px; left: 20px; z-index: 1000; background: #0088cc; color: white; border: none; padding: 8px 16px; display: none; cursor: pointer;">Refresh Data</button>');
+    // Add manual refresh button and style it based on theme
+    $("body").append('<button id="refreshButton" style="position: fixed; bottom: 20px; left: 20px; z-index: 1000; border: none; padding: 8px 16px; display: none; cursor: pointer;">Refresh Data</button>');
+
+    const theme = getCurrentTheme();
+    const refreshTextColor = theme === THEME.DEEPSEA ? '#ffffff' : '#000000';
+    $("#refreshButton").css({
+        'background-color': theme.PRIMARY,
+        'color': refreshTextColor
+    });
 
     $("#refreshButton").on("click", function () {
         $(this).text("Refreshing...");

--- a/templates/error.html
+++ b/templates/error.html
@@ -10,19 +10,26 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/error.css') }}">
     <!-- Add theme.js script for theme awareness -->
     <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
-    <script>// Apply theme class on page load
-    document.addEventListener('DOMContentLoaded', function() {
-      // Check if DeepSea theme is active
-      const useDeepSea = localStorage.getItem('useDeepSeaTheme') === 'true';
-      if (useDeepSea) {
+    <script>
+    // Apply theme class on page load
+    document.addEventListener('DOMContentLoaded', function () {
+      const useMatrix = localStorage.getItem('useMatrixTheme') === 'true';
+      const useDeepSea = !useMatrix && localStorage.getItem('useDeepSeaTheme') === 'true';
+
+      if (useMatrix) {
+        document.documentElement.classList.add('matrix-theme');
+      } else if (useDeepSea) {
         document.documentElement.classList.add('deepsea-theme');
 
         // Create underwater effects for DeepSea theme
         const rays = document.createElement('div');
         rays.className = 'underwater-rays';
         document.body.appendChild(rays);
+      } else {
+        document.documentElement.classList.add('bitcoin-theme');
       }
-    });</script>
+    });
+    </script>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
## Summary
- update refresh button style according to current theme
- adjust connection error styling for theme
- make error page apply bitcoin, matrix or deepsea themes

## Testing
- `make minify`

------
https://chatgpt.com/codex/tasks/task_e_6848d159c92c8320b42b526fb6dde8b2