### PR TITLE
Fix dashboard service reference update

### DIFF
--- a/config_routes.py
+++ b/config_routes.py
@@ -90,6 +90,12 @@ def update_config() -> Any:
                 network_fee=merged_config.get("network_fee", 0.0),
                 worker_service=_worker_service,
             )
+            try:
+                import App
+
+                App.dashboard_service = _dashboard_service
+            except Exception as e:  # pragma: no cover - defensive
+                logging.error("Error updating global dashboard service: %s", e)
             logging.info(
                 "Dashboard service reinitialized with new wallet: %s",
                 merged_config.get("wallet"),


### PR DESCRIPTION
## Summary
- ensure config update replaces global dashboard service
- test that /api/config replaces the dashboard service

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854bbe909e08320ab799722ee2991bd