### PR TITLE
Fix payout date parsing

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1510,7 +1510,7 @@ function verifyPayoutsAgainstOfficial() {
 
             // Get official payment records - newest first
             const officialPayments = data.payments.sort((a, b) =>
-                new Date(b.date) - new Date(a.date)
+                new Date(b.date_iso || b.date) - new Date(a.date_iso || a.date)
             );
 
             // Get our detected payouts
@@ -1521,7 +1521,7 @@ function verifyPayoutsAgainstOfficial() {
                 const payoutDate = new Date(detectedPayout.timestamp);
 
                 const matchingPayment = officialPayments.find(payment => {
-                    const paymentDate = new Date(payment.date);
+                    const paymentDate = new Date(payment.date_iso || payment.date);
                     return Math.abs(paymentDate - payoutDate) < (2 * 60 * 60 * 1000) &&
                         Math.abs(parseFloat(payment.amount_btc) - parseFloat(detectedPayout.amountBTC)) < 0.00001;
                 });
@@ -1547,7 +1547,7 @@ function verifyPayoutsAgainstOfficial() {
             thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
             officialPayments.forEach(payment => {
-                const paymentDate = new Date(payment.date);
+                const paymentDate = new Date(payment.date_iso || payment.date);
                 if (paymentDate < thirtyDaysAgo) return; // Skip older than 30 days
 
                 // Check if we already have this payment in our detected list


### PR DESCRIPTION
## Summary
- handle ISO timestamps when checking official payouts

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `make minify`

------
https://chatgpt.com/codex/tasks/task_e_684f83adef7c8320819b502a71148524