### PR TITLE
Fix worker service memory leak

### DIFF
--- a/data_service.py
+++ b/data_service.py
@@ -145,6 +145,14 @@ class MiningDashboardService:
                     except Exception:
                         pass
 
+            # Close associated worker service to prevent memory leaks
+            if self.worker_service and hasattr(self.worker_service, "close"):
+                try:
+                    self.worker_service.close()
+                except Exception:
+                    pass
+            self.worker_service = None
+
             # Cancel any pending futures and shutdown executor
             try:
                 from inspect import signature

--- a/tests/test_service_cleanup.py
+++ b/tests/test_service_cleanup.py
@@ -12,3 +12,25 @@ def test_service_cleanup():
     gc.collect()
     assert ref() is None
 
+
+def test_service_close_closes_worker(monkeypatch):
+    """close() should also close the associated worker service."""
+    svc = MiningDashboardService(0, 0, "w")
+
+    class DummyWorker:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    worker = DummyWorker()
+    svc.set_worker_service(worker)
+
+    monkeypatch.setattr(svc.executor, "shutdown", lambda wait=True, cancel_futures=True: None)
+    monkeypatch.setattr(svc.session, "close", lambda: None, raising=False)
+
+    svc.close()
+
+    assert worker.closed
+


### PR DESCRIPTION
## Summary
- close worker service when dashboard service closes
- test closing dashboard service closes worker service

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f97f236cc8320a7f464389dba8299