### PR TITLE
Add toggle for audio time display

### DIFF
--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -12,6 +12,7 @@
         const nextBtn = document.getElementById('audio-next');
         let progressBar = document.getElementById('audio-progress');
         let timeDisplay = document.getElementById('audio-remaining');
+        let showRemaining = true;
         if (!audio) { return; }
         const crossfadeDuration = 2;
         let isCrossfading = false;
@@ -260,8 +261,12 @@
                 progressBar.value = (audio.currentTime / audio.duration) * 100;
             }
             if (timeDisplay && audio.duration) {
-                const remaining = Math.max(0, audio.duration - audio.currentTime);
-                timeDisplay.textContent = '-' + formatTime(remaining);
+                if (showRemaining) {
+                    const remaining = Math.max(0, audio.duration - audio.currentTime);
+                    timeDisplay.textContent = '-' + formatTime(remaining);
+                } else {
+                    timeDisplay.textContent = formatTime(audio.currentTime);
+                }
             }
         }
 
@@ -318,6 +323,13 @@
         if (progressBar) {
             progressBar.addEventListener('input', function () {
                 seekTo(parseFloat(this.value));
+            });
+        }
+
+        if (timeDisplay) {
+            timeDisplay.addEventListener('click', function () {
+                showRemaining = !showRemaining;
+                updateProgress();
             });
         }
 

--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -26,3 +26,5 @@ def test_audio_controller_functions():
     assert "window.prevTrack" in content
     assert "window.togglePlay" in content
     assert "window.seekAudio" in content
+    assert "showRemaining" in content
+    assert "timeDisplay.addEventListener('click'" in content


### PR DESCRIPTION
## Summary
- allow toggling between remaining and elapsed time in audio controls
- test new behaviour in audio controller tests

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685097f7fbc0832080ca4353c6aad82f