### PR TITLE
Fix block annotations across days

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2506,7 +2506,15 @@ function updateChartWithNormalizedData(chart, data) {
                     const timeZone = dashboardTimezone || 'America/Los_Angeles';
                     const endTime = data.server_timestamp ?
                         new Date(data.server_timestamp) : new Date();
-                    const useExtendedLabels = validHistoryData.length > 1440;
+                    const labelTimestamps = validHistoryData.map((_, idx) => {
+                        const offset = (validHistoryData.length - 1 - idx) * 60000;
+                        return new Date(endTime.getTime() - offset);
+                    });
+
+                    const timeSpanMinutes = (labelTimestamps[labelTimestamps.length - 1].getTime() -
+                        labelTimestamps[0].getTime()) / 60000;
+
+                    const useExtendedLabels = timeSpanMinutes >= 1440;
 
                     const formatOptions = useExtendedLabels ? {
                         timeZone: timeZone,
@@ -2523,11 +2531,6 @@ function updateChartWithNormalizedData(chart, data) {
                     };
 
                     const timeFormatter = new Intl.DateTimeFormat('en-US', formatOptions);
-
-                    const labelTimestamps = validHistoryData.map((_, idx) => {
-                        const offset = (validHistoryData.length - 1 - idx) * 60000;
-                        return new Date(endTime.getTime() - offset);
-                    });
 
                     const formattedLabels = labelTimestamps.map(ts =>
                         timeFormatter.format(ts).replace(/\s[AP]M$/i, '')


### PR DESCRIPTION
## Summary
- detect span of time to switch to date+time labels
- regenerate minified assets

## Testing
- `make minify`
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f1637c344832089a2e66be2befa17