### PR TITLE
Refactor config routes into blueprint

### DIFF
--- a/config_routes.py
+++ b/config_routes.py
@@ -1,0 +1,142 @@
+# Configuration-related routes blueprint
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from flask import Blueprint, jsonify, request
+
+from config import load_config, save_config
+from data_service import MiningDashboardService
+
+config_bp = Blueprint("config", __name__)
+
+_dashboard_service: Any | None = None
+_worker_service: Any | None = None
+_notification_service: Any | None = None
+_update_metrics_job: Any | None = None
+
+
+def init_config_routes(
+    dashboard_service: Any,
+    worker_service: Any,
+    notification_service: Any,
+    update_metrics_job: Any,
+) -> None:
+    """Initialize the blueprint with required services."""
+    global _dashboard_service, _worker_service, _notification_service, _update_metrics_job
+    _dashboard_service = dashboard_service
+    _worker_service = worker_service
+    _notification_service = notification_service
+    _update_metrics_job = update_metrics_job
+
+
+@config_bp.route("/api/config", methods=["GET"])
+def get_config() -> Any:
+    """Return the current application configuration."""
+    try:
+        config = load_config()
+        return jsonify(config)
+    except Exception as e:  # pragma: no cover - defensive
+        logging.error(f"Error getting configuration: {e}")
+        return jsonify({"error": "internal server error"}), 500
+
+
+@config_bp.route("/api/config", methods=["POST"])
+def update_config() -> Any:
+    """Update the application configuration."""
+    global _dashboard_service, _worker_service
+
+    try:
+        new_config = request.json
+        logging.info("Received config update request: %s", new_config)
+        if not isinstance(new_config, dict):
+            logging.error("Invalid configuration format")
+            return jsonify({"error": "Invalid configuration format"}), 400
+
+        current_config = load_config()
+        currency_changed = (
+            "currency" in new_config
+            and new_config.get("currency") != current_config.get("currency", "USD")
+        )
+
+        defaults = {
+            "wallet": "yourwallethere",
+            "power_cost": 0.0,
+            "power_usage": 0.0,
+            "currency": "USD",
+            "EXCHANGE_RATE_API_KEY": "",
+        }
+
+        merged_config = {**current_config}
+        for key, value in defaults.items():
+            merged_config.setdefault(key, value)
+        for key, value in new_config.items():
+            if value is not None:
+                merged_config[key] = value
+
+        logging.info("Saving configuration: %s", merged_config)
+        if save_config(merged_config):
+            if _dashboard_service:
+                try:
+                    _dashboard_service.close()
+                except Exception as e:  # pragma: no cover - defensive
+                    logging.error("Error closing old dashboard service: %s", e)
+
+            _dashboard_service = MiningDashboardService(
+                merged_config.get("power_cost", 0.0),
+                merged_config.get("power_usage", 0.0),
+                merged_config.get("wallet"),
+                network_fee=merged_config.get("network_fee", 0.0),
+                worker_service=_worker_service,
+            )
+            logging.info(
+                "Dashboard service reinitialized with new wallet: %s",
+                merged_config.get("wallet"),
+            )
+
+            _worker_service.set_dashboard_service(_dashboard_service)
+            if hasattr(_dashboard_service, "set_worker_service"):
+                _dashboard_service.set_worker_service(_worker_service)
+            _notification_service.dashboard_service = _dashboard_service
+            logging.info("Worker service updated with the new dashboard service")
+
+            if currency_changed:
+                try:
+                    old_currency = current_config.get("currency", "USD")
+                    logging.info(
+                        "Currency changed from %s to %s",
+                        old_currency,
+                        merged_config["currency"],
+                    )
+                    updated_count = _notification_service.update_notification_currency(
+                        merged_config["currency"]
+                    )
+                    logging.info(
+                        "Updated %s notifications to use %s currency",
+                        updated_count,
+                        merged_config["currency"],
+                    )
+                except Exception as e:  # pragma: no cover - defensive
+                    logging.error("Error updating notification currency: %s", e)
+
+            _update_metrics_job(force=True)
+            logging.info("Forced metrics update after configuration change")
+
+            return jsonify(
+                {
+                    "status": "success",
+                    "message": "Configuration saved successfully",
+                    "config": merged_config,
+                }
+            )
+
+        logging.error("Failed to save configuration")
+        return jsonify({"error": "Failed to save configuration"}), 500
+    except Exception as e:  # pragma: no cover - defensive
+        logging.error("Error updating configuration: %s", e)
+        return jsonify({"error": "internal server error"}), 500
+
+
+__all__ = ["config_bp", "init_config_routes", "get_config", "update_config"]
+

