### PR TITLE
Fix TTL cache maxsize=0 logic

### DIFF
--- a/cache_utils.py
+++ b/cache_utils.py
@@ -47,6 +47,8 @@ def ttl_cache(ttl_seconds=60, maxsize=None):
         @wraps(func)
         def wrapper(*args, **kwargs):
             """Return cached results when available or call the wrapped function."""
+            if maxsize == 0:
+                return func(*args, **kwargs)
             if args and hasattr(args[0], "__dict__"):
                 obj = args[0]
                 key_args = args[1:]
@@ -121,6 +123,8 @@ class TTLDict:
     def __setitem__(self, key, value):
         with self._lock:
             self._purge_expired()
+            if self.maxsize == 0:
+                return
             if self.maxsize is not None and len(self._store) >= self.maxsize:
                 oldest = min(self._store.items(), key=lambda item: item[1][1])[0]
                 del self._store[oldest]

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -120,6 +120,26 @@ def test_ttl_cache_maxsize(monkeypatch):
     assert identity.cache_size() == 2
 
 
+def test_ttl_cache_maxsize_zero(monkeypatch):
+    """maxsize=0 disables caching entirely."""
+    fake_time = [0]
+    monkeypatch.setattr(time, "time", lambda: fake_time[0])
+
+    call_count = {"count": 0}
+
+    @ttl_cache(ttl_seconds=10, maxsize=0)
+    def identity(x):
+        call_count["count"] += 1
+        return x
+
+    assert identity(1) == 1
+    assert call_count["count"] == 1
+    assert identity.cache_size() == 0
+    assert identity(1) == 1
+    assert call_count["count"] == 2
+    assert identity.cache_size() == 0
+
+
 def test_ttl_cache_releases_object_cache(monkeypatch):
     """Cache entries for object methods should be removed when the object is garbage collected."""
     fake_time = [0]

--- a/tests/test_ttl_dict.py
+++ b/tests/test_ttl_dict.py
@@ -37,6 +37,14 @@ def test_ttl_dict_maxsize(monkeypatch):
     assert "a" not in d
 
 
+def test_ttl_dict_maxsize_zero(monkeypatch):
+    d = TTLDict(ttl_seconds=10, maxsize=0)
+    d["a"] = 1
+    assert len(d) == 0
+    with pytest.raises(KeyError):
+        _ = d["a"]
+
+
 def test_ttl_dict_thread_safety(monkeypatch):
     monkeypatch.setattr(time, "time", lambda: 0)
     d = TTLDict(ttl_seconds=10)


### PR DESCRIPTION
## Summary
- guard against caching when `maxsize` is zero in `ttl_cache` decorator
- skip storing entries in `TTLDict` when `maxsize` is zero
- add unit tests for `maxsize=0` edge cases

## Testing
- `ruff check .`
- `PYTHONPATH=$PWD pytest -q`
- `for f in tests/js/*.test.js; do node $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_684f97f75efc8320bbb6893be47fd633