### PR TITLE
Reset Alt+W sparklines

### DIFF
--- a/App.py
+++ b/App.py
@@ -1487,8 +1487,17 @@ class RobustMiddleware:
 def reset_chart_data():
     """API endpoint to reset chart data history."""
     try:
-        hashrate_keys = ["hashrate_60sec", "hashrate_3hr", "hashrate_10min", "hashrate_24hr"]
-        state_manager.clear_arrow_history(hashrate_keys)
+        clear_all = request.args.get("full") == "1"
+        if clear_all:
+            state_manager.clear_arrow_history()
+        else:
+            hashrate_keys = [
+                "hashrate_60sec",
+                "hashrate_3hr",
+                "hashrate_10min",
+                "hashrate_24hr",
+            ]
+            state_manager.clear_arrow_history(hashrate_keys)
 
         # Force an immediate save to Redis if available
         if state_manager and hasattr(state_manager, "redis_client") and state_manager.redis_client:

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ For optimal performance:
 6. Use hotkey Shift+R to clear chart and Redis data (as needed, not required)
 7. Check the currency settings if financial calculations appear incorrect
 8. Verify timezone settings for accurate time displays
-9. Alt + W on Dashboard resets wallet configuration and redirects to Boot sequence
+9. Alt + W on Dashboard resets wallet configuration and clears all chart and sparkline history before redirecting to the Boot sequence
 10. If block event lines persist, run `window.clearBlockAnnotations()` in your
     browser console to remove them. Events now store full timestamps, so
     annotations should disappear once they fall outside the 3‑hour window.

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -9,7 +9,7 @@ The dashboard supports a few quick keyboard commands to speed up navigation and 
 | **Alt+3** | Open the Earnings page |
 | **Alt+4** | Open the Blocks page |
 | **Alt+5** | Open the Notifications page |
-| **Alt+W** | Reset wallet address and chart data |
+| **Alt+W** | Reset wallet address, chart data, and sparkline history |
 | **Shift+R** | Reset the Dashboard chart |
 | **Esc** | Close any open block modal |
 

--- a/static/js/blocks.js
+++ b/static/js/blocks.js
@@ -283,7 +283,7 @@ function resetWalletAddress() {
     if (confirm("Are you sure you want to reset your wallet address? This will also clear all chart data and redirect you to the configuration page.")) {
         // First clear chart data using the existing API endpoint
         $.ajax({
-            url: '/api/reset-chart-data',
+            url: '/api/reset-chart-data?full=1',
             method: 'POST',
             success: function () {
                 console.log("Chart data reset successfully");

--- a/static/js/earnings.js
+++ b/static/js/earnings.js
@@ -265,7 +265,7 @@ function resetWalletAddress() {
     if (confirm("Are you sure you want to reset your wallet address? This will also clear all chart data and redirect you to the configuration page.")) {
         // First clear chart data using the existing API endpoint
         $.ajax({
-            url: '/api/reset-chart-data',
+            url: '/api/reset-chart-data?full=1',
             method: 'POST',
             success: function () {
                 console.log("Chart data reset successfully");

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3901,7 +3901,7 @@ function resetWalletAddress() {
     if (confirm("Are you sure you want to reset your wallet address? This will also clear all chart data and redirect you to the configuration page.")) {
         // First clear chart data using the existing API endpoint
         $.ajax({
-            url: '/api/reset-chart-data',
+            url: '/api/reset-chart-data?full=1',
             method: 'POST',
             success: function () {
                 console.log("Chart data reset successfully");

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -524,7 +524,7 @@ function resetWalletAddress() {
     if (confirm("Are you sure you want to reset your wallet address? This will also clear all chart data and redirect you to the configuration page.")) {
         // First clear chart data using the existing API endpoint
         $.ajax({
-            url: '/api/reset-chart-data',
+            url: '/api/reset-chart-data?full=1',
             method: 'POST',
             success: function () {
                 console.log("Chart data reset successfully");

--- a/static/js/workers.js
+++ b/static/js/workers.js
@@ -401,7 +401,7 @@ function resetWalletAddress() {
     if (confirm("Are you sure you want to reset your wallet address? This will also clear all chart data and redirect you to the configuration page.")) {
         // First clear chart data using the existing API endpoint
         $.ajax({
-            url: '/api/reset-chart-data',
+            url: '/api/reset-chart-data?full=1',
             method: 'POST',
             success: function () {
                 console.log("Chart data reset successfully");

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -427,3 +427,33 @@ def test_earnings_returns_generic_error(client, monkeypatch):
     data = resp.get_json()
     assert data["error"] == "internal server error"
 
+
+def test_reset_chart_data_hashrate_only(client):
+    import App
+    from collections import deque
+
+    App.state_manager.arrow_history = {
+        "hashrate_60sec": deque([{"time": "t", "value": 1}], maxlen=180),
+        "temp": deque([{"time": "t", "value": 2}], maxlen=180),
+    }
+
+    resp = client.post("/api/reset-chart-data")
+    assert resp.status_code == 200
+    history = App.state_manager.arrow_history
+    assert "hashrate_60sec" not in history or len(history["hashrate_60sec"]) == 0
+    assert "temp" in history and len(history["temp"]) > 0
+
+
+def test_reset_chart_data_full(client):
+    import App
+    from collections import deque
+
+    App.state_manager.arrow_history = {
+        "hashrate_60sec": deque([{"time": "t", "value": 1}], maxlen=180),
+        "temp": deque([{"time": "t", "value": 2}], maxlen=180),
+    }
+
+    resp = client.post("/api/reset-chart-data?full=1")
+    assert resp.status_code == 200
+    assert App.state_manager.arrow_history == {}
+


### PR DESCRIPTION
## Summary
- clear all sparkline history via `full=1` parameter
- document new Alt+W behavior
- test reset-chart-data endpoint

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4e70787c8320997bf8b8dec6e0ad