### PR TITLE
Add fallback when payout API unchanged

### DIFF
--- a/App.py
+++ b/App.py
@@ -1058,6 +1058,7 @@ def update_config():
                 merged_config.get("wallet"),
                 network_fee=merged_config.get("network_fee", 0.0),
                 worker_service=worker_service,
+                state_manager=state_manager,
             )
             logging.info(
                 f"Dashboard service reinitialized with new wallet: {merged_config.get('wallet')}"
@@ -1067,6 +1068,8 @@ def update_config():
             worker_service.set_dashboard_service(dashboard_service)
             if hasattr(dashboard_service, "set_worker_service"):
                 dashboard_service.set_worker_service(worker_service)
+            if hasattr(dashboard_service, "set_state_manager"):
+                dashboard_service.set_state_manager(state_manager)
             notification_service.dashboard_service = dashboard_service
             logging.info("Worker service updated with the new dashboard service")
 
@@ -1833,11 +1836,14 @@ dashboard_service = MiningDashboardService(
     config.get("wallet"),
     network_fee=config.get("network_fee", 0.0),
     worker_service=None,
+    state_manager=state_manager,
 )
 worker_service = WorkerService()
 # Connect the services
 if hasattr(dashboard_service, "set_worker_service"):
     dashboard_service.set_worker_service(worker_service)
+if hasattr(dashboard_service, "set_state_manager"):
+    dashboard_service.set_state_manager(state_manager)
 worker_service.set_dashboard_service(dashboard_service)
 notification_service.dashboard_service = dashboard_service
 


### PR DESCRIPTION
## Summary
- add `state_manager` parameter to `MiningDashboardService`
- save payout history and detect unchanged API results
- initialize dashboard service with state manager
- test scraping fallback when API payout history has no new data

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d067b3abc832082fa4b343bb237a7