### PR TITLE
Add extended metrics history option

### DIFF
--- a/app_setup.py
+++ b/app_setup.py
@@ -45,6 +45,20 @@ def configure_logging():
 def init_state_manager():
     """Return a state manager configured from environment variables."""
     redis_url = os.environ.get("REDIS_URL")
+    config = load_config()
+    extended = config.get("extended_history", False)
+    import state_manager
+    from memory_manager import MEMORY_CONFIG
+
+    if extended:
+        state_manager.MAX_HISTORY_ENTRIES = 43200
+        MEMORY_CONFIG["MAX_METRICS_LOG_ENTRIES"] = 43200
+        MEMORY_CONFIG["MAX_ARROW_HISTORY_ENTRIES"] = 43200
+    else:
+        state_manager.MAX_HISTORY_ENTRIES = 180
+        MEMORY_CONFIG["MAX_METRICS_LOG_ENTRIES"] = 180
+        MEMORY_CONFIG["MAX_ARROW_HISTORY_ENTRIES"] = 180
+
     return StateManager(redis_url)
 
 

--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
     "currency": "USD",
     "low_hashrate_threshold_ths": 3.0,
     "high_hashrate_threshold_ths": 20.0,
-    "EXCHANGE_RATE_API_KEY": ""
+    "EXCHANGE_RATE_API_KEY": "",
+    "extended_history": false
 }

--- a/config.py
+++ b/config.py
@@ -30,6 +30,7 @@ DEFAULT_CONFIG = {
     "low_hashrate_threshold_ths": 3.0,
     "high_hashrate_threshold_ths": 20.0,
     "EXCHANGE_RATE_API_KEY": "",
+    "extended_history": False,
 }
 
 
@@ -45,6 +46,7 @@ def validate_config(config):
         "low_hashrate_threshold_ths": (int, float),
         "high_hashrate_threshold_ths": (int, float),
         "EXCHANGE_RATE_API_KEY": str,
+        "extended_history": bool,
     }
 
     for key, expected in required_types.items():

--- a/config_routes.py
+++ b/config_routes.py
@@ -66,6 +66,7 @@ def update_config() -> Any:
             "power_usage": 0.0,
             "currency": "USD",
             "EXCHANGE_RATE_API_KEY": "",
+            "extended_history": False,
         }
 
         merged_config = {**current_config}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -20,6 +20,7 @@ The default configuration file contains the following keys:
 | `network_fee` | Additional fees beyond pool fees | `0.0` |
 | `currency` | Preferred fiat currency for earnings display | `"USD"` |
 | `EXCHANGE_RATE_API_KEY` | ExchangeRate-API key for currency conversion | `""` |
+| `extended_history` | Store one month of metrics history | `false` |
 | `low_hashrate_threshold_ths` | Threshold used by the notification service to determine low hashrate mode (TH/s). Does **not** affect the front-end chart. | `3.0` |
 | `high_hashrate_threshold_ths` | Threshold above which normal hashrate mode resumes (TH/s) | `20.0` |
 

--- a/sse_service.py
+++ b/sse_service.py
@@ -11,7 +11,7 @@ from typing import Callable, Optional, Any
 from flask import Blueprint, Response, jsonify, request, stream_with_context
 
 from json_utils import convert_deques
-from state_manager import MAX_HISTORY_ENTRIES
+import state_manager
 
 # Default connection limits
 MAX_SSE_CONNECTIONS = 50
@@ -46,7 +46,7 @@ def stream() -> Response:
     except ValueError:
         start_event_id = 0
 
-    num_points = MAX_HISTORY_ENTRIES
+    num_points = state_manager.MAX_HISTORY_ENTRIES
 
     def event_stream(start_event_id: int, num_points: int):
         global active_sse_connections

--- a/templates/boot.html
+++ b/templates/boot.html
@@ -756,6 +756,19 @@
             <input type="number" id="network-fee" step="0.1" min="0" max="10" placeholder="0.0" value="">
         </div>
         <div class="form-group">
+            <label for="extended-history">
+                Extended History
+                <span class="tooltip">
+                    ?
+                <span class="tooltip-text">Store one month of metrics instead of 3</span>
+                </span>
+            </label>
+            <select id="extended-history" class="form-control">
+                <option value="false">Standard (3 hrs)</option>
+                <option value="true">Extended (1 month)</option>
+            </select>
+        </div>
+        <div class="form-group">
             <label for="timezone">
                 Timezone
                 <span class="tooltip">
@@ -919,6 +932,7 @@
             const networkFee = parseFloat(document.getElementById('network-fee').value) || 0;
             const currency = document.getElementById('currency').value;
             const apiKey = document.getElementById('exchange-rate-api-key').value.trim();
