### PR TITLE
Install Chromium for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: '3.11'
+    - name: Install Chromium and Chromedriver
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y chromium-browser chromium-chromedriver
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- install Chromium and Chromedriver in CI before running tests

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68556e7cd008832095f8951e0377b347