### PR TITLE
Improve cache cleanup to manage memory

### DIFF
--- a/cache_utils.py
+++ b/cache_utils.py
@@ -85,6 +85,14 @@ def ttl_cache(ttl_seconds=60, maxsize=None):
                 cache.clear()
                 object_caches.clear()
 
+        def cache_purge():
+            """Purge expired items from all caches without clearing everything."""
+            now = time.time()
+            with lock:
+                _purge_expired(cache, now)
+                for c in list(object_caches.values()):
+                    _purge_expired(c, now)
+
         def cache_size():
             """Return the current number of cached entries after removing expired items."""
             now = time.time()
@@ -96,6 +104,7 @@ def ttl_cache(ttl_seconds=60, maxsize=None):
 
         wrapper.cache_clear = cache_clear
         wrapper.cache_size = cache_size
+        wrapper.cache_purge = cache_purge
         return wrapper
 
     return decorator

--- a/data_service.py
+++ b/data_service.py
@@ -72,9 +72,14 @@ class MiningDashboardService:
         self.worker_service = worker_service
 
     def purge_caches(self):
-        """Clear any ttl_cache caches to free memory."""
+        """Purge or clear ttl_cache caches to free memory."""
         for attr_name in dir(self):
             attr = getattr(self, attr_name)
+            if hasattr(attr, "cache_purge"):
+                try:
+                    attr.cache_purge()
+                except Exception:
+                    pass
             if hasattr(attr, "cache_clear"):
                 try:
                     attr.cache_clear()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -56,4 +56,6 @@ coded and not currently user configurable. See
 
 Expensive operations such as network requests, complex calculations and Redis queries are cached to reduce
 load on external services. Results are retained for up to 60 seconds before being refreshed. The built-in
-cache requires no configuration.
+cache requires no configuration. Caches use a time-to-live strategy and can be
+manually purged by calling the ``purge_caches`` method on the dashboard service
+or ``cache_purge`` on any ``ttl_cache`` decorated function.

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -183,3 +183,20 @@ def test_ttl_cache_with_sets(monkeypatch):
     fake_time[0] += 6
     assert sum_set({1, 2, 3}) == 6
     assert call_count["count"] == 2
+
+
+def test_ttl_cache_purge(monkeypatch):
+    """cache_purge removes expired items without clearing everything."""
+    fake_time = [0]
+    monkeypatch.setattr(time, "time", lambda: fake_time[0])
+
+    @ttl_cache(ttl_seconds=5)
+    def identity(x):
+        return x
+
+    identity(1)
+    assert identity.cache_size() == 1
+
+    fake_time[0] += 6
+    identity.cache_purge()
+    assert identity.cache_size() == 0


### PR DESCRIPTION
## Summary
- add `cache_purge` helper in `ttl_cache`
- use new method in `MiningDashboardService.purge_caches`
- document cache purge capability
- test cache purge behavior

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851796c1d188320a3d8cd0072ace08d