### PR TITLE
Fix currency formatting for string inputs

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -57,13 +57,18 @@ def get_currency_symbol(currency):
 
 
 def format_currency_value(value, currency, exchange_rates):
-    """Format a USD value in the selected currency"""
+    """Format a USD value in the selected currency."""
     if value is None or value == "N/A":
         return "N/A"
 
-    # Get exchange rate (default to 1.0 if not found)
+    try:
+        numeric_value = float(str(value).replace(",", ""))
+    except (TypeError, ValueError):
+        logging.error("Invalid currency value: %s", value)
+        return "N/A"
+
     exchange_rate = exchange_rates.get(currency, 1.0)
-    converted_value = value * exchange_rate
+    converted_value = numeric_value * exchange_rate
 
     # Get currency symbol
     symbol = get_currency_symbol(currency)

--- a/tests/test_format_currency_value.py
+++ b/tests/test_format_currency_value.py
@@ -1,0 +1,44 @@
+import types
+import sys
+
+# Provide lightweight pytz and requests stubs if not available
+if 'pytz' not in sys.modules:
+    tz_module = types.ModuleType('pytz')
+
+    class DummyTZInfo:
+        def utcoffset(self, dt):
+            return None
+        def dst(self, dt):
+            return None
+        def tzname(self, dt):
+            return 'UTC'
+        def localize(self, dt_obj):
+            return dt_obj.replace(tzinfo=self)
+
+    tz_module.timezone = lambda name: DummyTZInfo()
+    sys.modules['pytz'] = tz_module
+
+if 'requests' not in sys.modules:
+    req_module = types.ModuleType('requests')
+
+    class DummySession:
+        def get(self, *args, **kwargs):
+            raise NotImplementedError
+
+    req_module.Session = DummySession
+    req_module.exceptions = types.SimpleNamespace(Timeout=Exception, ConnectionError=Exception)
+    sys.modules['requests'] = req_module
+
+from notification_service import format_currency_value
+
+
+def test_format_currency_value_with_string():
+    rates = {'EUR': 0.5}
+    result = format_currency_value('10', 'EUR', rates)
+    assert result == '€5.00'
+
+
+def test_format_currency_value_invalid():
+    rates = {'USD': 1}
+    result = format_currency_value('abc', 'USD', rates)
+    assert result == 'N/A'


### PR DESCRIPTION
## Summary
- robustify `format_currency_value` to handle string numbers and invalid values
- test currency formatting for string and invalid inputs

## Testing
- `ruff .`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a164d5ca48320903c828047c9c4be