### PR TITLE
Restore test for dataclass slots support

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -66,3 +66,9 @@ def test_model_to_from_dict():
     new_worker = WorkerData.from_dict(d)
     assert new_worker.name == worker.name
     assert new_worker.status == worker.status
+
+
+def test_dataclasses_use_slots():
+    """Verify that dataclasses define __slots__ for memory efficiency."""
+    assert hasattr(OceanData, "__slots__")
+    assert hasattr(WorkerData, "__slots__")


### PR DESCRIPTION
## Summary
- reintroduce test for slot usage

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68517e6b32388320bef9db623d962dab