### PR TITLE
Fix hashrate chart labels variable

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2629,7 +2629,8 @@ function updateChartWithNormalizedData(chart, data) {
                     chart.data.datasets[0].data = limitedData;
 
                     // Similarly, limit the labels and timestamps
-                    const limitedLabels = formattedLabels.slice(-chartPoints);
+                    // Slice the already formatted labels based on the desired number of points
+                    const limitedLabels = labelInfo.labels.slice(-chartPoints);
                     const limitedTimestamps = labelTimestamps.slice(-chartPoints);
                     chart.data.labels = limitedLabels;
                     chart.labelTimestamps = limitedTimestamps;


### PR DESCRIPTION
## Summary
- fix undefined `formattedLabels` reference when slicing chart labels
- regenerate minified JS assets

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`
- `for f in tests/js/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_6861533843a083208f8bde689773c21c