### PR TITLE
Fix memory leak in metrics history

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -651,7 +651,8 @@ class StateManager:
                 minute_groups = {}
                 for entry in entries:
                     minute = entry["time"][:5]  # extract HH:MM
-                    minute_groups[minute] = entry  # take last entry for that minute
+                    # Store a copy so pruned entries can be freed
+                    minute_groups[minute] = entry.copy()  # take last entry for that minute
 
                 # Sort by time to ensure chronological order
                 aggregated_history[key] = sorted(list(minute_groups.values()), key=lambda x: x["time"])

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -357,3 +357,17 @@ def test_load_methods_cache_maxsize(monkeypatch):
     assert StateManager.load_graph_state.cache_size() <= 1
     assert StateManager.load_payout_history.cache_size() <= 1
     assert StateManager.load_last_earnings.cache_size() <= 1
+
+
+def test_update_metrics_history_copies_entries(monkeypatch):
+    """arrow_history in metrics should not reference internal state objects."""
+    mgr = StateManager()
+    monkeypatch.setattr("state_manager.get_timezone", lambda: "UTC")
+
+    metrics = {"hashrate_60sec": 1, "hashrate_60sec_unit": "th/s"}
+    mgr.update_metrics_history(metrics)
+
+    state_entry = mgr.arrow_history["hashrate_60sec"][-1]
+    metrics_entry = metrics["arrow_history"]["hashrate_60sec"][-1]
+
+    assert metrics_entry is not state_entry


### PR DESCRIPTION
## Summary
- avoid retaining pruned arrow history entries by copying them
- test that metrics history copies entries so old objects can free

## Testing
- `ruff .`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850d24e70248320800d11c437b2f17b