### PR TITLE
Fix extended history reload caching

### DIFF
--- a/config_routes.py
+++ b/config_routes.py
@@ -133,6 +133,8 @@ def update_config() -> Any:
                         "State manager reinitialized with extended_history=%s",
                         merged_config.get("extended_history"),
                     )
+                    App.cached_metrics = None
+                    logging.info("Cleared cached metrics after extended_history change")
                 except Exception as e:  # pragma: no cover - defensive
                     logging.error("Error reinitializing state manager: %s", e)
 

--- a/tests/test_extended_history_reload.py
+++ b/tests/test_extended_history_reload.py
@@ -54,7 +54,10 @@ def test_update_config_reinitializes_state_manager(client, monkeypatch):
     new_sm = object()
     monkeypatch.setattr(app_setup, "init_state_manager", lambda: new_sm)
 
+    App.cached_metrics = {"foo": "bar"}
+
     resp = client.post("/api/config", json={"extended_history": True})
     assert resp.status_code == 200
     assert App.state_manager is new_sm
     assert closed["flag"]
+    assert App.cached_metrics is None


### PR DESCRIPTION
## Summary
- reset `cached_metrics` when `extended_history` config changes
- test that cached metrics are cleared after updating config

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615c6dab788320abb915630059aed8