### PR TITLE
Enable Matrix audio tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ informed with minimal fuss.
 - **Boot Shortcut**: At the boot sequence prompt, enter `M` to activate the Matrix theme immediately.
 - **Authentic Rain**: Characters fall from a mixed set of Katakana, letters, digits and symbols, with rare hidden words like `OCEAN`, `BITCOIN` and `MATRIX`, rendered in a variety of monospace fonts for a more cinematic feel.
 - **Random Rotation**: Each character now rotates slightly at random as it falls, creating a dynamic cascade.
+- **Themed Audio**: While in Matrix mode, `matrix.mp3`, `matrix1.mp3` and `matrix2.mp3` loop in the background.
 
 ## Documentation
 

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -15,7 +15,16 @@
         const isMatrix = localStorage.getItem('useMatrixTheme') === 'true';
         const deepSeaTracks = ['/static/audio/ocean.mp3'];
         const bitcoinTracks = ['/static/audio/bitcoin.mp3', '/static/audio/bitcoin1.mp3', '/static/audio/bitcoin2.mp3'];
-        let playlist = (isDeepSea && !isMatrix) ? deepSeaTracks : bitcoinTracks;
+        const matrixTracks = ['/static/audio/matrix.mp3', '/static/audio/matrix1.mp3', '/static/audio/matrix2.mp3'];
+
+        let playlist;
+        if (isMatrix) {
+            playlist = matrixTracks;
+        } else if (isDeepSea) {
+            playlist = deepSeaTracks;
+        } else {
+            playlist = bitcoinTracks;
+        }
 
         let trackIndex = parseInt(localStorage.getItem('audioTrackIndex')) || 0;
         if (trackIndex >= playlist.length) {
@@ -111,9 +120,16 @@
             }, interval);
         };
 
-        const crossfadeToTheme = (useDeepSea) => {
+        const crossfadeToTheme = (theme) => {
             if (isCrossfading) { return; }
-            const newPlaylist = useDeepSea ? deepSeaTracks : bitcoinTracks;
+            if (typeof theme === 'boolean') {
+                theme = theme ? 'deepsea' : 'bitcoin';
+            }
+            const newPlaylist = theme === 'deepsea'
+                ? deepSeaTracks
+                : theme === 'matrix'
+                    ? matrixTracks
+                    : bitcoinTracks;
             if (playlist === newPlaylist) { return; }
             playlist = newPlaylist;
             trackIndex = 0;

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -498,9 +498,9 @@ function applyMatrixTheme() {
             bubbles.remove();
         }
 
-        // Switch audio to bitcoin playlist
+        // Switch audio to Matrix playlist
         if (window.crossfadeToTheme) {
-            window.crossfadeToTheme(false);
+            window.crossfadeToTheme('matrix');
         }
 
         if (window.initMatrixRain) {
@@ -536,7 +536,7 @@ function toggleTheme() {
 
     // Crossfade background audio to the new theme
     if (window.crossfadeToTheme) {
-        window.crossfadeToTheme(useDeepSea);
+        window.crossfadeToTheme(useDeepSea ? 'deepsea' : 'bitcoin');
     }
 
     // Show a themed loading message

--- a/tests/js/audioCrossfadeTheme.test.js
+++ b/tests/js/audioCrossfadeTheme.test.js
@@ -55,13 +55,17 @@ vm.runInContext(code, context);
 
 assert.strictEqual(typeof context.window.crossfadeToTheme, 'function');
 
-context.window.crossfadeToTheme(true);
+context.window.crossfadeToTheme('deepsea');
 for (let i = 0; i < 20; i++) { intervalFn(); }
-assert.strictEqual(audioElement.src, '/static/audio/ocean.mp3');
+assert.ok(audioElement.src.includes('/static/audio/ocean.mp3'));
 
-context.window.crossfadeToTheme(false);
+context.window.crossfadeToTheme('matrix');
 for (let i = 0; i < 20; i++) { intervalFn(); }
-assert.strictEqual(audioElement.src, '/static/audio/bitcoin.mp3');
+assert.ok(audioElement.src.includes('/static/audio/matrix'));
+
+context.window.crossfadeToTheme('bitcoin');
+for (let i = 0; i < 20; i++) { intervalFn(); }
+assert.ok(audioElement.src.includes('/static/audio/bitcoin'));
 
 assert.ok(intervalFn);
 console.log('audio crossfade theme tests passed');

--- a/tests/js/themeToggle.test.js
+++ b/tests/js/themeToggle.test.js
@@ -48,13 +48,13 @@ vm.runInContext(snippet, context);
 context.toggleTheme();
 assert.strictEqual(storage.getItem('useDeepSeaTheme'), 'true');
 assert.strictEqual(storage.getItem('useMatrixTheme'), 'false');
-assert.strictEqual(crossfadeCalls[0], true);
+assert.strictEqual(crossfadeCalls[0], 'deepsea');
 assert.ok(reloadCalled);
 
 reloadCalled = false;
 context.toggleTheme();
 assert.strictEqual(storage.getItem('useDeepSeaTheme'), 'false');
-assert.strictEqual(crossfadeCalls[1], false);
+assert.strictEqual(crossfadeCalls[1], 'bitcoin');
 assert.ok(reloadCalled);
 
 console.log('theme toggle tests passed');


### PR DESCRIPTION
## Summary
- add Matrix playlist to `audio.js` and update crossfade function
- crossfade audio to Matrix theme from `theme.js`
- update README with Matrix audio info
- adjust front-end tests for new API

## Testing
- `make minify`
- `node tests/js/audioCrossfadeTheme.test.js`
- `node tests/js/themeToggle.test.js`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504b1721d083208f3ab1269274a18a