### PR TITLE
Fix Redis string handling

### DIFF
--- a/notification_service.py
+++ b/notification_service.py
@@ -210,7 +210,9 @@ class NotificationService:
             if hasattr(self.state_manager, "redis_client") and self.state_manager.redis_client:
                 value = self.state_manager.redis_client.get(key)
                 if value is not None:
-                    return value.decode("utf-8")
+                    if isinstance(value, (bytes, bytearray)):
+                        return value.decode("utf-8")
+                    return str(value)
             return default
         except Exception as e:
             logging.error(f"[NotificationService] Error retrieving {key} from Redis: {e}")

--- a/tests/test_notification_service.py
+++ b/tests/test_notification_service.py
@@ -214,6 +214,18 @@ class RedisValueTest(unittest.TestCase):
         result = svc._get_redis_value("val", "default")
         self.assertEqual(result, "0")
 
+    def test_get_redis_value_str(self):
+        class DummyRedis:
+            def get(self, key):
+                return "1"  # return a plain string instead of bytes
+
+        state = DummyStateManager()
+        state.redis_client = DummyRedis()
+        svc = NotificationService(state)
+
+        result = svc._get_redis_value("val", "default")
+        self.assertEqual(result, "1")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- handle non-bytes values in NotificationService `_get_redis_value`
- test redis values that return strings

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeef32e448320972b3f83b5534e96