### PR TITLE
Optimize SSE with event-based updates

### DIFF
--- a/tests/test_metrics_event.py
+++ b/tests/test_metrics_event.py
@@ -1,0 +1,39 @@
+import importlib
+
+
+def test_update_metrics_sets_event(monkeypatch):
+    App = importlib.reload(importlib.import_module("App"))
+
+    class DummyTimer:
+        def __init__(self, timeout, handler):
+            self.timeout = timeout
+            self.handler = handler
+        def start(self):
+            pass
+        def cancel(self):
+            pass
+        def is_alive(self):
+            return False
+        def join(self):
+            pass
+
+    monkeypatch.setattr(App.threading, "Timer", DummyTimer)
+    monkeypatch.setattr(App.dashboard_service, "fetch_metrics", lambda: {"server_timestamp": 1})
+    monkeypatch.setattr(App.notification_service, "check_and_generate_notifications", lambda *a, **k: None)
+    monkeypatch.setattr(App.state_manager, "update_metrics_history", lambda metrics: None)
+    monkeypatch.setattr(App.state_manager, "persist_critical_state", lambda *a, **k: None)
+    monkeypatch.setattr(App.state_manager, "prune_old_data", lambda *a, **k: None)
+    monkeypatch.setattr(App.state_manager, "save_graph_state", lambda: None)
+    monkeypatch.setattr(App, "adaptive_gc", lambda: False)
+    monkeypatch.setattr(App, "log_memory_usage", lambda: None)
+    monkeypatch.setattr(App.notification_service, "add_notification", lambda *a, **k: None)
+    monkeypatch.setattr(App, "load_config", lambda: {})
+    monkeypatch.setitem(App.MEMORY_CONFIG, "ADAPTIVE_GC_ENABLED", False)
+
+    events = {"set": False}
+    monkeypatch.setattr(App.metrics_update_event, "set", lambda: events.__setitem__("set", True))
+
+    App.update_metrics_job(force=True)
+
+    assert events["set"]
+

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -27,6 +27,8 @@ def sse_client(monkeypatch):
     monkeypatch.setattr(App, "update_metrics_job", lambda force=False: None)
     monkeypatch.setattr(App, "MiningDashboardService", lambda *a, **k: object())
     monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
+    monkeypatch.setattr(App.metrics_update_event, "wait", lambda timeout=None: False)
+    monkeypatch.setattr(App.metrics_update_event, "clear", lambda: None)
 
     sample_cfg = {"wallet": "w"}
     monkeypatch.setattr(App, "load_config", lambda: sample_cfg)


### PR DESCRIPTION
## Summary
- trigger an event whenever metrics are refreshed
- make SSE loop wait on the event instead of polling every second
- adjust tests for the new event-based behaviour
- test that the event flag is set on update

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3260a2bc83208b7aff22b20b0d79