### PR TITLE
Update audio controls on theme change

### DIFF
--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -74,6 +74,15 @@
                 volumeSlider.style.setProperty('--volume-progress-value', pct + '%');
             }
         };
+        const refreshAudioThemeColors = () => {
+            if (typeof getComputedStyle === 'function') {
+                rootStyle = getComputedStyle(document.documentElement);
+                primaryColor = rootStyle.getPropertyValue('--primary-color').trim();
+                primaryRgb = rootStyle.getPropertyValue('--primary-color-rgb').trim();
+            }
+            updateVolumeSliderStyle();
+            updateProgress();
+        };
         updateVolumeSliderStyle();
 
         let storedTime = parseFloat(localStorage.getItem('audioPlaybackTime'));
@@ -250,6 +259,7 @@
         window.prevTrack = prevTrack;
         window.togglePlay = togglePlay;
         window.seekAudio = seekTo;
+        window.refreshAudioThemeColors = refreshAudioThemeColors;
 
         loadAndResume();
         updateProgress();

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -440,6 +440,10 @@ function applyDeepSeaTheme() {
             themeToggle.style.color = '#0088cc';
         }
 
+        if (window.refreshAudioThemeColors) {
+            window.refreshAudioThemeColors();
+        }
+
         console.log("DeepSea theme applied with color adjustments");
     } finally {
         // Reset the guard flag when done, even if there's an error
@@ -509,6 +513,10 @@ function applyMatrixTheme() {
 
         updateMatrixHeaderText();
         updateChartControlsLabel(true);
+
+        if (window.refreshAudioThemeColors) {
+            window.refreshAudioThemeColors();
+        }
 
         console.log('Matrix theme applied');
     } finally {

--- a/tests/test_audio_controller.py
+++ b/tests/test_audio_controller.py
@@ -26,5 +26,6 @@ def test_audio_controller_functions():
     assert "window.prevTrack" in content
     assert "window.togglePlay" in content
     assert "window.seekAudio" in content
+    assert "window.refreshAudioThemeColors" in content
     assert "showRemaining" in content
     assert "timeDisplay.addEventListener('click'" in content


### PR DESCRIPTION
## Summary
- update audio controls styling when the theme changes
- trigger audio style refresh from the DeepSea and Matrix theme functions
- test for `refreshAudioThemeColors`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `make minify`

------
https://chatgpt.com/codex/tasks/task_e_685179efe99c8320b4d3bd3d5f7b48f0