### PR TITLE
Fix zero-value redis retrieval

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -204,7 +204,7 @@ class NotificationService:
         try:
             if hasattr(self.state_manager, "redis_client") and self.state_manager.redis_client:
                 value = self.state_manager.redis_client.get(key)
-                if value:
+                if value is not None:
                     return value.decode("utf-8")
             return default
         except Exception as e:

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -202,5 +202,18 @@ class NotificationCurrencyTest(unittest.TestCase):
         self.assertTrue(resp.closed)
 
 
+class RedisValueTest(unittest.TestCase):
+    def test_get_redis_value_zero(self):
+        class DummyRedis:
+            def get(self, key):
+                return b"0"
+
+        state = DummyStateManager()
+        state.redis_client = DummyRedis()
+        svc = NotificationService(state)
+        result = svc._get_redis_value("val", "default")
+        self.assertEqual(result, "0")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle zero values correctly when fetching from Redis in `NotificationService`
- add regression test for `_get_redis_value`

## Testing
- `ruff check notification_service.py tests/test_notification_service.py`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1425c9f8832096c2c273605cb7de