### PR TITLE
Fix extended history time collision

### DIFF
--- a/state_manager.py
+++ b/state_manager.py
@@ -519,7 +519,8 @@ class StateManager:
         from zoneinfo import ZoneInfo
         from datetime import timedelta
 
-        current_second = datetime.now(ZoneInfo(get_timezone())).strftime("%H:%M:%S")
+        # Use full timestamp so extended history can span multiple days
+        current_second = datetime.now(ZoneInfo(get_timezone())).strftime("%Y-%m-%d %H:%M:%S")
 
         with state_lock:
             for key in arrow_keys:
@@ -660,7 +661,11 @@ class StateManager:
             for key, entries in self.arrow_history.items():
                 minute_groups = {}
                 for entry in entries:
-                    minute = entry["time"][:5]  # extract HH:MM
+                    ts = entry["time"]
+                    if len(ts) > 8:
+                        minute = ts[:16]  # YYYY-MM-DD HH:MM
+                    else:
+                        minute = ts[:5]  # legacy HH:MM
                     # Store a copy so pruned entries can be freed
                     minute_groups[minute] = entry.copy()  # take last entry for that minute
 

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -42,7 +42,9 @@ def test_save_and_load_graph_state_gzip():
     mgr = StateManager()
     mgr.redis_client = DummyRedis()
     mgr.arrow_history = {
-        "hashrate_60sec": deque([{"time": "00:00:01", "value": 1, "arrow": "", "unit": "th/s"}], maxlen=180)
+        "hashrate_60sec": deque([
+            {"time": "2024-01-01 00:00:01", "value": 1, "arrow": "", "unit": "th/s"}
+        ], maxlen=180)
     }
     mgr.hashrate_history = [1]
     mgr.metrics_log = deque(
@@ -167,7 +169,9 @@ def test_variance_history_persistence(monkeypatch):
 
     now = datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC"))
     mgr.arrow_history = {
-        "hashrate_60sec": deque([{"time": "00:00:01", "value": 1, "arrow": "", "unit": "th/s"}], maxlen=180)
+        "hashrate_60sec": deque([
+            {"time": "2024-01-01 00:00:01", "value": 1, "arrow": "", "unit": "th/s"}
+        ], maxlen=180)
     }
     mgr.hashrate_history = [1]
     mgr.metrics_log = deque(
@@ -331,7 +335,7 @@ def test_close_clears_cached_data():
     from datetime import datetime
 
     mgr = StateManager()
-    mgr.arrow_history = {"k": deque([{"time": "00:00:00", "value": 1}])}
+    mgr.arrow_history = {"k": deque([{"time": "2024-01-01 00:00:00", "value": 1}])}
     mgr.hashrate_history.append(1)
     mgr.metrics_log.append({"timestamp": "t", "metrics": {"a": 1}})
     mgr.payout_history = [1]


### PR DESCRIPTION
## Summary
- store full timestamps in `update_metrics_history` so entries span multiple days
- account for new timestamp format when grouping history
- update tests for new timestamp format

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9a66bd208320b219bc670fdf516c