### PR TITLE
Fix delayed audio progress updates

### DIFF
--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -10,7 +10,7 @@
         const playBtn = document.getElementById('audio-play');
         const prevBtn = document.getElementById('audio-prev');
         const nextBtn = document.getElementById('audio-next');
-        const progressBar = document.getElementById('audio-progress');
+        let progressBar = document.getElementById('audio-progress');
         const timeDisplay = document.getElementById('audio-remaining');
         if (!audio) { return; }
         const crossfadeDuration = 2;
@@ -245,6 +245,14 @@
         }
         
         function updateProgress() {
+            if (!progressBar) {
+                progressBar = document.getElementById('audio-progress');
+                if (progressBar) {
+                    progressBar.addEventListener('input', function () {
+                        seekTo(parseFloat(this.value));
+                    });
+                }
+            }
             if (progressBar && audio.duration) {
                 progressBar.value = (audio.currentTime / audio.duration) * 100;
             }


### PR DESCRIPTION
## Summary
- ensure audio progress bar is detected after the system monitor creates it
- regenerate minified JS assets

## Testing
- `PYTHONPATH=$PWD pytest -q`
- `node tests/js/formatCurrency.test.js && node tests/js/formatDuration.test.js && node tests/js/main_dom_safety.test.js && node tests/js/main_chart_load.test.js && node tests/js/normalizeHashrate.test.js && node tests/js/arrowIndicator.test.js && node tests/js/audioCrossfadeTheme.test.js && node tests/js/getBlockTimerClass.test.js && node tests/js/blockProbability.test.js && node tests/js/notificationsTimestamp.test.js && node tests/js/workerUtils.test.js && node tests/js/themeToggle.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6850915aa7a4832099ef50c7d8f736f1