### PR TITLE
Fix numeric parse for scientific notation

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -619,7 +619,7 @@ class NotificationService:
             cleaned = value_str.replace(",", "")
             # Remove spaces between a sign and the digits (e.g. "- 1.2" -> "-1.2")
             cleaned = re.sub(r"([+-])\s+(?=\d)", r"\1", cleaned).strip()
-            match = re.search(r"[-+]?\d*\.?\d+", cleaned)
+            match = re.search(r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?", cleaned)
             if match:
                 try:
                     return float(match.group(0))

--- a/tests/test_parse_numeric_value.py
+++ b/tests/test_parse_numeric_value.py
@@ -74,3 +74,9 @@ def test_parse_numeric_value_with_sign_and_space():
     """Negative values with spaces after the sign should parse correctly."""
     svc = NotificationService(DummyState())
     assert svc._parse_numeric_value("- 2,000.5 TH/s") == pytest.approx(-2000.5)
+
+
+def test_parse_numeric_value_with_exponent():
+    svc = NotificationService(DummyState())
+    assert svc._parse_numeric_value("1e2") == pytest.approx(100)
+    assert svc._parse_numeric_value("-3.5e3 TH/s") == pytest.approx(-3500)


### PR DESCRIPTION
## Summary
- handle scientific notation in `_parse_numeric_value`
- add regression test for exponential numeric strings

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a315b9d3c8320a5ff0ec09c9121db