### PR TITLE
Fix memory leak when leaving blocks page

### DIFF
--- a/static/js/blocks.js
+++ b/static/js/blocks.js
@@ -131,6 +131,12 @@ function cleanupEventHandlers() {
         clearInterval(refreshIntervalId);
         refreshIntervalId = null;
     }
+    if (minerChart) {
+        if (typeof minerChart.destroy === 'function') {
+            minerChart.destroy();
+        }
+        minerChart = null;
+    }
 }
 
 // Setup keyboard navigation for modal

--- a/tests/js/blocks_cleanup.test.js
+++ b/tests/js/blocks_cleanup.test.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const { setupBasicDOM, setupJqueryStub } = require('./test_utils');
+
+setupBasicDOM();
+setupJqueryStub();
+
+let destroyed = false;
+function Chart() {
+    this.destroy = () => { destroyed = true; };
+}
+
+const context = {
+    console,
+    window: { Chart },
+    Chart,
+    $: global.$,
+    document: global.document,
+    setInterval: () => 1,
+    setTimeout: () => 1,
+    clearInterval: id => cleared.push(id),
+    localStorage: global.localStorage,
+    navigator: {},
+    globalThis: {}
+};
+const cleared = [];
+vm.createContext(context);
+
+const code = fs.readFileSync(__dirname + '/../../static/js/blocks.js', 'utf8');
+vm.runInContext(code, context);
+
+// Create chart instance and intervals inside the same context
+vm.runInContext('minerChart = new Chart(); notificationIntervalId = 1; refreshIntervalId = 2;', context);
+
+const result = vm.runInContext('cleanupEventHandlers(); minerChart;', context);
+
+assert.ok(destroyed, 'chart should be destroyed');
+assert.strictEqual(result, null);
+assert.deepStrictEqual(cleared, [1, 2]);
+
+console.log('blocks cleanup test passed');


### PR DESCRIPTION
## Summary
- destroy the Chart.js instance during blocks page cleanup
- add regression test ensuring chart cleanup releases resources
- regenerate minified JS assets

## Testing
- `make minify-js`
- `PYTHONPATH=$PWD pytest -q`
- `node tests/js/blocks_cleanup.test.js`

------
https://chatgpt.com/codex/tasks/task_e_684f9d39e1bc83209252d8cf5f019207