### PR TITLE
Fix TTLDict cache cleanup to reduce memory usage

### DIFF
--- a/App.py
+++ b/App.py
@@ -377,7 +377,11 @@ def memory_watchdog():
             # 3. Clear any non-critical caches
             ds = globals().get("dashboard_service")
             if ds and hasattr(ds, "cache"):
-                ds.cache.clear()
+                cache_obj = ds.cache
+                if hasattr(cache_obj, "purge"):
+                    cache_obj.purge()
+                elif hasattr(cache_obj, "clear"):
+                    cache_obj.clear()
                 logging.info("Cleared dashboard service cache")
 
             # 4. Notify about the memory issue

--- a/cache_utils.py
+++ b/cache_utils.py
@@ -185,5 +185,10 @@ class TTLDict:
             self._purge_expired()
             return [v[0] for v in self._store.values()]
 
+    def purge(self):
+        """Public method to purge expired entries."""
+        with self._lock:
+            self._purge_expired()
+
 
 __all__ = ["ttl_cache", "TTLDict"]

--- a/tests/test_ttl_dict.py
+++ b/tests/test_ttl_dict.py
@@ -79,3 +79,15 @@ def test_ttl_dict_iteration_purges(monkeypatch):
     assert list(d) == []
     assert len(d) == 0
 
+
+def test_ttl_dict_purge_method(monkeypatch):
+    fake_time = [0]
+    monkeypatch.setattr(time, "time", lambda: fake_time[0])
+
+    d = TTLDict(ttl_seconds=10)
+    d["a"] = 1
+    fake_time[0] += 11
+    d.purge()
+
+    assert len(d) == 0
+


### PR DESCRIPTION
## Summary
- purge dashboard service caches using new `TTLDict.purge` during memory watchdog cleanup
- add a `purge` helper to `TTLDict`
- test that `TTLDict.purge` removes expired entries

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850526be6b483208a2b31f60d679e1a