### PR TITLE
Fix state manager reload leak

### DIFF
--- a/App.py
+++ b/App.py
@@ -103,6 +103,7 @@ scheduler_recreate_lock = threading.Lock()
 # Track scheduler health
 _previous_scheduler = globals().get("scheduler")
 _previous_dashboard_service = globals().get("dashboard_service")
+_previous_state_manager = globals().get("state_manager")
 scheduler = None
 
 # Global start time
@@ -138,6 +139,15 @@ logger.addHandler(console_handler)
 # Initialize state manager with Redis URL from environment
 redis_url = os.environ.get("REDIS_URL")
 state_manager = StateManager(redis_url)
+
+# Close any previous state manager instance to prevent resource leaks
+if _previous_state_manager:
+    try:
+        _previous_state_manager.close()
+    except Exception as e:
+        logging.error(f"Error closing previous state manager: {e}")
+    finally:
+        _previous_state_manager = None
 
 # Initialize notification service after state_manager
 notification_service = NotificationService(state_manager)

--- a/tests/test_state_manager_reload_cleanup.py
+++ b/tests/test_state_manager_reload_cleanup.py
@@ -1,0 +1,44 @@
+import importlib
+
+
+class DummyStateManager:
+    def __init__(self, *args, **kwargs):
+        self.closed = False
+        self.redis_client = None
+
+    def get_notifications(self):
+        return []
+
+    def save_notifications(self, notifications):
+        pass
+
+    def load_critical_state(self):
+        return None, None
+
+    def close(self):
+        self.closed = True
+
+
+class DummyService:
+    def __init__(self, *args, **kwargs):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def test_previous_state_manager_closed(monkeypatch):
+    App = importlib.reload(importlib.import_module("App"))
+
+    dummy = DummyStateManager()
+    App.state_manager = dummy
+    dummy_service = DummyService()
+    App.dashboard_service = dummy_service
+
+    monkeypatch.setattr("state_manager.StateManager", lambda *a, **k: DummyStateManager())
+    monkeypatch.setattr("data_service.MiningDashboardService", lambda *a, **k: DummyService())
+
+    App = importlib.reload(App)
+
+    assert dummy.closed
+    assert App._previous_state_manager is None


### PR DESCRIPTION
## Summary
- ensure previous state manager is closed on reload to avoid memory leak
- test that old state manager gets closed when App is reloaded

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9d39e1bc83209252d8cf5f019207