### PR TITLE
Fix payout history trimming bug

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -692,11 +692,11 @@ class StateManager:
         return self.payout_history
 
     def save_payout_history(self, history):
-        """Save payout history to Redis and memory."""
+        """Save payout history to Redis and memory, keeping the newest entries."""
         try:
             # Trim to the most recent MAX_PAYOUT_HISTORY_ENTRIES records
             if len(history) > MAX_PAYOUT_HISTORY_ENTRIES:
-                history = history[:MAX_PAYOUT_HISTORY_ENTRIES]
+                history = history[-MAX_PAYOUT_HISTORY_ENTRIES:]
 
             self.payout_history = history
             if self.redis_client:

--- a/tests/test_payout_history_limit.py
+++ b/tests/test_payout_history_limit.py
@@ -8,3 +8,6 @@ def test_save_payout_history_prunes(monkeypatch):
     long_history = [{"id": i} for i in range(state_manager.MAX_PAYOUT_HISTORY_ENTRIES + 5)]
     mgr.save_payout_history(long_history)
     assert len(mgr.get_payout_history()) == state_manager.MAX_PAYOUT_HISTORY_ENTRIES
+    saved = mgr.get_payout_history()
+    assert saved[0]["id"] == 5
+    assert saved[-1]["id"] == state_manager.MAX_PAYOUT_HISTORY_ENTRIES + 4


### PR DESCRIPTION
## Summary
- keep latest payout entries instead of earliest when pruning history
- test that payout history saves the newest entries

## Testing
- `ruff check state_manager.py tests/test_payout_history_limit.py`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848dc547c2c8320a87c3b5d2ec93530