### PR TITLE
Add getBlockTimerClass front-end test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         node tests/js/normalizeHashrate.test.js
         node tests/js/arrowIndicator.test.js
         node tests/js/audioCrossfadeTheme.test.js
+        node tests/js/getBlockTimerClass.test.js
         node tests/js/blockProbability.test.js
         node tests/js/notificationsTimestamp.test.js
         node tests/js/workerUtils.test.js

--- a/tests/js/getBlockTimerClass.test.js
+++ b/tests/js/getBlockTimerClass.test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const filePath = path.join(__dirname, '../../static/js/main.js');
+const lines = fs.readFileSync(filePath, 'utf8').split('\n');
+const start = lines.findIndex(l => l.includes('function getBlockTimerClass'));
+let end = start;
+while (end < lines.length && !lines[end].startsWith('}')) {
+    end++;
+}
+const snippet = lines.slice(start, end + 1).join('\n');
+
+const context = {};
+vm.createContext(context);
+vm.runInContext(snippet, context);
+
+assert.strictEqual(context.getBlockTimerClass(0), 'very-lucky');
+assert.strictEqual(context.getBlockTimerClass(8 * 60 - 1), 'very-lucky');
+assert.strictEqual(context.getBlockTimerClass(8 * 60), 'lucky');
+assert.strictEqual(context.getBlockTimerClass(10 * 60 - 1), 'lucky');
+assert.strictEqual(context.getBlockTimerClass(10 * 60), 'normal-luck');
+assert.strictEqual(context.getBlockTimerClass(12 * 60), 'normal-luck');
+assert.strictEqual(context.getBlockTimerClass(12 * 60 + 1), 'unlucky');
+
+console.log('getBlockTimerClass tests passed');


### PR DESCRIPTION
## Summary
- add tests for `getBlockTimerClass` in the main.js front-end logic
- run the new test in CI with the rest of the Node tests

## Testing
- `PYTHONPATH=$PWD pytest`
- `node tests/js/formatCurrency.test.js`
- `node tests/js/formatDuration.test.js`
- `node tests/js/main_dom_safety.test.js`
- `node tests/js/main_chart_load.test.js`
- `node tests/js/normalizeHashrate.test.js`
- `node tests/js/arrowIndicator.test.js`
- `node tests/js/audioCrossfadeTheme.test.js`
- `node tests/js/getBlockTimerClass.test.js`
- `node tests/js/blockProbability.test.js`
- `node tests/js/notificationsTimestamp.test.js`
- `node tests/js/workerUtils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6849fe4ce7a08320a8892f65cd64326b