### PR TITLE
Update DATUM offline icon

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -590,6 +590,21 @@ html.deepsea-theme .toggle-btn.active {
   opacity: 0.7;
 }
 
+/* ----- DATUM PLUG ICON ----- */
+.datum-plug {
+  display: inline-block;
+  margin-left: 6px;
+  font-size: 0.75rem;
+  position: relative;
+  top: -1px;
+}
+
+.datum-plug-offline {
+  color: #ff5555;
+  text-shadow: 0 0 3px #ff5555;
+  opacity: 0.7;
+}
+
 /* Theme-specific colors for the satellite dish */
 html.deepsea-theme .satellite-dish-connected {
   color: #32cd32; /* Use same green for consistency */

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2060,11 +2060,11 @@ function updateWorkersCount() {
             updateElementHTML("miner_status", "<span class='status-red'>OFFLINE</span> <span class='retro-led-offline'></span>");
         }
 
-        // Update DATUM GATEWAY status with satellite dish icon
+        // Update DATUM GATEWAY status icon
         if (latestMetrics.pool_fees_percentage !== undefined && latestMetrics.pool_fees_percentage >= 0.9 && latestMetrics.pool_fees_percentage <= 1.3) {
             updateElementHTML("datum_status", "<span class='status-green'>CONNECTED</span> <i class='fa-solid fa-satellite-dish satellite-dish satellite-dish-connected'></i>");
         } else {
-            updateElementHTML("datum_status", "<span class='status-red'>OFFLINE</span> <i class='fa-solid fa-satellite-dish satellite-dish satellite-dish-offline'></i>");
+            updateElementHTML("datum_status", "<span class='status-red'>OFFLINE</span> <i class='fa-solid fa-plug-circle-xmark datum-plug datum-plug-offline'></i>");
         }
     }
 }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -49,7 +49,7 @@
                             {% if metrics.pool_fees_percentage >= 0.9 and metrics.pool_fees_percentage <= 1.3 %}
                             <span class="status-green">CONNECTED</span> <i class="fa-solid fa-satellite-dish satellite-dish satellite-dish-connected"></i>
                             {% else %}
-                            <span class="status-red">OFFLINE</span> <i class="fa-solid fa-satellite-dish satellite-dish satellite-dish-offline"></i>
+                            <span class="status-red">OFFLINE</span> <i class="fa-solid fa-plug-circle-xmark datum-plug datum-plug-offline"></i>
                             {% endif %}
                         {% else %}
                         N/A


### PR DESCRIPTION
## Summary
- show a plug-circle-xmark icon when DATUM gateway is offline
- style new datum plug icon in dashboard css
- adjust JS updater for DATUM status

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a5667d45c8320a7d592e518de6caa