### PR TITLE
Update sparkline configuration

### DIFF
--- a/static/js/sparklines.js
+++ b/static/js/sparklines.js
@@ -31,7 +31,7 @@
             'pool_fees_percentage',
             'last_block',
             'est_time_to_payout',
-            'daily_mined_sats',
+            'daily_revenue',
             'monthly_mined_sats',
             'estimated_earnings_per_day_sats',
             'estimated_earnings_next_block_sats',

--- a/tests/test_sparklines_skip_keys.py
+++ b/tests/test_sparklines_skip_keys.py
@@ -13,7 +13,7 @@ def test_sparklines_skip_keys():
         'pool_fees_percentage',
         'last_block',
         'est_time_to_payout',
-        'daily_mined_sats',
+        'daily_revenue',
         'monthly_mined_sats',
         'estimated_earnings_per_day_sats',
         'estimated_earnings_next_block_sats',


### PR DESCRIPTION
## Summary
- add Daily Revenue to sparkline skip list
- allow sparklines for Projected Daily (Net) by removing `daily_mined_sats` from skip list
- update test expectations

## Testing
- `pip install -r requirements.txt`
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f94fcefc883208a9188cc20f2d9d8