### PR TITLE
Fix currency normalization

### DIFF
--- a/config.py
+++ b/config.py
@@ -169,13 +169,13 @@ def get_currency():
 
     env_currency = os.environ.get("CURRENCY")
     if env_currency:
-        return env_currency
+        return str(env_currency).upper()
 
     # Then check config file
     config = load_config()
     currency = config.get("currency")
     if currency:
-        return currency
+        return str(currency).upper()
 
     # Default to USD
     return "USD"

--- a/tests/test_config_helpers.py
+++ b/tests/test_config_helpers.py
@@ -56,8 +56,22 @@ def test_get_currency_env(monkeypatch, tmp_path):
     assert mod.get_currency() == "EUR"
 
 
+def test_get_currency_env_lowercase(monkeypatch, tmp_path):
+    path = create_config(tmp_path, currency="GBP")
+    mod = reload_config(monkeypatch, path)
+    monkeypatch.setenv("CURRENCY", "eur")
+    assert mod.get_currency() == "EUR"
+
+
 def test_get_currency_config(monkeypatch, tmp_path):
     path = create_config(tmp_path, currency="AUD")
+    mod = reload_config(monkeypatch, path)
+    monkeypatch.delenv("CURRENCY", raising=False)
+    assert mod.get_currency() == "AUD"
+
+
+def test_get_currency_config_lowercase(monkeypatch, tmp_path):
+    path = create_config(tmp_path, currency="aud")
     mod = reload_config(monkeypatch, path)
     monkeypatch.delenv("CURRENCY", raising=False)
     assert mod.get_currency() == "AUD"


### PR DESCRIPTION
## Summary
- normalize currency codes in `get_currency`
- test lowercase env and config values

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `for f in *.test.js; do node $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_6849fe24757883209fccc6266068f0d3