### PR TITLE
Fix audio timer on pages with delayed monitor init

### DIFF
--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -11,7 +11,7 @@
         const prevBtn = document.getElementById('audio-prev');
         const nextBtn = document.getElementById('audio-next');
         let progressBar = document.getElementById('audio-progress');
-        const timeDisplay = document.getElementById('audio-remaining');
+        let timeDisplay = document.getElementById('audio-remaining');
         if (!audio) { return; }
         const crossfadeDuration = 2;
         let isCrossfading = false;
@@ -252,6 +252,9 @@
                         seekTo(parseFloat(this.value));
                     });
                 }
+            }
+            if (!timeDisplay) {
+                timeDisplay = document.getElementById('audio-remaining');
             }
             if (progressBar && audio.duration) {
                 progressBar.value = (audio.currentTime / audio.duration) * 100;


### PR DESCRIPTION
## Summary
- ensure `audio-remaining` reference is refreshed if the element loads late
- minify static assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68509438e87083208cafa7f75013c3a0