### PR TITLE
Fix worker service resource cleanup

### DIFF
--- a/App.py
+++ b/App.py
@@ -1885,6 +1885,13 @@ def graceful_shutdown(signum, frame):
         except Exception as e:
             logging.error(f"Error closing dashboard service: {e}")
 
+    # Close worker service
+    if worker_service:
+        try:
+            worker_service.close()
+        except Exception as e:
+            logging.error(f"Error closing worker service: {e}")
+
     # Close state manager resources
     if state_manager:
         try:

--- a/tests/test_worker_service.py
+++ b/tests/test_worker_service.py
@@ -252,3 +252,16 @@ def test_service_worker_cycle_collected(monkeypatch):
 
     assert ref_svc() is None
     assert ref_ws() is None
+
+
+def test_worker_service_close_clears_cache(monkeypatch):
+    """close() should clear cached data and drop dashboard reference."""
+    ws = WorkerService()
+    ws.worker_data_cache = {"dummy": True}
+    ws.last_worker_data_update = 1.0
+    svc = MiningDashboardService(0, 0, "w")
+    ws.set_dashboard_service(svc)
+    ws.close()
+    assert ws.worker_data_cache is None
+    assert ws.last_worker_data_update is None
+    assert ws.dashboard_service is None

--- a/worker_service.py
+++ b/worker_service.py
@@ -47,6 +47,12 @@ class WorkerService:
             logging.info(f"Worker service updated with new wallet: {self.wallet}")
         logging.info("Dashboard service connected to worker service")
 
+    def close(self):
+        """Release cached data and drop service references."""
+        self.worker_data_cache = None
+        self.last_worker_data_update = None
+        self.dashboard_service = None
+
     def generate_default_workers_data(self):
         """
         Generate default worker data when no metrics are available.


### PR DESCRIPTION
## Summary
- add `WorkerService.close` to free cached data and service reference
- call `worker_service.close` during graceful shutdown
- test the new cleanup logic

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4666f90483209790bb45bdf8ee0f