### PR TITLE
Fix hotkeys on earnings page

### DIFF
--- a/templates/earnings.html
+++ b/templates/earnings.html
@@ -156,6 +156,8 @@
 {% endblock %}
 
 {% block javascript %}
+{{ super() }}
 <script src="{{ url_for('static', filename='js/formatCurrency.js') }}"></script>
 <script src="{{ url_for('static', filename='js/earnings.js') }}"></script>
+<script src="{{ url_for('static', filename='js/shortcuts.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure hotkeys script loads on earnings view

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`
- `make minify`

------
https://chatgpt.com/codex/tasks/task_e_684d0665e9108320bf35e0d950b1a873