### PR TITLE
Update README for hashrate CSV export

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ For more details, refer to the [docker-compose documentation](https://docs.docke
 - Currency conversion for earnings in selected fiat
 - Historical data for earnings analysis
 - Download payment history as CSV
+- Export hashrate history as CSV via `/api/history?format=csv`
 
 ### Blocks Explorer
 


### PR DESCRIPTION
## Summary
- document how to export hashrate history in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_685e0598b3688320bc5fbe99ab0807c6