### PR TITLE
Fix dataclass compatibility for Python 3.9

### DIFF
--- a/models.py
+++ b/models.py
@@ -9,7 +9,7 @@ import logging
 import re
 
 
-@dataclass(slots=True)
+@dataclass
 class OceanData:
     """Data structure for Ocean.xyz pool mining data."""
 
@@ -76,7 +76,7 @@ class OceanData:
         return cls(**filtered_data)
 
 
-@dataclass(slots=True)
+@dataclass
 class WorkerData:
     """Data structure for individual worker information."""
 


### PR DESCRIPTION
## Summary
- remove `slots=True` from `OceanData` and `WorkerData` dataclasses

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517e6b32388320bef9db623d962dab