### PR TITLE
Improve comments and docstrings

### DIFF
--- a/App.py
+++ b/App.py
@@ -1328,7 +1328,13 @@ def memory_history():
 
 @app.route("/api/force-gc", methods=["POST"])
 def force_gc():
-    """API endpoint to force garbage collection."""
+    """Force Python's garbage collector to run.
+
+    The optional JSON payload may include a ``generation`` key specifying
+    which GC generation to target (0-2). The endpoint returns statistics
+    about the collection including number of objects collected and the
+    duration of the run.
+    """
     try:
         generation = request.json.get("generation", 2) if request.is_json else 2
 
@@ -1493,7 +1499,13 @@ def reset_chart_data():
 
 @app.route("/api/payout-history", methods=["GET", "POST", "DELETE"])
 def payout_history():
-    """API endpoint to manage payout history."""
+    """Manage payout history through a simple REST style interface.
+
+    * ``GET`` returns the currently stored payout history.
+    * ``POST`` accepts either a full ``history`` list or a single ``record``
+      dictionary to prepend to the history.
+    * ``DELETE`` clears all stored payout data.
+    """
     try:
         if request.method == "GET":
             history = state_manager.get_payout_history()

--- a/error_handlers.py
+++ b/error_handlers.py
@@ -1,7 +1,11 @@
+"""Flask error handling utilities used across the dashboard."""
+
 import logging
 from flask import Blueprint, render_template
 
-errors = Blueprint('errors', __name__)
+# Blueprint that holds the error handler routes. This object is imported by
+# the main application when registering blueprints.
+errors = Blueprint("errors", __name__)
 
 @errors.app_errorhandler(404)
 def page_not_found(error):

--- a/worker_service.py
+++ b/worker_service.py
@@ -383,7 +383,9 @@ class WorkerService:
         Returns:
             dict: Generated worker data
         """
-        # If metrics aren't available yet, return default data
+        # If metrics aren't available yet, return default data. This ensures the
+        # frontend still renders something even if the initial network request
+        # fails or the pool is unreachable.
         if not cached_metrics:
             logging.warning("No cached metrics available for worker fallback data")
             return self.generate_default_workers_data()
@@ -404,7 +406,8 @@ class WorkerService:
             logging.warning("No workers reported in metrics, forcing 1 worker")
             workers_count = 1
 
-        # Get hashrate from cached metrics
+        # Pull the 3 hour hashrate from cached metrics. This is used as the base
+        # to evenly distribute hashrate across the simulated workers.
         original_hashrate_3hr = float(cached_metrics.get("hashrate_3hr", 0) or 0)
         hashrate_unit = cached_metrics.get("hashrate_3hr_unit", "TH/s")
 


### PR DESCRIPTION
## Summary
- add module and blueprint docstrings in `error_handlers`
- expand explanations in `cache_utils.ttl_cache`
- clarify fallback worker generation comments
- document payout history API usage
- describe forced garbage collection endpoint

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fea0015c8320ae668d955404a354