### PR TITLE
Ensure payout history refreshes regularly

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1734,6 +1734,8 @@ function handleVisibilityChange() {
             setupEventSource();
         }
         manualRefresh(); // Always refresh data when page becomes visible
+        // Ensure payout history is up to date
+        verifyPayoutsAgainstOfficial();
     }
 }
 
@@ -1779,6 +1781,8 @@ function manualRefresh() {
             latestMetrics = data;
 
             updateUI();
+            // Refresh payout history from the earnings API
+            verifyPayoutsAgainstOfficial();
             hideConnectionIssue();
 
             // Notify BitcoinMinuteRefresh that we've refreshed the data


### PR DESCRIPTION
## Summary
- refresh payout history during manual refresh
- reload payout history when page becomes visible

## Testing
- `make minify-js`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d122829188320af9911898328627b