### PR TITLE
Fix TTLDict iteration memory leak

### DIFF
--- a/cache_utils.py
+++ b/cache_utils.py
@@ -171,5 +171,19 @@ class TTLDict:
             self._purge_expired()
             return [(k, v[0]) for k, v in self._store.items()]
 
+    def __iter__(self):
+        """Iterate over keys while purging expired entries."""
+        with self._lock:
+            self._purge_expired()
+            keys = list(self._store.keys())
+        for key in keys:
+            yield key
+
+    def values(self):
+        """Return list of values after purging expired items."""
+        with self._lock:
+            self._purge_expired()
+            return [v[0] for v in self._store.values()]
+
 
 __all__ = ["ttl_cache", "TTLDict"]

--- a/tests/test_ttl_dict.py
+++ b/tests/test_ttl_dict.py
@@ -67,3 +67,15 @@ def test_ttl_dict_thread_safety(monkeypatch):
 
     assert not errors
     assert len(d) == 250
+
+def test_ttl_dict_iteration_purges(monkeypatch):
+    fake_time = [0]
+    monkeypatch.setattr(time, "time", lambda: fake_time[0])
+
+    d = TTLDict(ttl_seconds=10)
+    d["a"] = 1
+    fake_time[0] += 11
+
+    assert list(d) == []
+    assert len(d) == 0
+


### PR DESCRIPTION
## Summary
- purge expired TTLDict entries when iterating or retrieving values
- test that iteration removes expired entries

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9d39e1bc83209252d8cf5f019207