+            const extendedHistory = document.getElementById('extended-history').value === 'true';
 
             const updatedConfig = {
                 wallet: wallet || (currentConfig ? currentConfig.wallet : ""),
@@ -927,7 +941,8 @@
                 timezone: timezone,
                 network_fee: networkFee,
                 currency: currency,
-                EXCHANGE_RATE_API_KEY: apiKey
+                EXCHANGE_RATE_API_KEY: apiKey,
+                extended_history: extendedHistory
             };
 
             return fetch('/api/config', {
@@ -975,7 +990,8 @@
         let currentConfig = {
             wallet: "yourwallethere",
             power_cost: 0.0,
-            power_usage: 0.0
+            power_usage: 0.0,
+            extended_history: false
         };
 
         // Update loadConfig function to handle currency
@@ -998,6 +1014,7 @@
                         document.getElementById('power-usage').value = currentConfig.power_usage || "";
                         document.getElementById('network-fee').value = currentConfig.network_fee || "";
                         document.getElementById('exchange-rate-api-key').value = currentConfig.EXCHANGE_RATE_API_KEY || "";
+                        document.getElementById('extended-history').value = currentConfig.extended_history ? 'true' : 'false';
 
                         // Set currency dropdown value if available
                         if (currentConfig.currency) {
@@ -1016,7 +1033,8 @@
                             power_usage: 0.0,
                             network_fee: 0.0,
                             currency: "USD",
-                            EXCHANGE_RATE_API_KEY: ""
+                            EXCHANGE_RATE_API_KEY: "",
+                            extended_history: false
                         };
 
                         document.getElementById('wallet-address').value = currentConfig.wallet || "";
@@ -1025,6 +1043,7 @@
                         document.getElementById('network-fee').value = currentConfig.network_fee || "";
                         document.getElementById('exchange-rate-api-key').value = currentConfig.EXCHANGE_RATE_API_KEY || "";
                         document.getElementById('currency').value = currentConfig.currency || "USD";
+                        document.getElementById('extended-history').value = currentConfig.extended_history ? 'true' : 'false';
 
                         resolve(currentConfig);
                     });
@@ -1072,6 +1091,7 @@
             document.getElementById('power-usage').value = 0.0;
             document.getElementById('network-fee').value = 0.0;
             document.getElementById('exchange-rate-api-key').value = '';
+            document.getElementById('extended-history').value = 'false';
 
             // Visual feedback
             const btn = document.getElementById('use-defaults');

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -447,6 +447,22 @@ def test_earnings_csv_export(client, monkeypatch):
     assert "date,txid,lightning_txid,amount_btc,amount_sats,status" in text
 
 
+def test_history_csv_export(client, monkeypatch):
+    import App
+
+    h = {"hashrate": [{"time": "t", "value": 1, "arrow": "", "unit": "th/s"}]}
+    m = [{"timestamp": "t", "metrics": {"hashrate": 1}}]
+    monkeypatch.setattr(App.state_manager, "get_history", lambda: h)
+    monkeypatch.setattr(App.state_manager, "get_metrics_log", lambda: m)
+
+    resp = client.get("/api/history?format=csv")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/csv"
+    text = resp.data.decode()
+    assert "metric,time,value,arrow,unit" in text
+    assert "timestamp,hashrate" in text
+
+
 
 def test_earnings_returns_generic_error(client, monkeypatch):
     import App

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,6 +78,7 @@ def test_validate_config_valid():
         "low_hashrate_threshold_ths": 3.0,
         "high_hashrate_threshold_ths": 20.0,
         "EXCHANGE_RATE_API_KEY": "KEY",
+        "extended_history": False,
     }
     assert config_module.validate_config(cfg)
 
@@ -93,6 +94,7 @@ def test_validate_config_missing_key():
         "low_hashrate_threshold_ths": 3.0,
         "high_hashrate_threshold_ths": 20.0,
         "EXCHANGE_RATE_API_KEY": "KEY",
+        "extended_history": False,
     }
     cfg.pop("wallet")
     assert not config_module.validate_config(cfg)

--- a/tests/test_history_csv.py
+++ b/tests/test_history_csv.py
@@ -1,0 +1,20 @@
+import importlib
+import io
+import gc
+
+
+def test_history_csv_functions_close_stringio():
+    App = importlib.reload(importlib.import_module("App"))
+    history = {"hashrate": [{"time": "t", "value": 1, "arrow": "", "unit": "th/s"}]}
+    metrics_log = [{"timestamp": "t", "metrics": {"hashrate": 1}}]
+    gc.collect()
+    before = sum(1 for obj in gc.get_objects() if isinstance(obj, io.StringIO))
+    for _ in range(3):
+        h_csv = App.arrow_history_to_csv(history)
+        m_csv = App.metrics_log_to_csv(metrics_log)
+        assert "hashrate" in h_csv
+        assert "timestamp" in m_csv
+    gc.collect()
+    after = sum(1 for obj in gc.get_objects() if isinstance(obj, io.StringIO))
+    assert before == after
+

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -271,6 +271,15 @@ def test_hashrate_history_loaded_as_deque(monkeypatch):
     assert isinstance(new_mgr.hashrate_history, deque)
     assert new_mgr.hashrate_history.maxlen == MAX_HISTORY_ENTRIES
 
+
+def test_extended_history_entries(monkeypatch):
+    import state_manager as sm
+    sm.MAX_HISTORY_ENTRIES = 10
+    mgr = sm.StateManager()
+    for i in range(15):
+        mgr.metrics_log.append({"timestamp": str(i), "metrics": {}})
+    assert len(mgr.metrics_log) == sm.MAX_HISTORY_ENTRIES
+
 def test_metrics_log_snapshot_omits_history(monkeypatch):
     """metrics_log should not store arrow_history or history fields."""
     mgr = StateManager()


### PR DESCRIPTION
## Summary
- make metrics history window configurable
- add boot UI selector for extended history
- document `extended_history` config option
- adjust SSE service and setup to use dynamic history length
- test extended history
- extend history to 30 days and provide CSV export

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `make minify`


------
https://chatgpt.com/codex/tasks/task_e_685dfde5af3c8320bbf37e5a458a4112