### PR TITLE
Add caching to bitcoin stats

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -1215,6 +1215,7 @@ class MiningDashboardService:
                 "timestamp": datetime.now(ZoneInfo(get_timezone())).isoformat(),
             }
 
+    @ttl_cache(ttl_seconds=60, maxsize=1)
     def get_bitcoin_stats(self):
         """
         Fetch Bitcoin network statistics with improved error handling and caching.


### PR DESCRIPTION
## Summary
- add ttl_cache decorator around `get_bitcoin_stats` to avoid repeated network requests

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f8cb8284c8320bf213ee4c8baac2d