### PR TITLE
Fix convert_to_ths exponent parsing

### DIFF
--- a/models.py
+++ b/models.py
@@ -171,7 +171,7 @@ def convert_to_ths(value, unit):
     try:
         if isinstance(value, str):
             cleaned = value.replace(",", "").strip()
-            match = re.match(r"[-+]?\d*\.?\d+", cleaned)
+            match = re.match(r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?", cleaned)
             value = float(match.group(0)) if match else 0
         value = float(value)
         if value <= 0:

--- a/tests/test_convert_to_ths.py
+++ b/tests/test_convert_to_ths.py
@@ -38,6 +38,8 @@ def test_negative_or_none_returns_zero():
         ("10", "TH/s", 10),
         ("1.5", "PH/s", 1500),
         ("2,000", "GH/s", 2.0),
+        ("1e2", "GH/s", 0.1),
+        ("2.5e3", "MH/s", 0.0025),
     ],
 )
 def test_string_values(value, unit, expected):


### PR DESCRIPTION
## Summary
- handle scientific notation in `convert_to_ths`
- test exponent support in conversion helper

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9d4244ac8320a237809b76411499