### PR TITLE
Fix event listener leak in progress bar

### DIFF
--- a/static/js/BitcoinProgressBar.js
+++ b/static/js/BitcoinProgressBar.js
@@ -615,6 +615,23 @@ const BitcoinMinuteRefresh = (function () {
     }
 
     /**
+     * Clean up event listeners and timers to prevent memory leaks
+     */
+    function cleanup() {
+        detachDragBehavior();
+        window.removeEventListener('storage', handleStorageChange);
+        document.removeEventListener('visibilitychange', handleVisibilityChange);
+        if (uptimeInterval) {
+            clearInterval(uptimeInterval);
+            uptimeInterval = null;
+        }
+        if (healthInterval) {
+            clearInterval(healthInterval);
+            healthInterval = null;
+        }
+    }
+
+    /**
      * Add snapping functionality to the draggable terminal
      */
     function addSnappingBehavior() {
@@ -1962,7 +1979,8 @@ const BitcoinMinuteRefresh = (function () {
         toggleTerminal: toggleTerminal,
         hideTerminal: hideTerminal,
         showTerminal: showTerminal,
-        updateTheme: applyThemeColor
+        updateTheme: applyThemeColor,
+        cleanup: cleanup
     };
 })();
 
@@ -1977,4 +1995,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Update theme based on current setting
     setTimeout(() => BitcoinMinuteRefresh.updateTheme(), 100);
+});
+
+// Ensure resources are released when navigating away
+window.addEventListener('beforeunload', function () {
+    if (window.BitcoinMinuteRefresh && typeof BitcoinMinuteRefresh.cleanup === 'function') {
+        BitcoinMinuteRefresh.cleanup();
+    }
 });


### PR DESCRIPTION
## Summary
- clean up drag and page event listeners
- expose cleanup method and call on page unload
- regenerate minified assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fe2a3b6c8320b8940f542de93704