### PR TITLE
Fix memory leak by clearing service caches

### DIFF
--- a/App.py
+++ b/App.py
@@ -387,13 +387,20 @@ def memory_watchdog():
 
             # 3. Clear any non-critical caches
             ds = globals().get("dashboard_service")
-            if ds and hasattr(ds, "cache"):
-                cache_obj = ds.cache
-                if hasattr(cache_obj, "purge"):
-                    cache_obj.purge()
-                elif hasattr(cache_obj, "clear"):
-                    cache_obj.clear()
-                logging.info("Cleared dashboard service cache")
+            if ds:
+                if hasattr(ds, "cache"):
+                    cache_obj = ds.cache
+                    if hasattr(cache_obj, "purge"):
+                        cache_obj.purge()
+                    elif hasattr(cache_obj, "clear"):
+                        cache_obj.clear()
+                    logging.info("Cleared dashboard service cache")
+                if hasattr(ds, "purge_caches"):
+                    try:
+                        ds.purge_caches()
+                        logging.info("Purged dashboard service caches")
+                    except Exception as e:
+                        logging.error(f"Error purging dashboard caches: {e}")
 
             # 4. Notify about the memory issue
             notification_service.add_notification(

--- a/data_service.py
+++ b/data_service.py
@@ -71,6 +71,16 @@ class MiningDashboardService:
         """Associate a WorkerService instance for power estimation."""
         self.worker_service = worker_service
 
+    def purge_caches(self):
+        """Clear any ttl_cache caches to free memory."""
+        for attr_name in dir(self):
+            attr = getattr(self, attr_name)
+            if hasattr(attr, "cache_clear"):
+                try:
+                    attr.cache_clear()
+                except Exception:
+                    pass
+
     def estimate_total_power(self, cached_metrics=None):
         """Estimate total power usage from worker data if available."""
         if not self.worker_service:

--- a/tests/test_service_cleanup.py
+++ b/tests/test_service_cleanup.py
@@ -34,3 +34,23 @@ def test_service_close_closes_worker(monkeypatch):
 
     assert worker.closed
 
+
+def test_service_purge_caches(monkeypatch):
+    """purge_caches should clear ttl_cache decorated methods."""
+    svc = MiningDashboardService(0, 0, "w")
+
+    called = {"cleared": False}
+
+    def dummy_cache_clear():
+        called["cleared"] = True
+
+    def dummy_func(self):
+        return "x"
+
+    dummy_func.cache_clear = dummy_cache_clear
+    setattr(svc, "dummy", dummy_func.__get__(svc, type(svc)))
+
+    svc.purge_caches()
+
+    assert called["cleared"]
+


### PR DESCRIPTION
## Summary
- add `purge_caches` method on `MiningDashboardService`
- invoke `purge_caches` from the memory watchdog
- test cache purge functionality

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_6850d24e70248320800d11c437b2f17b