### PR TITLE
Unify volume slider styling

### DIFF
--- a/static/css/common.css
+++ b/static/css/common.css
@@ -1332,23 +1332,28 @@ html.deepsea-theme #congratsMessage {
   direction: rtl;
   appearance: none;
   -webkit-appearance: none;
-  accent-color: var(--primary-color);
-}
-
-.volume-slider::-webkit-slider-thumb,
-.volume-slider::-moz-range-thumb {
-  background-color: var(--primary-color);
-  border: 1px solid var(--primary-color);
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+  background-color: rgba(var(--primary-color-rgb), 0.2);
+  border: 1px solid rgba(var(--primary-color-rgb), 0.5);
+  border-radius: 2px;
+  background-image: linear-gradient(
+    to top,
+    var(--primary-color) var(--volume-progress-value, 100%),
+    rgba(var(--primary-color-rgb), 0.2) var(--volume-progress-value, 100%)
+  );
+  background-repeat: no-repeat;
   cursor: pointer;
 }
 
-.volume-slider::-webkit-slider-runnable-track,
-.volume-slider::-moz-range-track {
-  background-color: rgba(var(--primary-color-rgb), 0.5);
-  border-radius: 2px;
+.volume-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 0;
+  height: 0;
+}
+
+.volume-slider::-moz-range-thumb {
+  width: 0;
+  height: 0;
+  border: none;
 }
 
 .audio-controls:hover .volume-slider {

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -68,6 +68,13 @@
                 volumeSlider.value = 100;
             }
         }
+        const updateVolumeSliderStyle = () => {
+            if (volumeSlider && volumeSlider.style) {
+                const pct = parseInt(volumeSlider.value, 10);
+                volumeSlider.style.setProperty('--volume-progress-value', pct + '%');
+            }
+        };
+        updateVolumeSliderStyle();
 
         let storedTime = parseFloat(localStorage.getItem('audioPlaybackTime'));
         const storedMuted = localStorage.getItem('audioMuted') === 'true';
@@ -317,6 +324,7 @@
                 audio.volume = volume;
                 nextAudio.volume = volume;
                 localStorage.setItem('audioVolume', volume.toString());
+                updateVolumeSliderStyle();
             });
         }
 


### PR DESCRIPTION
## Summary
- style the volume slider like the audio progress bar
- update JS to apply CSS variable for volume slider fill
- guard style updates if the slider is missing

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest -q`
- `for f in tests/js/*.test.js; do node $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_6850e5633e408320be92ebfd7a8d34f5