### PR TITLE
Fix memory leak in metrics log

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -670,6 +670,7 @@ class StateManager:
             snapshot = metrics.copy()
             snapshot.pop("arrow_history", None)
             snapshot.pop("history", None)
+            snapshot.pop("workers", None)
 
             entry = {"timestamp": datetime.now().isoformat(), "metrics": snapshot}
             self.metrics_log.append(entry)

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -284,6 +284,18 @@ def test_metrics_log_snapshot_omits_history(monkeypatch):
     assert "history" not in latest
 
 
+def test_metrics_log_snapshot_omits_workers(monkeypatch):
+    """metrics_log should not store workers field."""
+    mgr = StateManager()
+    monkeypatch.setattr("state_manager.get_timezone", lambda: "UTC")
+
+    metrics = {"workers": [{"id": 1}, {"id": 2}]}
+    mgr.update_metrics_history(metrics)
+
+    latest = mgr.metrics_log[-1]["metrics"]
+    assert "workers" not in latest
+
+
 def test_close_closes_redis_connection():
     mgr = StateManager()
 


### PR DESCRIPTION
## Summary
- prune `workers` data from metrics log snapshots
- test that metrics log entries exclude worker details

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850d24e70248320800d11c437b2f17b