### PR TITLE
Fix memory leak on service cleanup

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -172,7 +172,11 @@ class MiningDashboardService:
 
     def __del__(self):
         """Ensure resources are released when the service is garbage collected."""
-        self.close()
+        try:
+            if not getattr(self, "_closed", False):
+                self.close()
+        except Exception:
+            pass
 
     def fetch_metrics(self):
         """


### PR DESCRIPTION
## Summary
- ensure MiningDashboardService doesn't try to log while finalizing

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeefa5af48320afabcaf598e4502d