### PR TITLE
Fix block chart disappearing

### DIFF
--- a/static/js/blocks.js
+++ b/static/js/blocks.js
@@ -119,7 +119,7 @@ function prepareChartData(initialBlocks) {
 }
 
 // Clean up event handlers when refreshing or navigating
-function cleanupEventHandlers() {
+function cleanupEventHandlers(preserve_chart = false) {
     $(window).off("click.blockModal");
     $(document).off("keydown.blockModal");
     $(window).off('resize');
@@ -131,7 +131,7 @@ function cleanupEventHandlers() {
         clearInterval(refreshIntervalId);
         refreshIntervalId = null;
     }
-    if (minerChart) {
+    if (!preserve_chart && minerChart) {
         if (typeof minerChart.destroy === 'function') {
             minerChart.destroy();
         }
@@ -1043,8 +1043,8 @@ function showBlockDetails(block) {
     const modal = $("#block-modal");
     const blockDetails = $("#block-details");
 
-    // Clean up previous handlers
-    cleanupEventHandlers();
+    // Clean up previous handlers but keep the chart
+    cleanupEventHandlers(true);
 
     // Re-add scoped handlers
     setupModalKeyboardNavigation();
@@ -1345,5 +1345,5 @@ function closeModal() {
     const modal = $("#block-modal");
     modal.css("display", "none");
     modal.attr("aria-hidden", "true");
-    cleanupEventHandlers();
+    cleanupEventHandlers(true);
 }

--- a/tests/js/blocks_cleanup_preserve.test.js
+++ b/tests/js/blocks_cleanup_preserve.test.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const { setupBasicDOM, setupJqueryStub } = require('./test_utils');
+
+setupBasicDOM();
+setupJqueryStub();
+
+let destroyed = false;
+function Chart() {
+    this.destroy = () => { destroyed = true; };
+}
+
+const context = {
+    console,
+    window: { Chart },
+    Chart,
+    $: global.$,
+    document: global.document,
+    setInterval: () => 1,
+    setTimeout: () => 1,
+    clearInterval: id => cleared.push(id),
+    localStorage: global.localStorage,
+    navigator: {},
+    globalThis: {}
+};
+const cleared = [];
+vm.createContext(context);
+
+const code = fs.readFileSync(__dirname + '/../../static/js/blocks.js', 'utf8');
+vm.runInContext(code, context);
+
+// Create chart instance and intervals inside the same context
+vm.runInContext('minerChart = new Chart(); notificationIntervalId = 1; refreshIntervalId = 2;', context);
+
+const result = vm.runInContext('cleanupEventHandlers(true); minerChart;', context);
+
+assert.ok(!destroyed, 'chart should not be destroyed when preserve flag is true');
+assert.strictEqual(result instanceof Chart, true);
+assert.deepStrictEqual(cleared, [1, 2]);
+
+console.log('blocks cleanup preserve test passed');
+


### PR DESCRIPTION
## Summary
- preserve miner chart when closing block details modal
- add regression test for preserving the chart
- update minified assets

## Testing
- `make minify`
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`
- `node tests/js/blocks_cleanup_preserve.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68556f21eb848320a886811741e37566