--- a/tests/test_dashboard_defaults.py
+++ b/tests/test_dashboard_defaults.py
@@ -29,8 +29,12 @@ def client(monkeypatch):
     monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
 
     sample_cfg = {"wallet": "w"}
-    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
-    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+    import config as cfg
+    import config_routes
+    monkeypatch.setattr(cfg, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(cfg, "save_config", lambda c: True)
+    monkeypatch.setattr(config_routes, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(config_routes, "save_config", lambda c: True)
 
     App.cached_metrics = None
     return App.app.test_client()

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -25,8 +25,12 @@ def client(monkeypatch):
     monkeypatch.setattr(App, "MiningDashboardService", lambda *a, **k: object())
     monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
     sample_cfg = {"wallet": "w"}
-    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
-    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+    import config as cfg
+    import config_routes
+    monkeypatch.setattr(cfg, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(cfg, "save_config", lambda c: True)
+    monkeypatch.setattr(config_routes, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(config_routes, "save_config", lambda c: True)
     return App.app.test_client()
 
 

--- a/tests/test_service_worker.py
+++ b/tests/test_service_worker.py
@@ -30,8 +30,12 @@ def client(monkeypatch):
     monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
 
     sample_cfg = {"wallet": "w"}
-    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
-    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+    import config as cfg
+    import config_routes
+    monkeypatch.setattr(cfg, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(cfg, "save_config", lambda c: True)
+    monkeypatch.setattr(config_routes, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(config_routes, "save_config", lambda c: True)
 
     return App.app.test_client()
 

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -30,8 +30,12 @@ def sse_client(monkeypatch):
     monkeypatch.setattr(App.worker_service, "set_dashboard_service", lambda *a, **k: None)
 
     sample_cfg = {"wallet": "w"}
-    monkeypatch.setattr(App, "load_config", lambda: sample_cfg)
-    monkeypatch.setattr(App, "save_config", lambda cfg: True)
+    import config as cfg
+    import config_routes
+    monkeypatch.setattr(cfg, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(cfg, "save_config", lambda c: True)
+    monkeypatch.setattr(config_routes, "load_config", lambda: sample_cfg)
+    monkeypatch.setattr(config_routes, "save_config", lambda c: True)
 
     return App.app.test_client()
 

--- a/tests/test_timer_cleanup.py
+++ b/tests/test_timer_cleanup.py
@@ -29,7 +29,10 @@ def test_update_metrics_job_joins_timer(monkeypatch):
     monkeypatch.setattr(App, "adaptive_gc", lambda: False)
     monkeypatch.setattr(App, "log_memory_usage", lambda: None)
     monkeypatch.setattr(App.notification_service, "add_notification", lambda *a, **k: None)
-    monkeypatch.setattr(App, "load_config", lambda: {})
+    import config as cfg
+    import config_routes
+    monkeypatch.setattr(cfg, "load_config", lambda: {})
+    monkeypatch.setattr(config_routes, "load_config", lambda: {})
     monkeypatch.setitem(App.MEMORY_CONFIG, "ADAPTIVE_GC_ENABLED", False)
 
     App.update_metrics_job(force=True)


### PR DESCRIPTION
## Summary
- move configuration API endpoints into new `config_routes` blueprint
- register blueprint in `App.py`
- adjust tests to patch configuration functions in new module

## Testing
- `ruff . --quiet`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b7ab53308320b0a1e4a16ad8bfd8