### PR TITLE
Fix logging on repeated service close

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -122,7 +122,16 @@ class MiningDashboardService:
     def close(self):
         """Close any open network resources."""
         if getattr(self, "_closed", False):
-            logging.warning("Service already closed")
+            root_logger = logging.getLogger()
+            try:
+                # Only log if at least one handler has an open stream
+                if any(
+                    getattr(h, "stream", None) and not getattr(h.stream, "closed", False)
+                    for h in root_logger.handlers
+                ):
+                    logging.warning("Service already closed")
+            except Exception:
+                pass
             return
 
         self._closed = True

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -736,6 +736,26 @@ def test_close_clears_resources(monkeypatch):
     assert svc.executor is None
 
 
+def test_close_handles_closed_logging_stream(monkeypatch):
+    """Calling close twice should not error even if logging streams are closed."""
+    svc = MiningDashboardService(0, 0, "w")
+    import logging
+    import io
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger()
+    logger.addHandler(handler)
+
+    svc.close()
+    stream.close()
+
+    # Should not raise even though the handler stream is closed
+    svc.close()
+
+    logger.removeHandler(handler)
+
+
 def test_fetch_metrics_cancels_futures(monkeypatch):
     """Futures should be cancelled when fetch_metrics times out."""
     svc = MiningDashboardService(0, 0, "w")


### PR DESCRIPTION
## Summary
- improve the close logic in `MiningDashboardService`
- add regression test for closing with a closed logging stream

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b465f293483209ddcc3584aeada78