### PR TITLE
Fix matrix rain grey outline

### DIFF
--- a/static/js/matrixRain.js
+++ b/static/js/matrixRain.js
@@ -64,7 +64,7 @@
         }
 
         function draw() {
-            ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
+            ctx.fillStyle = 'rgba(0, 0, 0, 1)';
             ctx.fillRect(0, 0, width, height);
             ctx.fillStyle = '#39ff14';
 


### PR DESCRIPTION
## Summary
- fix matrix rain so the background clears to solid black

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848f48bce388320b61fbe50ad924e7f