### PR TITLE
Allow Alt-W to clear block notifications

### DIFF
--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -9,7 +9,7 @@ The dashboard supports a few quick keyboard commands to speed up navigation and 
 | **Alt+3** | Open the Earnings page |
 | **Alt+4** | Open the Blocks page |
 | **Alt+5** | Open the Notifications page |
-| **Alt+W** | Reset wallet address, chart data, and sparkline history |
+| **Alt+W** | Reset wallet address, chart data, sparkline history, and clear all notifications |
 | **Shift+R** | Reset the Dashboard chart |
 | **Esc** | Close any open block modal |
 

--- a/notification_routes.py
+++ b/notification_routes.py
@@ -80,11 +80,13 @@ def api_clear_notifications():
     category = request.json.get("category")
     older_than_days = request.json.get("older_than_days")
     read_only = request.json.get("read_only", False)
+    include_block = request.json.get("include_block", False)
 
     cleared_count = _notification_service.clear_notifications(
         category=category,
         older_than_days=older_than_days,
         read_only=read_only,
+        include_block=include_block,
     )
 
     return jsonify(

--- a/notification_service.py
+++ b/notification_service.py
@@ -417,7 +417,11 @@ class NotificationService:
         return False
 
     def clear_notifications(
-        self, category: Optional[str] = None, older_than_days: Optional[int] = None, read_only: bool = False
+        self,
+        category: Optional[str] = None,
+        older_than_days: Optional[int] = None,
+        read_only: bool = False,
+        include_block: bool = False,
     ) -> int:
         """
         Clear notifications with optimized filtering.
@@ -426,6 +430,7 @@ class NotificationService:
             category (str, optional): Only clear specific category
             older_than_days (int, optional): Only clear notifications older than this
             read_only (bool, optional): Only clear notifications that have been read
+            include_block (bool, optional): Also clear block found notifications
 
         Returns:
             int: Number of notifications cleared
@@ -441,8 +446,9 @@ class NotificationService:
             n
             for n in self.notifications
             if (
-                n.get("category") == NotificationCategory.BLOCK.value
-            )  # Never delete block found notifications
+                not include_block
+                and n.get("category") == NotificationCategory.BLOCK.value
+            )  # Never delete block found notifications unless include_block
             or (
                 category and n.get("category") != category
             )  # Keep if we're filtering by category and this isn't that category

--- a/static/js/blocks.js
+++ b/static/js/blocks.js
@@ -281,7 +281,9 @@ $(document).keydown(function (event) {
         $.ajax({
             url: "/api/notifications/clear",
             method: "POST",
-            data: JSON.stringify({}),
+            data: JSON.stringify({
+                include_block: true
+            }),
             contentType: "application/json",
             success: function () {
                 if (typeof updateNotificationBadge === 'function') {

--- a/static/js/earnings.js
+++ b/static/js/earnings.js
@@ -345,7 +345,9 @@ $(document).keydown(function (event) {
         $.ajax({
             url: "/api/notifications/clear",
             method: "POST",
-            data: JSON.stringify({}),
+            data: JSON.stringify({
+                include_block: true
+            }),
             contentType: "application/json",
             success: function () {
                 if (typeof updateNotificationBadge === 'function') {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3934,7 +3934,9 @@ $(document).keydown(function (event) {
         $.ajax({
             url: "/api/notifications/clear",
             method: "POST",
-            data: JSON.stringify({}),
+            data: JSON.stringify({
+                include_block: true
+            }),
             contentType: "application/json",
             success: function () {
                 if (typeof updateNotificationBadge === 'function') {

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -516,7 +516,9 @@ $(document).keydown(function (event) {
         $.ajax({
             url: "/api/notifications/clear",
             method: "POST",
-            data: JSON.stringify({}),
+            data: JSON.stringify({
+                include_block: true
+            }),
             contentType: "application/json",
             success: function () {
                 if (typeof updateUnreadCount === 'function') {

--- a/static/js/workers.js
+++ b/static/js/workers.js
@@ -393,7 +393,9 @@ $(document).keydown(function (event) {
         $.ajax({
             url: "/api/notifications/clear",
             method: "POST",
-            data: JSON.stringify({}),
+            data: JSON.stringify({
+                include_block: true
+            }),
             contentType: "application/json",
             success: function () {
                 if (typeof updateNotificationBadge === 'function') {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -335,6 +335,22 @@ def test_clear_notifications_retains_block_notifications(client):
     assert App.notification_service.notifications[0]["category"] == "block"
 
 
+def test_clear_notifications_including_blocks(client):
+    import App
+
+    App.notification_service.notifications = [
+        {"id": "1", "read": True, "category": "block", "timestamp": "2023-01-01T00:00:00"},
+        {"id": "2", "read": True, "category": "system", "timestamp": "2023-01-02T00:00:00"},
+    ]
+
+    resp = client.post("/api/notifications/clear", json={"include_block": True})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert data["cleared_count"] == 2
+    assert len(App.notification_service.notifications) == 0
+
+
 def test_batch_endpoint(client):
     resp = client.post(
         "/api/batch",


### PR DESCRIPTION
## Summary
- add `include_block` option to `clear_notifications`
- support the new parameter in the clear notifications API route
- update JS Alt-W handlers to include block notifications when clearing
- document updated behavior for Alt+W shortcut
- test that block notifications are removed when `include_block` is true

## Testing
- `pip install -r requirements.txt`
- `make minify`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f4f9ddf9c8320b5d6f4f66bc741ed