### PR TITLE
Fix unit parsing in convert_to_ths

### DIFF
--- a/models.py
+++ b/models.py
@@ -177,7 +177,29 @@ def convert_to_ths(value, unit):
         if value <= 0:
             return 0
 
-        unit = unit.lower() if unit else "th/s"
+        unit = unit.lower().strip() if unit else "th/s"
+        unit = unit.replace(" ", "")
+        unit = unit.replace("persecond", "/s").replace("persec", "/s")
+        if not unit.endswith("/s"):
+            replacements = {
+                "phs": "ph/s",
+                "ph": "ph/s",
+                "ehs": "eh/s",
+                "eh": "eh/s",
+                "ths": "th/s",
+                "th": "th/s",
+                "ghs": "gh/s",
+                "gh": "gh/s",
+                "mhs": "mh/s",
+                "mh": "mh/s",
+                "khs": "kh/s",
+                "kh": "kh/s",
+                "hs": "h/s",
+            }
+            for suffix, normalized in replacements.items():
+                if unit.endswith(suffix):
+                    unit = normalized
+                    break
 
         if "ph/s" in unit:
             return value * 1000  # 1 PH/s = 1000 TH/s

--- a/tests/test_convert_to_ths.py
+++ b/tests/test_convert_to_ths.py
@@ -44,3 +44,16 @@ def test_negative_or_none_returns_zero():
 )
 def test_string_values(value, unit, expected):
     assert convert_to_ths(value, unit) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "value, unit, expected",
+    [
+        (1, "TH", 1),
+        (2, "PH", 2000),
+        (3, "GHs", 0.003),
+        (4, "mh", 0.000004),
+    ],
+)
+def test_unit_variants_without_slash(value, unit, expected):
+    assert convert_to_ths(value, unit) == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- support hashrate unit strings that omit the `/s` suffix
- add regression tests for these unit variations

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850cfadee688320aa8baaf295a0491f